### PR TITLE
[Suggestion] Enhance mention's markup

### DIFF
--- a/models/markup.ts
+++ b/models/markup.ts
@@ -64,7 +64,7 @@ let md = createMarkdownIt({ html: true, linkify: true })
       const actor = env.mentionedActors[handle];
       if (actor == null) return {};
       return {
-        class: "u-url mention",
+        class: "u-url mention bg-stone-300 rounded-lg p-1",
         title: actor.name ?? handle,
         "data-username": actor.username,
         "data-host": actor.instanceHost,


### PR DESCRIPTION
![스크린샷 2025-03-21 09-46-36](https://github.com/user-attachments/assets/c2f97a5e-d5b6-4562-bea4-f48409786465)

Current Situation (As-is)
Because of the user’s thumbnail image, it’s not immediately clear where the mention ends and the message begins.

Proposed Improvement (To-be)
To improve clarity, we should apply a more emphasized style to the mention so that users can easily distinguish it from the rest of the message.


Because styling is not much good and it's just PoC, You don't need to merge this.