### PR TITLE
Fix username and hadle text overflow 

### DIFF
--- a/components/NoteExcerpt.tsx
+++ b/components/NoteExcerpt.tsx
@@ -60,7 +60,7 @@ export function NoteExcerpt(props: NoteExcerptProps) {
                 class="inline-block mr-2 align-text-bottom"
               />
             </Link>
-            <div class="flex flex-col">
+            <div class="flex flex-col wrap-anywhere">
               <Link
                 href={post.actor.url ?? post.actor.iri}
                 internalHref={post.actor.accountId == null

--- a/components/PageTitle.tsx
+++ b/components/PageTitle.tsx
@@ -11,7 +11,7 @@ export interface PageTitleProps {
 
 export function PageTitle(props: PageTitleProps) {
   return (
-    <div class={props.class}>
+    <div class={`wrap-anywhere ${props.class}`}>
       <h1
         class={`text-xl font-bold ${props.subtitle == null ? "mb-5" : "mb-1"}`}
       >

--- a/islands/QuotedPostCard.tsx
+++ b/islands/QuotedPostCard.tsx
@@ -126,7 +126,7 @@ export function QuotedPostCard(props: QuotedPostCardProps) {
                   height={48}
                   class="shrink-0 size-12"
                 />
-                <div class="flex flex-col">
+                <div class="flex flex-col wrap-anywhere">
                   <p>
                     {post.actor.name == null
                       ? <strong>{post.actor.username}</strong>


### PR DESCRIPTION
## 문제

![Screenshot 2025-04-22 at 8 09 18 PM](https://github.com/user-attachments/assets/6c0d8a3c-733d-468d-b114-53b042613880)
> https://hackers.pub/@kodingwarrior/019656b4-23b1-7328-bd92-79aa1046881d

user handle text overflow 가 발생해서 전체 페이지에 가로 스크롤이 생기는 문제를 고쳤습니다.

Safari, FireFox, Chrome 관계 없이 나타나는 문제입니다.

## `overflow-wrap: anywhere` 적용 이후 

![Screenshot 2025-04-22 at 8 09 26 PM](https://github.com/user-attachments/assets/24d5a29d-b97b-4f06-8ffe-e18f30a54369)

## 로컬 테스트

개발 환경 설정에 드는 시간이 길어 로컬 테스트를 아직 하지 못했습니다. @dahlia 실례하지만 직접 테스트를 부탁드립니다.

프로덕션 환경에서 스타일을 인스펙트-수정하여 이에 대응되는 tailwind 클래스네임을 집어넣었습니다.

---

## 후속 작업

프로필 이미지 및 팔로우 버튼이 쪼그라드는 문제 해결을 후속 작업으로 마쳤습니다. 이 PR의 문제가 먼저 해결이 필요한 종속적인 문제라 포크 레포지토리에 임시로 올렸습니다.

- https://github.com/mu-hun/hackerspub/pull/2

이 PR이 머지 된 이후에 타겟 브랜치를 바꾸어 올려두겠습니다.