### PR TITLE
Make NoteExcerpt component with image responsive

### DIFF
--- a/web/components/NoteExcerpt.tsx
+++ b/web/components/NoteExcerpt.tsx
@@ -189,34 +189,25 @@ export function NoteExcerpt(props: NoteExcerptProps) {
                         post.link.imageHeight != null &&
                         post.link.imageWidth / post.link.imageHeight > 1.5
                       ? "block"
-                      : "flex items-center"
+                      : "flex flex-wrap items-center"
                   }
                   `}
                 >
-                  {post.link.imageUrl && post.link.imageWidth != null &&
-                    post.link.imageHeight != null &&
-                    post.link.imageWidth / post.link.imageHeight > 1.5 &&
-                    (
+                  {post.link.imageUrl && (
+                    <div class="grow">
                       <img
                         src={post.link.imageUrl}
                         alt={post.link.imageAlt ?? undefined}
                         width={post.link.imageWidth ?? undefined}
                         height={post.link.imageHeight ?? undefined}
-                        class="w-full h-auto"
+                        class={post.link.imageWidth != null &&
+                            post.link.imageHeight != null &&
+                            post.link.imageWidth / post.link.imageHeight > 1.5
+                          ? "w-full h-auto m-auto"
+                          : "max-h-40 w-auto m-auto"}
                       />
-                    )}
-                  {post.link.imageUrl && (post.link.imageWidth == null ||
-                    post.link.imageHeight == null ||
-                    post.link.imageWidth / post.link.imageHeight <= 1.5) &&
-                    (
-                      <img
-                        src={post.link.imageUrl}
-                        alt={post.link.imageAlt ?? undefined}
-                        width={post.link.imageWidth ?? undefined}
-                        height={post.link.imageHeight ?? undefined}
-                        class="max-h-40 w-auto"
-                      />
-                    )}
+                    </div>
+                  )}
                   <div>
                     <p class="m-4 font-bold">{post.link.title}</p>
                     {(post.link.description ||


### PR DESCRIPTION
Fix overflowing layout issue on narrow width screen.

This changes are tested on iPad with web inspector.

<details>
<summary>Before/After</summary>

## Wide-width

### Before
![before-wide-width](https://github.com/user-attachments/assets/7737fd12-76f6-4086-9811-62a0bbf6caed)

### After
![after-wide-width](https://github.com/user-attachments/assets/166396f6-2917-42d6-bd0e-876824c9b67c)

## Medium width

### Before
![before-med-width](https://github.com/user-attachments/assets/ccbd09d2-bd30-4b6f-bcae-1416d71b1e9c)

### After
![after-med-width](https://github.com/user-attachments/assets/133a6322-a224-458b-a2f0-bdd7793eb101)

## Narrow width

## Before
![before-narrow-width](https://github.com/user-attachments/assets/7b06125b-488a-45d5-b4e8-4f35450558b0)

### After
![after-narrow-width](https://github.com/user-attachments/assets/2bae36ce-018f-4aae-b3d3-ab3747b1d8ed)
</details>
