### PR TITLE
Fix text wrapping issue caused by missing wrap-anywhere class in TailwindCSS v3

### DIFF
--- a/web/components/NoteExcerpt.tsx
+++ b/web/components/NoteExcerpt.tsx
@@ -60,7 +60,13 @@ export function NoteExcerpt(props: NoteExcerptProps) {
                 class="inline-block mr-2 align-text-bottom"
               />
             </Link>
-            <div class="flex flex-col wrap-anywhere">
+            <div
+              style={{
+                // TODO: use wrap-anywhere class when using Tailwind CSS v4
+                overflowWrap: "anywhere",
+              }}
+              class="flex flex-col"
+            >
               <Link
                 href={post.actor.url ?? post.actor.iri}
                 internalHref={post.actor.accountId == null

--- a/web/components/PageTitle.tsx
+++ b/web/components/PageTitle.tsx
@@ -11,7 +11,13 @@ export interface PageTitleProps {
 
 export function PageTitle(props: PageTitleProps) {
   return (
-    <div class={`wrap-anywhere break-keep ${props.class}`}>
+    <div
+      style={{
+        // TODO: use wrap-anywhere class when using Tailwind CSS v4
+        overflowWrap: "anywhere",
+      }}
+      class={`break-keep ${props.class}`}
+    >
       <h1
         class={`text-xl font-bold ${props.subtitle == null ? "mb-5" : "mb-1"}`}
       >

--- a/web/islands/QuotedPostCard.tsx
+++ b/web/islands/QuotedPostCard.tsx
@@ -126,7 +126,13 @@ export function QuotedPostCard(props: QuotedPostCardProps) {
                   height={48}
                   class="shrink-0 size-12"
                 />
-                <div class="flex flex-col wrap-anywhere">
+                <div
+                  style={{
+                    // TODO: use wrap-anywhere class when using Tailwind CSS v4
+                    overflowWrap: "anywhere",
+                  }}
+                  class="flex flex-col"
+                >
                   <p>
                     {post.actor.name == null
                       ? <strong>{post.actor.username}</strong>


### PR DESCRIPTION
This pull request applies `overflow-wrap: anywhere` CSS[^1] via `style` property instead `wrap-anywhere` TailwindCSS class[^2]. It is because Hackers' Pub is using TailwindCSS v3 and TailwindCSS v3 doesn't have `wrap-anywhere` class.

https://github.com/hackers-pub/hackerspub/blob/9e4858087a3d2de956bccbd0bc680700bc4b1c4a/deno.json#L102

So some long username still occurs overflow even if it has `wrap-anywhere` class.

<img width="451" alt="image" src="https://github.com/user-attachments/assets/6879bffb-e77f-4355-8ec5-f412e0b7c60c" />

After setting `overflow-wrap: anywhere` in direct, it becomes to have any overflow 😀 

<img width="1079" alt="image" src="https://github.com/user-attachments/assets/36ea2dda-d8f2-4a1c-b501-5b309d63c461" />


[^1]: https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-wrap#anywhere
[^2]: https://tailwindcss.com/docs/overflow-wrap#wrapping-anywhere