### PR TITLE
Fix username and handle text overflow in `/notifications`

### DIFF
--- a/web/routes/notifications.tsx
+++ b/web/routes/notifications.tsx
@@ -152,7 +152,13 @@ export default define.page<typeof handler, NotificationsProps>(
                         }
                         `}
                       >
-                        <div class="flex items-center gap-2">
+                        <div
+                          style={{
+                            // TODO: use wrap-anywhere class when using Tailwind CSS v4
+                            overflowWrap: "anywhere",
+                          }}
+                          class="flex items-center gap-2"
+                        >
                           <p>
                             <Msg
                               $key="notification.followedYou"
@@ -190,7 +196,13 @@ export default define.page<typeof handler, NotificationsProps>(
                         }
                         `}
                       >
-                        <div class="flex items-center">
+                        <div
+                          style={{
+                            // TODO: use wrap-anywhere class when using Tailwind CSS v4
+                            overflowWrap: "anywhere",
+                          }}
+                          class="flex items-center"
+                        >
                           <p>
                             {notification.type === "react"
                               ? (


### PR DESCRIPTION
There is a bug where username and handle text are overflowed in `/notifications` path.

<img width="1109" alt="image" src="https://github.com/user-attachments/assets/a0deff54-2c4b-4f93-bb8e-cfb4edc24d01" />

<img width="1100" alt="image" src="https://github.com/user-attachments/assets/71877d70-19ce-44c1-83a1-c20470677963" />

By applying `overflow-wrap: anywhere` style, the overflow issue is resolved.

<img width="1100" alt="image" src="https://github.com/user-attachments/assets/9905e9e1-d866-48ef-8bde-6ee0b8289613" />

<img width="1091" alt="image" src="https://github.com/user-attachments/assets/ce067993-9276-4cf8-a5c9-34b879f1fde3" />
