### PR TITLE
Provide sign in with passkey button

### DIFF
--- a/web/locales/en.json
+++ b/web/locales/en.json
@@ -67,6 +67,7 @@
     "description": "If you have an account, we'll send you a sign-in link. If you have a passkey registered, you can use it to sign in instead. If you don't have an account, you need to be invited by an existing Hackers' Pub member.",
     "emailOrUsername": "Email address or username",
     "submit": "$t(signInUp.title)",
+    "withPasskey": "$t(signInUp.title) with passkey",
     "invalidEmailOrUsername": "Invalid email address or username. Please check your input.",
     "noSuchEmailOrUsername": "This email address or username is not registered with Hackers' Pub.",
     "signInEmailSubject": "Sign in to Hackers' Pub",

--- a/web/locales/ja.json
+++ b/web/locales/ja.json
@@ -65,6 +65,7 @@
     "description": "アカウントをお持ちの場合はログインリンクを送信します。パスキーを登録している場合は、代わりにそれを使用してログインできます。アカウントをお持ちでない場合は、既存のHackers' Pubメンバーからの招待が必要です。",
     "emailOrUsername": "メールアドレスまたはユーザー名",
     "submit": "$t(signInUp.title)",
+    "withPasskey": "パスキーを使用して$t(signInUp.title)",
     "invalidEmailOrUsername": "無効なメールアドレスまたはユーザー名です。入力を確認してください。",
     "noSuchEmailOrUsername": "このメールアドレスまたはユーザー名はHackers' Pubに登録されていません。",
     "signInEmailSubject": "Hackers' Pubへのログイン",

--- a/web/locales/ko.json
+++ b/web/locales/ko.json
@@ -65,6 +65,7 @@
     "description": "이미 계정이 있으면 로그인 링크를 보내드립니다. 패스키를 등록했다면 대신 그것을 사용하여 로그인할 수 있습니다. 계정이 없으시면 다른 Hackers' Pub 회원에게 초대를 받으셔야 합니다.",
     "emailOrUsername": "이메일 주소 또는 아이디",
     "submit": "$t(signInUp.title)",
+    "withPasskey": "패스키로 $t(signInUp.title)",
     "invalidEmailOrUsername": "유효하지 않은 이메일 주소 또는 아이디입니다. 입력값을 확인해주세요.",
     "noSuchEmailOrUsername": "이 이메일 주소 또는 아이디는 Hackers' Pub에 등록되어 있지 않습니다.",
     "signInEmailSubject": "Hackers' Pub 로그인",


### PR DESCRIPTION
On some environment, autofill with passkey doesn't works. Providing button make it works.

This button is tested on macOS Safari, Google Chrome, Firefox. I couldn't sign in with passkey autofill on these browsers.