### PR TITLE
Fix link title overflowing

### DIFF
--- a/web/components/NoteExcerpt.tsx
+++ b/web/components/NoteExcerpt.tsx
@@ -209,7 +209,9 @@ export function NoteExcerpt(props: NoteExcerptProps) {
                     </div>
                   )}
                   <div>
-                    <p class="m-4 font-bold">{post.link.title}</p>
+                    <p class="m-4 font-bold wrap-anywhere">
+                      {post.link.title}
+                    </p>
                     {(post.link.description ||
                       post.link.author && !URL.canParse(post.link.author)) && (
                       <p class="m-4 text-stone-500 dark:text-stone-400 line-clamp-2">

--- a/web/components/NoteExcerpt.tsx
+++ b/web/components/NoteExcerpt.tsx
@@ -60,13 +60,7 @@ export function NoteExcerpt(props: NoteExcerptProps) {
                 class="inline-block mr-2 align-text-bottom"
               />
             </Link>
-            <div
-              style={{
-                // TODO: use wrap-anywhere class when using Tailwind CSS v4
-                overflowWrap: "anywhere",
-              }}
-              class="flex flex-col"
-            >
+            <div class="flex flex-col wrap-anywhere">
               <Link
                 href={post.actor.url ?? post.actor.iri}
                 internalHref={post.actor.accountId == null

--- a/web/components/PageTitle.tsx
+++ b/web/components/PageTitle.tsx
@@ -12,11 +12,7 @@ export interface PageTitleProps {
 export function PageTitle(props: PageTitleProps) {
   return (
     <div
-      style={{
-        // TODO: use wrap-anywhere class when using Tailwind CSS v4
-        overflowWrap: "anywhere",
-      }}
-      class={`break-keep ${props.class}`}
+      class={`break-keep wrap-anywhere ${props.class}`}
     >
       <h1
         class={`text-xl font-bold ${props.subtitle == null ? "mb-5" : "mb-1"}`}

--- a/web/islands/QuotedPostCard.tsx
+++ b/web/islands/QuotedPostCard.tsx
@@ -126,13 +126,7 @@ export function QuotedPostCard(props: QuotedPostCardProps) {
                   height={48}
                   class="shrink-0 size-12"
                 />
-                <div
-                  style={{
-                    // TODO: use wrap-anywhere class when using Tailwind CSS v4
-                    overflowWrap: "anywhere",
-                  }}
-                  class="flex flex-col"
-                >
+                <div class="flex flex-col wrap-anywhere">
                   <p>
                     {post.actor.name == null
                       ? <strong>{post.actor.username}</strong>

--- a/web/islands/RecommendedActors.tsx
+++ b/web/islands/RecommendedActors.tsx
@@ -63,10 +63,7 @@ export function RecommendedActors(
                               ? `/${actor.handle}`
                               : `/@${actor.username}`}
                             href={actor.url ?? actor.iri}
-                            style={{
-                              // TODO: use wrap-anywhere class when using Tailwind CSS v4
-                              overflowWrap: "anywhere",
-                            }}
+                            class="wrap-anywhere"
                           >
                             {actor.name == null ? actor.username : (
                               <span

--- a/web/routes/notifications.tsx
+++ b/web/routes/notifications.tsx
@@ -152,13 +152,7 @@ export default define.page<typeof handler, NotificationsProps>(
                         }
                         `}
                       >
-                        <div
-                          style={{
-                            // TODO: use wrap-anywhere class when using Tailwind CSS v4
-                            overflowWrap: "anywhere",
-                          }}
-                          class="flex items-center gap-2"
-                        >
+                        <div class="flex items-center gap-2 wrap-anywhere">
                           <p>
                             <Msg
                               $key="notification.followedYou"
@@ -196,13 +190,7 @@ export default define.page<typeof handler, NotificationsProps>(
                         }
                         `}
                       >
-                        <div
-                          style={{
-                            // TODO: use wrap-anywhere class when using Tailwind CSS v4
-                            overflowWrap: "anywhere",
-                          }}
-                          class="flex items-center"
-                        >
+                        <div class="flex items-center wrap-anywhere">
                           <p>
                             {notification.type === "react"
                               ? (

--- a/web/static/styles.css
+++ b/web/static/styles.css
@@ -304,3 +304,8 @@
 .prose > p:last-child > a.quote-inline:last-child {
   display: none;
 }
+
+/* TODO: remove this when using Tailwind CSS v4 */
+.wrap-anywhere {
+  overflow-wrap: anywhere;
+}


### PR DESCRIPTION
Fix #41 

Also, this PR adopts `wrap-anywhere` class from Tailwind CSS v4 to reduce duplicated styles with same todo.

# Before

![before](https://github.com/user-attachments/assets/f702466c-0c6b-4a0e-8845-49a9ff8b5842)

# After

![after](https://github.com/user-attachments/assets/cf851aeb-da54-4b4f-b98e-4ed45cec391d)
