### PR TITLE
Show all media for every screen

### DIFF
--- a/web/components/NoteExcerpt.tsx
+++ b/web/components/NoteExcerpt.tsx
@@ -284,7 +284,7 @@ export function NoteExcerpt(props: NoteExcerptProps) {
           {post.media.length > 0 && (
             <div
               class={`
-              flex [justify-center:safe_center] lg:justify-center w-full overflow-x-auto
+              flex [justify-content:safe_center] lg:justify-center w-full overflow-x-auto
               ${
                 props.replyTarget
                   ? `

--- a/web/components/NoteExcerpt.tsx
+++ b/web/components/NoteExcerpt.tsx
@@ -284,7 +284,7 @@ export function NoteExcerpt(props: NoteExcerptProps) {
           {post.media.length > 0 && (
             <div
               class={`
-              flex [justify-content:safe_center] lg:justify-center w-full overflow-x-auto
+              flex [justify-content:safe_center] w-full overflow-x-auto
               ${
                 props.replyTarget
                   ? `


### PR DESCRIPTION
## Situation

Currently, we cannot see the all media if they are overflowed. For example,

https://play.tailwindcss.com/kN3oEcKcdf

```html
<div class="flex w-full overflow-x-auto [justify-center:safe_center] lg:justify-center">
  <a href="https://media.hackers.pub/note-media/72f8bf41-ff30-46c8-ac76-03bc6e905582.webp" target="_blank" class=""><img src="https://media.hackers.pub/note-media/72f8bf41-ff30-46c8-ac76-03bc6e905582.webp" alt="" width="4032" height="3024" class="mt-2 max-h-96 max-w-96 object-contain" /></a><a href="https://media.hackers.pub/note-media/70ce77a1-329a-4407-a75d-39db18a8cfc3.webp" target="_blank" class=""><img src="https://media.hackers.pub/note-media/70ce77a1-329a-4407-a75d-39db18a8cfc3.webp" alt="" width="4032" height="3024" class="mt-2 max-h-96 max-w-96 object-contain" /></a><a href="https://media.hackers.pub/note-media/936d8e0a-f0d2-46f4-809f-97294ac5d7e7.webp" target="_blank" class=""><img src="https://media.hackers.pub/note-media/936d8e0a-f0d2-46f4-809f-97294ac5d7e7.webp" alt="" width="4032" height="3024" class="mt-2 max-h-96 max-w-96 object-contain" /></a><a href="https://media.hackers.pub/note-media/ab959b1c-f2a1-416f-a9e9-f80c0b31bedf.webp" target="_blank" class=""><img src="https://media.hackers.pub/note-media/ab959b1c-f2a1-416f-a9e9-f80c0b31bedf.webp" alt="" width="4032" height="3024" class="mt-2 max-h-96 max-w-96 object-contain" /></a><a href="https://media.hackers.pub/note-media/73ac2eb4-b098-4454-b5df-9c6757ffa581.webp" target="_blank" class=""><img src="https://media.hackers.pub/note-media/73ac2eb4-b098-4454-b5df-9c6757ffa581.webp" alt="" width="4032" height="3024" class="mt-2 max-h-96 max-w-96 object-contain" /></a><a href="https://media.hackers.pub/note-media/fd2e3ccf-e307-4908-979f-80338e4b39ca.webp" target="_blank" class=""><img src="https://media.hackers.pub/note-media/fd2e3ccf-e307-4908-979f-80338e4b39ca.webp" alt="" width="4032" height="3024" class="mt-2 max-h-96 max-w-96 object-contain" /></a>
</div>
```

If screen is wide than 1024:

<img width="1293" alt="image" src="https://github.com/user-attachments/assets/50cf516e-75e8-4038-847a-f75a8867b067" />

If not:

<img width="1659" alt="image" src="https://github.com/user-attachments/assets/fcce83f8-92d0-4fe9-82f5-b1ceca09f534" />

## Solution (Changes)

This pull request corrects a typo at property name `justify-center` → `justify-content`.

Also, even if the width of the screen is wide than 1024, it needs to use `safe` keyterm to show all media (to include overflowed one). So I removed `lg:justify-center` and it becomes to apply `justify-content: safe center` for all screen.

<img width="810" alt="image" src="https://github.com/user-attachments/assets/a2ae7c89-aea1-46fd-a593-10fbce268694" />


## Links

- Used Hackers' Pub note: https://hackers.pub/@iamuhun/0196b3cd-299a-7539-833d-72a039059430
- Related commit: https://github.com/hackers-pub/hackerspub/commit/a8d10a4bf77cf8c3f21369af6799ef02a4610684
- https://v3.tailwindcss.com/docs/justify-content#center
- https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content
- https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content#the_safe_keyterm