### PR TITLE
폰트 패밀리에 `system-ui` 제거

### DIFF
--- a/web/tailwind.config.ts
+++ b/web/tailwind.config.ts
@@ -5,6 +5,13 @@ export default {
   content: [
     "{routes,islands,components}/**/*.{ts,tsx}",
   ],
+  theme: {
+    extend: {
+      fontFamily: {
+        sans:  ['-apple-system', 'BlinkMacSystemFont', 'sans-serif', '"Apple Color Emoji"', '"Segoe UI Emoji"', '"Segoe UI Symbol"', '"Noto Color Emoji"']
+      }
+    },
+  },
   plugins: [
     typography,
   ],


### PR DESCRIPTION
윈도우즈 환경에서는 폰트 패밀리에 `system-ui`가 적용된 사이트에서는 `lang` 속성이 반영되지 않아 CJK 환경 등에서 `lang` 속성이 제대로 되어있음에도 불구하고 글꼴 가능성이 나빠지는 문제가 발생합니다. 가령 한국어 윈도우즈 환경에서는 `lang` 속성이 `ja`로 되어있음에도 불구하고 일본어 가독성이 나쁜 맑은 고딕으로 렌더링 되어 가독성이 처참해지는 문제가 있습니다. 따라서 이를 해결하기 위해 애플 환경에서만 시스템 폰트가 적용되도록 합니다.