### PR TITLE
Fix link description overflow 

### DIFF
--- a/web/components/NoteExcerpt.tsx
+++ b/web/components/NoteExcerpt.tsx
@@ -214,7 +214,7 @@ export function NoteExcerpt(props: NoteExcerptProps) {
                     </p>
                     {(post.link.description ||
                       post.link.author && !URL.canParse(post.link.author)) && (
-                      <p class="m-4 text-stone-500 dark:text-stone-400 line-clamp-2">
+                      <p class="m-4 text-stone-500 dark:text-stone-400 line-clamp-2 wrap-anywhere">
                         {post.link.author && (
                           <>
                             <span class="font-bold">{post.link.author}</span>


### PR DESCRIPTION
# Reproduction

Share this URL
http://www.youtube.com/watch?v=Q--e5Mhbr7g

# Before

<img width="446" alt="image" src="https://github.com/user-attachments/assets/b4eaa2a9-75b0-43a2-abe6-682a29173719" />

# After

<img width="446" alt="image" src="https://github.com/user-attachments/assets/fddd2ca9-4082-4859-823e-1a77f074684b" />


