### PR TITLE
Enhance language detection with simple heuristic

### DIFF
--- a/models/langdet.ts
+++ b/models/langdet.ts
@@ -10,7 +10,7 @@ export interface DetectLanguageOptions {
 
 export function detectLanguage(options: DetectLanguageOptions): string | null {
   const acceptLanguages = parseAcceptLanguage(options.acceptLanguage ?? "");
-  const langDetect = detectAll(options.text);
+  const langDetect = detectAll(sanitizeText(options.text));
   for (let i = 0; i < langDetect.length; i++) {
     langDetect[i].accuracy = (langDetect[i].accuracy +
       (acceptLanguages[langDetect[i].lang] ?? acceptLanguages["*"] ?? 0)) / 2;
@@ -31,4 +31,13 @@ function parseAcceptLanguage(acceptLanguage: string): Record<string, number> {
   });
   langs.sort((a, b) => b[1] - a[1]);
   return Object.fromEntries(langs);
+}
+
+function sanitizeText(text: string): string {
+  const URL_PATTERN = /https?:\/\/[^\s]+/g;
+  const MENTION_PATTERN =
+    /@[\p{L}\p{N}._-]+(@(?:[\p{L}\p{N}][\p{L}\p{N}_-]*\.)+[\p{L}\p{N}]{2,})?/giu;
+
+  return text.replaceAll(URL_PATTERN, "")
+    .replaceAll(MENTION_PATTERN, "");
 }

--- a/web/islands/Composer.tsx
+++ b/web/islands/Composer.tsx
@@ -6,7 +6,7 @@ import type { Uuid } from "@hackerspub/models/uuid";
 import { getFixedT } from "i18next";
 import type { JSX } from "preact";
 import { useRef, useState } from "preact/hooks";
-import { detectLanguage } from "../../models/langdet.ts";
+import { detectLanguage } from "@hackerspub/models/langdet";
 import { Button } from "../components/Button.tsx";
 import { Msg, TranslationSetup } from "../components/Msg.tsx";
 import { TextArea } from "../components/TextArea.tsx";

--- a/web/islands/Composer.tsx
+++ b/web/islands/Composer.tsx
@@ -6,7 +6,7 @@ import type { Uuid } from "@hackerspub/models/uuid";
 import { getFixedT } from "i18next";
 import type { JSX } from "preact";
 import { useRef, useState } from "preact/hooks";
-import { detectAll } from "tinyld.browser";
+import { detectLanguage } from "../../models/langdet.ts";
 import { Button } from "../components/Button.tsx";
 import { Msg, TranslationSetup } from "../components/Msg.tsx";
 import { TextArea } from "../components/TextArea.tsx";
@@ -79,13 +79,8 @@ export function Composer(props: ComposerProps) {
     if (contentLanguageManuallySet) return;
     const value = event.currentTarget.value;
     setContent(value);
-    const result = detectAll(value);
-    for (const pair of result) {
-      if (pair.lang === props.language) pair.accuracy += 0.5;
-      pair.accuracy /= 2;
-    }
-    result.sort((a, b) => b.accuracy - a.accuracy);
-    const detected = result[0]?.lang;
+    // FIXME: `acceptLanguage === null` ok?
+    const detected = detectLanguage({ text: value, acceptLanguage: null });
     if (detected != null) setContentLanguage(detected);
   }
 


### PR DESCRIPTION
I added sanitization before language detection. It removes fediverse handles and URLs.
You can test this with "@hello https://hello.com bread". The current Hackers' Pub recognizes it as Italiano while this patched one recognizes it as English.