### PR TITLE
Fix overflow in remote reply description

### DIFF
--- a/web/routes/@[username]/[idOrYear]/index.tsx
+++ b/web/routes/@[username]/[idOrYear]/index.tsx
@@ -561,7 +561,7 @@ export default define.page<typeof handler, NotePageProps>(
           ? (
             <>
               <hr class="my-4 ml-14 opacity-50 dark:opacity-25" />
-              <p class="mt-4 leading-7 ml-14 text-stone-500 dark:text-stone-400">
+              <p class="mt-4 leading-7 ml-14 text-stone-500 dark:text-stone-400 break-words">
                 <Msg
                   $key="note.remoteReplyDescription"
                   permalink={

--- a/web/routes/@[username]/[idOrYear]/quotes.tsx
+++ b/web/routes/@[username]/[idOrYear]/quotes.tsx
@@ -230,7 +230,7 @@ export default define.page<typeof handler, NoteQuotesProps>(
           ? (
             <>
               <hr class="my-4 ml-14 opacity-50 dark:opacity-25" />
-              <p class="mt-4 leading-7 ml-14 text-stone-500 dark:text-stone-400">
+              <p class="mt-4 leading-7 ml-14 text-stone-500 dark:text-stone-400 break-words">
                 <Msg
                   $key="note.remoteQuoteDescription"
                   permalink={


### PR DESCRIPTION
The remote reply description was overflowing, causing horizontal scrolling on Safari with small screens, which resulted in a bad user experience.
Applied the break-words class to the remote reply description to prevent overflow.

before
<img width="300" alt="before" src="https://github.com/user-attachments/assets/c107953f-fe75-4aa6-88f8-a0029ff34f74" />

after
<img width="300" alt="after" src="https://github.com/user-attachments/assets/70b4dd51-4b95-45f2-96c0-480f0055de0f" />
