### PR TITLE
web-next: Add followers page with pagination and i18n support

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -152,6 +152,7 @@
     "npm:cssfilter@^0.0.11": "0.0.11",
     "npm:cssnano@6.0.3": "6.0.3_postcss@8.4.35",
     "npm:drizzle-kit@1.0.0-beta.1-5e64efc": "1.0.0-beta.1-5e64efc_esbuild@0.19.12",
+    "npm:drizzle-kit@beta": "1.0.0-beta.1-c0277c0_esbuild@0.25.8",
     "npm:drizzle-orm@1.0.0-beta.1-5e64efc": "1.0.0-beta.1-5e64efc_@opentelemetry+api@1.9.0_postgres@3.4.7_@cloudflare+workers-types@4.20250723.0",
     "npm:esbuild-wasm@0.23.1": "0.23.1",
     "npm:esbuild@0.23.1": "0.23.1",
@@ -6734,8 +6735,18 @@
         "@drizzle-team/brocli",
         "@esbuild-kit/esm-loader",
         "esbuild@0.19.12",
-        "esbuild-register",
+        "esbuild-register@3.6.0_esbuild@0.19.12",
         "gel"
+      ],
+      "bin": true
+    },
+    "drizzle-kit@1.0.0-beta.1-c0277c0_esbuild@0.25.8": {
+      "integrity": "sha512-8oRt69AyPA1ONsI1/2nZCJGkp9egyQOOe/uBuNB8yxcWxIMCDI60OF4rLHUaYfpHP4zuqJwiABFIBQUViPxXTw==",
+      "dependencies": [
+        "@drizzle-team/brocli",
+        "@esbuild-kit/esm-loader",
+        "esbuild@0.25.8",
+        "esbuild-register@3.6.0_esbuild@0.25.8"
       ],
       "bin": true
     },
@@ -6882,6 +6893,13 @@
       "dependencies": [
         "debug@4.4.1",
         "esbuild@0.19.12"
+      ]
+    },
+    "esbuild-register@3.6.0_esbuild@0.25.8": {
+      "integrity": "sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg==",
+      "dependencies": [
+        "debug@4.4.1",
+        "esbuild@0.25.8"
       ]
     },
     "esbuild-wasm@0.23.1": {

--- a/graphql/actor.ts
+++ b/graphql/actor.ts
@@ -27,6 +27,9 @@ export const Actor = builder.drizzleNode("actorTable", {
     uuid: t.expose("id", { type: "UUID" }),
     iri: t.field({
       type: "URL",
+      select: {
+        columns: { iri: true },
+      },
       resolve(actor) {
         return new URL(actor.iri);
       },
@@ -69,6 +72,9 @@ export const Actor = builder.drizzleNode("actorTable", {
     name: t.field({
       type: "HTML",
       nullable: true,
+      select: {
+        columns: { name: true, emojis: true },
+      },
       resolve(actor) {
         return actor.name
           ? renderCustomEmojis(escape(actor.name), actor.emojis)
@@ -188,6 +194,7 @@ builder.drizzleObjectFields(Actor, (t) => ({
     {
       type: Actor,
       select: (args, ctx, select) => ({
+        columns: { followersCount: true },
         with: {
           followers: followerConnectionHelpers.getQuery(args, ctx, select),
         },
@@ -217,6 +224,7 @@ builder.drizzleObjectFields(Actor, (t) => ({
     {
       type: Actor,
       select: (args, ctx, select) => ({
+        columns: { followeesCount: true },
         with: {
           followees: followeeConnectionHelpers.getQuery(args, ctx, select),
         },

--- a/web-next/package.json
+++ b/web-next/package.json
@@ -39,5 +39,6 @@
     "relay-compiler": "^19.0.0",
     "vite-plugin-cjs-interop": "^2.2.0",
     "vite-plugin-relay-lite": "^0.11.0"
-  }
+  },
+  "packageManager": "pnpm@10.12.4+sha512.5ea8b0deed94ed68691c9bad4c955492705c5eeb8a87ef86bc62c74a26b037b08ff9570f108b2e4dbd1dd1a9186fea925e527f141c648e85af45631074680184"
 }

--- a/web-next/src/components/ActorFollowerList.tsx
+++ b/web-next/src/components/ActorFollowerList.tsx
@@ -1,0 +1,96 @@
+import { graphql } from "relay-runtime";
+import { createSignal, For, Match, Show, Switch } from "solid-js";
+import { createPaginationFragment } from "solid-relay";
+import { useLingui } from "~/lib/i18n/macro.d.ts";
+import { ActorFollowerList_followers$key } from "./__generated__/ActorFollowerList_followers.graphql.ts";
+import { SmallProfileCard } from "./SmallProfileCard.tsx";
+
+export interface ActorFollowerListProps {
+  $followers: ActorFollowerList_followers$key;
+}
+
+export function ActorFollowerList(props: ActorFollowerListProps) {
+  const { t } = useLingui();
+  const followers = createPaginationFragment(
+    graphql`
+      fragment ActorFollowerList_followers on Actor
+        @refetchable(queryName: "ActorFollowerListQuery")
+        @argumentDefinitions(
+          cursor: { type: "String" }
+          count: { type: "Int", defaultValue: 20 }
+        )
+      {
+        followers(after: $cursor, first: $count)
+          @connection(key: "ActorFollowerList_followers")
+        {
+          edges {
+            node {
+              ...SmallProfileCard_actor
+            }
+          }
+          pageInfo {
+            hasNextPage
+          }
+        }
+      }
+    `,
+    () => props.$followers,
+  );
+  const [loadingState, setLoadingState] = createSignal<
+    "loaded" | "loading" | "errored"
+  >("loaded");
+
+  function onLoadMore() {
+    setLoadingState("loading");
+    followers.loadNext(20, {
+      onComplete(error) {
+        setLoadingState(error == null ? "loaded" : "errored");
+      },
+    });
+  }
+
+  return (
+    <div class="border rounded-xl *:first:rounded-t-xl *:last:rounded-b-xl max-w-prose mx-auto my-4">
+      <Show when={followers()}>
+        {(data) => (
+          <>
+            <ul class="divide-y divide-solid">
+              <For each={data().followers.edges}>
+                {(edge) => (
+                  <li>
+                    <SmallProfileCard $actor={edge.node} />
+                  </li>
+                )}
+              </For>
+            </ul>
+            <Show when={followers.hasNext}>
+              <div
+                on:click={loadingState() === "loading" ? undefined : onLoadMore}
+                class="block px-4 py-8 text-center text-muted-foreground cursor-pointer hover:text-primary hover:bg-secondary"
+              >
+                <Switch>
+                  <Match
+                    when={followers.pending || loadingState() === "loading"}
+                  >
+                    {t`Loading more followers…`}
+                  </Match>
+                  <Match when={loadingState() === "errored"}>
+                    {t`Failed to load more followers; click to retry`}
+                  </Match>
+                  <Match when={loadingState() === "loaded"}>
+                    {t`Load more followers`}
+                  </Match>
+                </Switch>
+              </div>
+            </Show>
+            <Show when={data().followers.edges.length < 1}>
+              <div class="px-4 py-8 text-center text-muted-foreground">
+                {t`No followers found`}
+              </div>
+            </Show>
+          </>
+        )}
+      </Show>
+    </div>
+  );
+}

--- a/web-next/src/components/ProfileCard.tsx
+++ b/web-next/src/components/ProfileCard.tsx
@@ -28,10 +28,10 @@ export function ProfileCard(props: ProfileCardProps) {
         actor {
           instanceHost
           bio
-          followees {
+          followeesCount: followees {
             totalCount
           }
-          followers {
+          followersCount: followers {
             totalCount
           }
         }
@@ -51,12 +51,7 @@ export function ProfileCard(props: ProfileCardProps) {
     <Show when={account()}>
       {(account) => (
         <>
-          <div
-            class="p-4"
-            classList={{
-              "border-b": (account().actor.bio?.trim() ?? "") === "",
-            }}
-          >
+          <div class="p-4">
             <div class="flex items-center gap-4 mx-auto max-w-prose">
               <Avatar class="size-16">
                 <a href={`/@${account().username}`}>
@@ -140,21 +135,25 @@ export function ProfileCard(props: ProfileCardProps) {
           <div class="p-4 pt-0 border-b">
             <div class="mx-auto max-w-prose text-muted-foreground">
               <a>
-                {i18n._(msg`${
-                  plural(account().actor.followees.totalCount, {
-                    one: "# following",
-                    other: "# following",
-                  })
-                }`)}
+                {i18n._(
+                  msg`${
+                    plural(account().actor.followeesCount.totalCount, {
+                      one: "# following",
+                      other: "# following",
+                    })
+                  }`,
+                )}
               </a>{" "}
               &middot;{" "}
-              <a>
-                {i18n._(msg`${
-                  plural(account().actor.followers.totalCount, {
-                    one: "# follower",
-                    other: "# followers",
-                  })
-                }`)}
+              <a href={`/@${account().username}/followers`}>
+                {i18n._(
+                  msg`${
+                    plural(account().actor.followersCount.totalCount, {
+                      one: "# follower",
+                      other: "# followers",
+                    })
+                  }`,
+                )}
               </a>
             </div>
           </div>

--- a/web-next/src/components/SmallProfileCard.tsx
+++ b/web-next/src/components/SmallProfileCard.tsx
@@ -1,0 +1,63 @@
+import { graphql } from "relay-runtime";
+import { Show } from "solid-js";
+import { createFragment } from "solid-relay";
+import { Avatar, AvatarImage } from "~/components/ui/avatar.tsx";
+import type { SmallProfileCard_actor$key } from "./__generated__/SmallProfileCard_actor.graphql.ts";
+
+export interface SmallProfileCardProps {
+  $actor: SmallProfileCard_actor$key;
+}
+
+export function SmallProfileCard(props: SmallProfileCardProps) {
+  const actor = createFragment(
+    graphql`
+      fragment SmallProfileCard_actor on Actor {
+        avatarUrl
+        name
+        bio
+        handle
+        local
+        username
+      }
+    `,
+    () => props.$actor,
+  );
+
+  return (
+    <Show when={actor()}>
+      {(actor) => (
+        <div class="flex flex-col gap-4 p-4">
+          <div class="flex flex-row gap-4 items-center">
+            <Avatar class="size-16">
+              <a
+                href={`/${
+                  actor().local ? `@${actor().username}` : actor().handle
+                }`}
+              >
+                <AvatarImage src={actor().avatarUrl} class="size-16" />
+              </a>
+            </Avatar>
+            <div class="flex flex-col">
+              <a
+                href={`/${
+                  actor().local ? `@${actor().username}` : actor().handle
+                }`}
+                class="font-semibold text-lg"
+              >
+                {actor().name}
+              </a>
+              <span class="text-muted-foreground select-all">
+                {actor().handle}
+              </span>
+            </div>
+          </div>
+          <Show when={actor().bio}>
+            {(bio) => (
+              <div innerHTML={bio()} class="prose dark:prose-invert"></div>
+            )}
+          </Show>
+        </div>
+      )}
+    </Show>
+  );
+}

--- a/web-next/src/locales/en-US/messages.po
+++ b/web-next/src/locales/en-US/messages.po
@@ -13,13 +13,13 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#. placeholder {0}: account().actor.followers.totalCount
-#: src/components/ProfileCard.tsx:79
+#. placeholder {0}: account().actor.followersCount.totalCount
+#: src/components/ProfileCard.tsx:150
 msgid "{0, plural, one {# follower} other {# followers}}"
 msgstr "{0, plural, one {# follower} other {# followers}}"
 
-#. placeholder {0}: account().actor.followees.totalCount
-#: src/components/ProfileCard.tsx:73
+#. placeholder {0}: account().actor.followeesCount.totalCount
+#: src/components/ProfileCard.tsx:139
 msgid "{0, plural, one {# following} other {# following}}"
 msgstr "{0, plural, one {# following} other {# following}}"
 
@@ -68,6 +68,10 @@ msgstr "Enter your email or username below to sign in."
 msgid "Failed to load more articles; click to retry"
 msgstr "Failed to load more articles; click to retry"
 
+#: src/components/ActorFollowerList.tsx:78
+msgid "Failed to load more followers; click to retry"
+msgstr "Failed to load more followers; click to retry"
+
 #: src/components/ActorNoteList.tsx:70
 msgid "Failed to load more notes; click to retry"
 msgstr "Failed to load more notes; click to retry"
@@ -89,6 +93,10 @@ msgstr "Fediverse"
 #: src/components/AppSidebar.tsx:115
 msgid "Feed"
 msgstr "Feed"
+
+#: src/routes/(root)/[username]/(profile)/followers.tsx:74
+msgid "Followers"
+msgstr "Followers"
 
 #: src/components/VisibilityTag.tsx:76
 msgid "Followers only"
@@ -114,6 +122,10 @@ msgstr "Home"
 msgid "Load more articles"
 msgstr "Load more articles"
 
+#: src/components/ActorFollowerList.tsx:81
+msgid "Load more followers"
+msgstr "Load more followers"
+
 #: src/components/ActorNoteList.tsx:73
 msgid "Load more notes"
 msgstr "Load more notes"
@@ -126,6 +138,10 @@ msgstr "Load more posts"
 #: src/components/ActorArticleList.tsx:70
 msgid "Loading more articles…"
 msgstr "Loading more articles…"
+
+#: src/components/ActorFollowerList.tsx:75
+msgid "Loading more followers…"
+msgstr "Loading more followers…"
 
 #: src/components/ActorNoteList.tsx:67
 msgid "Loading more notes…"
@@ -144,6 +160,10 @@ msgstr "Markdown guide"
 #: src/components/VisibilityTag.tsx:98
 msgid "Mentioned only"
 msgstr "Mentioned only"
+
+#: src/components/ActorFollowerList.tsx:88
+msgid "No followers found"
+msgstr "No followers found"
 
 #: src/components/ActorArticleList.tsx:83
 msgid "No notes articles"
@@ -234,7 +254,7 @@ msgstr "Translated from {0}"
 
 #. placeholder {0}: "OWNER"
 #. placeholder {1}: "RELATIVE_TIME"
-#: src/components/ProfileCard.tsx:139
+#: src/components/ProfileCard.tsx:116
 msgid "Verified that this link is owned by {0} {1}"
 msgstr "Verified that this link is owned by {0} {1}"
 

--- a/web-next/src/locales/ja-JP/messages.po
+++ b/web-next/src/locales/ja-JP/messages.po
@@ -13,13 +13,13 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#. placeholder {0}: account().actor.followers.totalCount
-#: src/components/ProfileCard.tsx:79
+#. placeholder {0}: account().actor.followersCount.totalCount
+#: src/components/ProfileCard.tsx:150
 msgid "{0, plural, one {# follower} other {# followers}}"
 msgstr "{0, plural, other {#フォロワー}}"
 
-#. placeholder {0}: account().actor.followees.totalCount
-#: src/components/ProfileCard.tsx:73
+#. placeholder {0}: account().actor.followeesCount.totalCount
+#: src/components/ProfileCard.tsx:139
 msgid "{0, plural, one {# following} other {# following}}"
 msgstr "{0, plural, other {#フォロー}}"
 
@@ -68,6 +68,10 @@ msgstr "以下にメールアドレスまたはユーザー名を入力してロ
 msgid "Failed to load more articles; click to retry"
 msgstr "記事の読み込みに失敗しました。クリックして再試行してください"
 
+#: src/components/ActorFollowerList.tsx:78
+msgid "Failed to load more followers; click to retry"
+msgstr "フォロワーの読み込みに失敗しました。クリックして再試行してください"
+
 #: src/components/ActorNoteList.tsx:70
 msgid "Failed to load more notes; click to retry"
 msgstr "投稿の読み込みに失敗しました。クリックして再試行してください"
@@ -89,6 +93,10 @@ msgstr "フェディバース"
 #: src/components/AppSidebar.tsx:115
 msgid "Feed"
 msgstr "フィード"
+
+#: src/routes/(root)/[username]/(profile)/followers.tsx:74
+msgid "Followers"
+msgstr "フォロワー"
 
 #: src/components/VisibilityTag.tsx:76
 msgid "Followers only"
@@ -114,6 +122,10 @@ msgstr "ホーム"
 msgid "Load more articles"
 msgstr "記事をもっと読み込む"
 
+#: src/components/ActorFollowerList.tsx:81
+msgid "Load more followers"
+msgstr "フォロワーをもっと読み込む"
+
 #: src/components/ActorNoteList.tsx:73
 msgid "Load more notes"
 msgstr "投稿をもっと読み込む"
@@ -126,6 +138,10 @@ msgstr "コンテンツをもっと読み込む"
 #: src/components/ActorArticleList.tsx:70
 msgid "Loading more articles…"
 msgstr "記事を読み込み中…"
+
+#: src/components/ActorFollowerList.tsx:75
+msgid "Loading more followers…"
+msgstr "フォロワーを読み込み中…"
 
 #: src/components/ActorNoteList.tsx:67
 msgid "Loading more notes…"
@@ -144,6 +160,10 @@ msgstr "Markdown ガイド"
 #: src/components/VisibilityTag.tsx:98
 msgid "Mentioned only"
 msgstr "メンションされたユーザーのみ"
+
+#: src/components/ActorFollowerList.tsx:88
+msgid "No followers found"
+msgstr "フォロワーはいません"
 
 #: src/components/ActorArticleList.tsx:83
 msgid "No notes articles"
@@ -234,7 +254,7 @@ msgstr "{0}から翻訳"
 
 #. placeholder {0}: "OWNER"
 #. placeholder {1}: "RELATIVE_TIME"
-#: src/components/ProfileCard.tsx:139
+#: src/components/ProfileCard.tsx:116
 msgid "Verified that this link is owned by {0} {1}"
 msgstr "{1}に{0}さんがこのリンクの所有者であることを確認済み"
 

--- a/web-next/src/locales/ko-KR/messages.po
+++ b/web-next/src/locales/ko-KR/messages.po
@@ -13,13 +13,13 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#. placeholder {0}: account().actor.followers.totalCount
-#: src/components/ProfileCard.tsx:79
+#. placeholder {0}: account().actor.followersCount.totalCount
+#: src/components/ProfileCard.tsx:150
 msgid "{0, plural, one {# follower} other {# followers}}"
 msgstr "{0, plural, other {# 팔로워}}"
 
-#. placeholder {0}: account().actor.followees.totalCount
-#: src/components/ProfileCard.tsx:73
+#. placeholder {0}: account().actor.followeesCount.totalCount
+#: src/components/ProfileCard.tsx:139
 msgid "{0, plural, one {# following} other {# following}}"
 msgstr "{0, plural, other {# 팔로잉}}"
 
@@ -68,6 +68,10 @@ msgstr "로그인하려면 아래에 이메일 또는 아이디를 입력해주�
 msgid "Failed to load more articles; click to retry"
 msgstr "게시글 불러오기 실패. 클릭하여 재시도하세요"
 
+#: src/components/ActorFollowerList.tsx:78
+msgid "Failed to load more followers; click to retry"
+msgstr "팔로워 불러오기 실패. 클릭하여 재시도하세요"
+
 #: src/components/ActorNoteList.tsx:70
 msgid "Failed to load more notes; click to retry"
 msgstr "단문 불러오기 실패. 클릭하여 재시도하세요"
@@ -89,6 +93,10 @@ msgstr "연합우주"
 #: src/components/AppSidebar.tsx:115
 msgid "Feed"
 msgstr "피드"
+
+#: src/routes/(root)/[username]/(profile)/followers.tsx:74
+msgid "Followers"
+msgstr "팔로워"
 
 #: src/components/VisibilityTag.tsx:76
 msgid "Followers only"
@@ -114,6 +122,10 @@ msgstr "홈"
 msgid "Load more articles"
 msgstr "게시글 더 불러오기"
 
+#: src/components/ActorFollowerList.tsx:81
+msgid "Load more followers"
+msgstr "팔로워 더 불러오기"
+
 #: src/components/ActorNoteList.tsx:73
 msgid "Load more notes"
 msgstr "단문 더 불러오기"
@@ -126,6 +138,10 @@ msgstr "콘텐츠 더 불러오기"
 #: src/components/ActorArticleList.tsx:70
 msgid "Loading more articles…"
 msgstr "게시글 불러오는 중…"
+
+#: src/components/ActorFollowerList.tsx:75
+msgid "Loading more followers…"
+msgstr "팔로워 불러오는 중…"
 
 #: src/components/ActorNoteList.tsx:67
 msgid "Loading more notes…"
@@ -144,6 +160,10 @@ msgstr "Markdown 가이드"
 #: src/components/VisibilityTag.tsx:98
 msgid "Mentioned only"
 msgstr "언급된 사용자만"
+
+#: src/components/ActorFollowerList.tsx:88
+msgid "No followers found"
+msgstr "팔로워가 없습니다"
 
 #: src/components/ActorArticleList.tsx:83
 msgid "No notes articles"
@@ -234,7 +254,7 @@ msgstr "{0}에서 번역됨"
 
 #. placeholder {0}: "OWNER"
 #. placeholder {1}: "RELATIVE_TIME"
-#: src/components/ProfileCard.tsx:139
+#: src/components/ProfileCard.tsx:116
 msgid "Verified that this link is owned by {0} {1}"
 msgstr "{1}에 {0} 님이 이 링크의 소유자임이 확인됨"
 

--- a/web-next/src/locales/zh-CN/messages.po
+++ b/web-next/src/locales/zh-CN/messages.po
@@ -13,13 +13,13 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#. placeholder {0}: account().actor.followers.totalCount
-#: src/components/ProfileCard.tsx:79
+#. placeholder {0}: account().actor.followersCount.totalCount
+#: src/components/ProfileCard.tsx:150
 msgid "{0, plural, one {# follower} other {# followers}}"
 msgstr "{0, plural, other {被 # 人关注}}"
 
-#. placeholder {0}: account().actor.followees.totalCount
-#: src/components/ProfileCard.tsx:73
+#. placeholder {0}: account().actor.followeesCount.totalCount
+#: src/components/ProfileCard.tsx:139
 msgid "{0, plural, one {# following} other {# following}}"
 msgstr "{0, plural, other {关注 # 人}}"
 
@@ -68,6 +68,10 @@ msgstr "请在下方输入您的邮箱或用户名以登录。"
 msgid "Failed to load more articles; click to retry"
 msgstr "加载更多文章失败，点击重试"
 
+#: src/components/ActorFollowerList.tsx:78
+msgid "Failed to load more followers; click to retry"
+msgstr "加载更多粉丝失败，点击重试"
+
 #: src/components/ActorNoteList.tsx:70
 msgid "Failed to load more notes; click to retry"
 msgstr "加载更多帖子失败，点击重试"
@@ -89,6 +93,10 @@ msgstr "联邦宇宙"
 #: src/components/AppSidebar.tsx:115
 msgid "Feed"
 msgstr "订阅流"
+
+#: src/routes/(root)/[username]/(profile)/followers.tsx:74
+msgid "Followers"
+msgstr "粉丝"
 
 #: src/components/VisibilityTag.tsx:76
 msgid "Followers only"
@@ -114,6 +122,10 @@ msgstr "首页"
 msgid "Load more articles"
 msgstr "加载更多文章"
 
+#: src/components/ActorFollowerList.tsx:81
+msgid "Load more followers"
+msgstr "加载更多粉丝"
+
 #: src/components/ActorNoteList.tsx:73
 msgid "Load more notes"
 msgstr "加载更多帖子"
@@ -126,6 +138,10 @@ msgstr "加载更多内容"
 #: src/components/ActorArticleList.tsx:70
 msgid "Loading more articles…"
 msgstr "加载更多文章中…"
+
+#: src/components/ActorFollowerList.tsx:75
+msgid "Loading more followers…"
+msgstr "加载更多粉丝中…"
 
 #: src/components/ActorNoteList.tsx:67
 msgid "Loading more notes…"
@@ -144,6 +160,10 @@ msgstr "Markdown 指南"
 #: src/components/VisibilityTag.tsx:98
 msgid "Mentioned only"
 msgstr "只提及用户可见"
+
+#: src/components/ActorFollowerList.tsx:88
+msgid "No followers found"
+msgstr "未找到粉丝"
 
 #: src/components/ActorArticleList.tsx:83
 msgid "No notes articles"
@@ -234,7 +254,7 @@ msgstr "翻译自{0}"
 
 #. placeholder {0}: "OWNER"
 #. placeholder {1}: "RELATIVE_TIME"
-#: src/components/ProfileCard.tsx:139
+#: src/components/ProfileCard.tsx:116
 msgid "Verified that this link is owned by {0} {1}"
 msgstr "已于{1}验证此链接归{0}所有"
 

--- a/web-next/src/locales/zh-TW/messages.po
+++ b/web-next/src/locales/zh-TW/messages.po
@@ -13,13 +13,13 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#. placeholder {0}: account().actor.followers.totalCount
-#: src/components/ProfileCard.tsx:79
+#. placeholder {0}: account().actor.followersCount.totalCount
+#: src/components/ProfileCard.tsx:150
 msgid "{0, plural, one {# follower} other {# followers}}"
 msgstr "{0, plural, other {被 # 人關注}}"
 
-#. placeholder {0}: account().actor.followees.totalCount
-#: src/components/ProfileCard.tsx:73
+#. placeholder {0}: account().actor.followeesCount.totalCount
+#: src/components/ProfileCard.tsx:139
 msgid "{0, plural, one {# following} other {# following}}"
 msgstr "{0, plural, other {關注 # 人}}"
 
@@ -68,6 +68,10 @@ msgstr "請在下方輸入您的電子郵件或使用者名稱以登入。"
 msgid "Failed to load more articles; click to retry"
 msgstr "載入更多文章失敗，點擊重試"
 
+#: src/components/ActorFollowerList.tsx:78
+msgid "Failed to load more followers; click to retry"
+msgstr "載入更多粉絲失敗，點擊重試"
+
 #: src/components/ActorNoteList.tsx:70
 msgid "Failed to load more notes; click to retry"
 msgstr "載入更多貼文失敗，點擊重試"
@@ -89,6 +93,10 @@ msgstr "聯邦宇宙"
 #: src/components/AppSidebar.tsx:115
 msgid "Feed"
 msgstr "訂閱流"
+
+#: src/routes/(root)/[username]/(profile)/followers.tsx:74
+msgid "Followers"
+msgstr "粉絲"
 
 #: src/components/VisibilityTag.tsx:76
 msgid "Followers only"
@@ -114,6 +122,10 @@ msgstr "首頁"
 msgid "Load more articles"
 msgstr "載入更多文章"
 
+#: src/components/ActorFollowerList.tsx:81
+msgid "Load more followers"
+msgstr "載入更多粉絲"
+
 #: src/components/ActorNoteList.tsx:73
 msgid "Load more notes"
 msgstr "載入更多貼文"
@@ -126,6 +138,10 @@ msgstr "載入更多內容"
 #: src/components/ActorArticleList.tsx:70
 msgid "Loading more articles…"
 msgstr "載入更多文章中…"
+
+#: src/components/ActorFollowerList.tsx:75
+msgid "Loading more followers…"
+msgstr "載入更多粉絲中…"
 
 #: src/components/ActorNoteList.tsx:67
 msgid "Loading more notes…"
@@ -144,6 +160,10 @@ msgstr "Markdown 指南"
 #: src/components/VisibilityTag.tsx:98
 msgid "Mentioned only"
 msgstr "只提及使用者可見"
+
+#: src/components/ActorFollowerList.tsx:88
+msgid "No followers found"
+msgstr "未找到粉絲"
 
 #: src/components/ActorArticleList.tsx:83
 msgid "No notes articles"
@@ -234,7 +254,7 @@ msgstr "翻譯自{0}"
 
 #. placeholder {0}: "OWNER"
 #. placeholder {1}: "RELATIVE_TIME"
-#: src/components/ProfileCard.tsx:139
+#: src/components/ProfileCard.tsx:116
 msgid "Verified that this link is owned by {0} {1}"
 msgstr "已於{1}驗證此連結歸{0}所有"
 

--- a/web-next/src/routes/(root)/[username]/(profile)/followers.tsx
+++ b/web-next/src/routes/(root)/[username]/(profile)/followers.tsx
@@ -1,0 +1,91 @@
+import { query, type RouteDefinition, useParams } from "@solidjs/router";
+import { graphql } from "relay-runtime";
+import { Show } from "solid-js";
+import {
+  createPreloadedQuery,
+  loadQuery,
+  useRelayEnvironment,
+} from "solid-relay";
+import { ActorFollowerList } from "~/components/ActorFollowerList.tsx";
+import { ProfileCard } from "~/components/ProfileCard.tsx";
+import { ProfilePageBreadcrumb } from "~/components/ProfilePageBreadcrumb.tsx";
+import {
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbSeparator,
+} from "~/components/ui/breadcrumb.tsx";
+import { useLingui } from "~/lib/i18n/macro.d.ts";
+import type { followersPageQuery } from "./__generated__/followersPageQuery.graphql.ts";
+
+export const route = {
+  matchFilters: {
+    username: /^\@/,
+  },
+  preload(args) {
+    const username = args.params.username;
+    void loadPageQuery(username.substring(1));
+  },
+} satisfies RouteDefinition;
+
+const followersPageQuery = graphql`
+  query followersPageQuery($username: String!) {
+    accountByUsername(username: $username) {
+      ...ProfileCard_account
+      ...ProfilePageBreadcrumb_account
+      username
+      actor {
+        ...ActorFollowerList_followers
+      }
+    }
+  }
+`;
+
+const loadPageQuery = query(
+  (username: string) =>
+    loadQuery<followersPageQuery>(
+      useRelayEnvironment()(),
+      followersPageQuery,
+      { username },
+    ),
+  "loadFollowersPageQuery",
+);
+
+export default function ProfileFollowersPage() {
+  const params = useParams();
+  const { t } = useLingui();
+  const username = params.username.substring(1);
+  const data = createPreloadedQuery<followersPageQuery>(
+    followersPageQuery,
+    () => loadPageQuery(username),
+  );
+  return (
+    <Show when={data()}>
+      {(data) => (
+        <>
+          <Show
+            when={data().accountByUsername}
+          >
+            {(account) => (
+              <>
+                <ProfilePageBreadcrumb $account={account()}>
+                  <BreadcrumbSeparator />
+                  <BreadcrumbItem>
+                    <BreadcrumbLink current>
+                      {t`Followers`}
+                    </BreadcrumbLink>
+                  </BreadcrumbItem>
+                </ProfilePageBreadcrumb>
+                <div>
+                  <ProfileCard $account={account()} />
+                </div>
+                <div class="p-4">
+                  <ActorFollowerList $followers={account().actor} />
+                </div>
+              </>
+            )}
+          </Show>
+        </>
+      )}
+    </Show>
+  );
+}


### PR DESCRIPTION
- Add ActorFollowerList component with pagination and loading states
- Add SmallProfileCard component for follower display
- Create followers route with breadcrumb navigation
- Update ProfileCard to link followers count to followers page
- Optimize GraphQL queries with proper column selection
- Add follower-related translations for all supported locales
- Update package manager to pnpm with proper lockfile

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a dedicated followers page for user profiles, accessible via a new route.
  * Added a paginated followers list component, allowing users to view and load more followers.
  * Introduced a compact profile card component for displaying follower information.

* **Improvements**
  * Updated profile cards to link follower counts directly to the followers page.
  * Enhanced internationalization support with new and updated translations for follower-related UI in multiple languages.

* **Chores**
  * Specified the package manager and version in the project configuration for improved dependency management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->