### PR TITLE
ci: Enable Deno cache in GitHub Actions workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,7 @@ jobs:
     - uses: denoland/setup-deno@v2
       with:
         deno-version: 2.4.1
+        cache: true
     - run: npx @dotenvx/dotenvx run -f .env.ci -- deno task -r codegen
     - run: npx @dotenvx/dotenvx run -f .env.ci -- deno task test
     - run: deno task check


### PR DESCRIPTION
This PR is a rather minor change. It enables the `cache` option for the `denoland/setup-deno` action. I opened this PR because I believe that fetching dependencies takes up a significant portion of the Deno build time. However, it may not be very effective since deno.lock constantly changes due to versions like `drizzle-kit@beta`.

Please refer to the following:

- https://github.com/denoland/setup-deno#caching-dependencies-downloaded-by-deno-automatically
- https://docs.deno.com/runtime/reference/continuous_integration/#caching-dependencies