### PR TITLE
web-next: Add follow relationship indicators to profile cards

### DIFF
--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -86,6 +86,8 @@ type Actor implements Node {
   created: DateTime!
   followees(after: String, before: String, first: Int, last: Int): ActorFolloweesConnection!
   followers(after: String, before: String, first: Int, last: Int): ActorFollowersConnection!
+  follows(followeeId: ID): Boolean!
+  followsViewer: Boolean!
   handle: String!
   handleHost: String!
   headerUrl: URL
@@ -93,6 +95,7 @@ type Actor implements Node {
   instance: Instance
   instanceHost: String!
   iri: URL!
+  isFollowedBy(followerId: ID): Boolean!
   local: Boolean!
   name: HTML
   notes(after: String, before: String, first: Int, last: Int): ActorNotesConnection!

--- a/web-next/src/components/ProfileCard.tsx
+++ b/web-next/src/components/ProfileCard.tsx
@@ -34,6 +34,7 @@ export function ProfileCard(props: ProfileCardProps) {
           followersCount: followers {
             totalCount
           }
+          followsViewer
         }
         links {
           name
@@ -155,6 +156,10 @@ export function ProfileCard(props: ProfileCardProps) {
                   }`,
                 )}
               </a>
+              <Show when={account().actor.followsViewer}>
+                {" "}
+                &middot; {t`Following you`}
+              </Show>
             </div>
           </div>
         </>

--- a/web-next/src/locales/en-US/messages.po
+++ b/web-next/src/locales/en-US/messages.po
@@ -14,12 +14,12 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. placeholder {0}: account().actor.followersCount.totalCount
-#: src/components/ProfileCard.tsx:150
+#: src/components/ProfileCard.tsx:151
 msgid "{0, plural, one {# follower} other {# followers}}"
 msgstr "{0, plural, one {# follower} other {# followers}}"
 
 #. placeholder {0}: account().actor.followeesCount.totalCount
-#: src/components/ProfileCard.tsx:139
+#: src/components/ProfileCard.tsx:140
 msgid "{0, plural, one {# following} other {# following}}"
 msgstr "{0, plural, one {# following} other {# following}}"
 
@@ -37,7 +37,7 @@ msgstr "A sign-in link has been sent to your email. Please check your inbox (or 
 msgid "Account"
 msgstr "Account"
 
-#: src/routes/(root)/[username]/(profile)/articles.tsx:77
+#: src/routes/(root)/[username]/(profile)/articles.tsx:80
 #: src/components/ProfileTabs.tsx:47
 msgid "Articles"
 msgstr "Articles"
@@ -101,6 +101,10 @@ msgstr "Followers"
 #: src/components/VisibilityTag.tsx:76
 msgid "Followers only"
 msgstr "Followers only"
+
+#: src/components/ProfileCard.tsx:161
+msgid "Following you"
+msgstr "Following you"
 
 #: src/components/AppSidebar.tsx:290
 msgid "GitHub repository"
@@ -207,7 +211,7 @@ msgstr "Quiet public"
 msgid "Read full article"
 msgstr "Read full article"
 
-#: src/routes/(root)/[username]/(profile)/shares.tsx:77
+#: src/routes/(root)/[username]/(profile)/shares.tsx:80
 #: src/components/ProfileTabs.tsx:50
 msgid "Shares"
 msgstr "Shares"
@@ -254,7 +258,7 @@ msgstr "Translated from {0}"
 
 #. placeholder {0}: "OWNER"
 #. placeholder {1}: "RELATIVE_TIME"
-#: src/components/ProfileCard.tsx:116
+#: src/components/ProfileCard.tsx:117
 msgid "Verified that this link is owned by {0} {1}"
 msgstr "Verified that this link is owned by {0} {1}"
 

--- a/web-next/src/locales/ja-JP/messages.po
+++ b/web-next/src/locales/ja-JP/messages.po
@@ -14,12 +14,12 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. placeholder {0}: account().actor.followersCount.totalCount
-#: src/components/ProfileCard.tsx:150
+#: src/components/ProfileCard.tsx:151
 msgid "{0, plural, one {# follower} other {# followers}}"
 msgstr "{0, plural, other {#フォロワー}}"
 
 #. placeholder {0}: account().actor.followeesCount.totalCount
-#: src/components/ProfileCard.tsx:139
+#: src/components/ProfileCard.tsx:140
 msgid "{0, plural, one {# following} other {# following}}"
 msgstr "{0, plural, other {#フォロー}}"
 
@@ -37,7 +37,7 @@ msgstr "ログインリンクがメールに送信されました。受信トレ
 msgid "Account"
 msgstr "アカウント"
 
-#: src/routes/(root)/[username]/(profile)/articles.tsx:77
+#: src/routes/(root)/[username]/(profile)/articles.tsx:80
 #: src/components/ProfileTabs.tsx:47
 msgid "Articles"
 msgstr "記事"
@@ -101,6 +101,10 @@ msgstr "フォロワー"
 #: src/components/VisibilityTag.tsx:76
 msgid "Followers only"
 msgstr "フォロワーのみ"
+
+#: src/components/ProfileCard.tsx:161
+msgid "Following you"
+msgstr "あなたをフォロー中"
 
 #: src/components/AppSidebar.tsx:290
 msgid "GitHub repository"
@@ -207,7 +211,7 @@ msgstr "ひかえめな公開"
 msgid "Read full article"
 msgstr "記事全文を読む"
 
-#: src/routes/(root)/[username]/(profile)/shares.tsx:77
+#: src/routes/(root)/[username]/(profile)/shares.tsx:80
 #: src/components/ProfileTabs.tsx:50
 msgid "Shares"
 msgstr "共有"
@@ -254,7 +258,7 @@ msgstr "{0}から翻訳"
 
 #. placeholder {0}: "OWNER"
 #. placeholder {1}: "RELATIVE_TIME"
-#: src/components/ProfileCard.tsx:116
+#: src/components/ProfileCard.tsx:117
 msgid "Verified that this link is owned by {0} {1}"
 msgstr "{1}に{0}さんがこのリンクの所有者であることを確認済み"
 

--- a/web-next/src/locales/ko-KR/messages.po
+++ b/web-next/src/locales/ko-KR/messages.po
@@ -14,12 +14,12 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. placeholder {0}: account().actor.followersCount.totalCount
-#: src/components/ProfileCard.tsx:150
+#: src/components/ProfileCard.tsx:151
 msgid "{0, plural, one {# follower} other {# followers}}"
 msgstr "{0, plural, other {# 팔로워}}"
 
 #. placeholder {0}: account().actor.followeesCount.totalCount
-#: src/components/ProfileCard.tsx:139
+#: src/components/ProfileCard.tsx:140
 msgid "{0, plural, one {# following} other {# following}}"
 msgstr "{0, plural, other {# 팔로잉}}"
 
@@ -37,7 +37,7 @@ msgstr "로그인 링크가 이메일로 전송되었습니다. 받은 편지함
 msgid "Account"
 msgstr "계정"
 
-#: src/routes/(root)/[username]/(profile)/articles.tsx:77
+#: src/routes/(root)/[username]/(profile)/articles.tsx:80
 #: src/components/ProfileTabs.tsx:47
 msgid "Articles"
 msgstr "게시글"
@@ -101,6 +101,10 @@ msgstr "팔로워"
 #: src/components/VisibilityTag.tsx:76
 msgid "Followers only"
 msgstr "팔로워만"
+
+#: src/components/ProfileCard.tsx:161
+msgid "Following you"
+msgstr "당신을 팔로우합니다"
 
 #: src/components/AppSidebar.tsx:290
 msgid "GitHub repository"
@@ -207,7 +211,7 @@ msgstr "조용히 공개"
 msgid "Read full article"
 msgstr "게시글 전체 읽기"
 
-#: src/routes/(root)/[username]/(profile)/shares.tsx:77
+#: src/routes/(root)/[username]/(profile)/shares.tsx:80
 #: src/components/ProfileTabs.tsx:50
 msgid "Shares"
 msgstr "공유"
@@ -254,7 +258,7 @@ msgstr "{0}에서 번역됨"
 
 #. placeholder {0}: "OWNER"
 #. placeholder {1}: "RELATIVE_TIME"
-#: src/components/ProfileCard.tsx:116
+#: src/components/ProfileCard.tsx:117
 msgid "Verified that this link is owned by {0} {1}"
 msgstr "{1}에 {0} 님이 이 링크의 소유자임이 확인됨"
 

--- a/web-next/src/locales/zh-CN/messages.po
+++ b/web-next/src/locales/zh-CN/messages.po
@@ -14,12 +14,12 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. placeholder {0}: account().actor.followersCount.totalCount
-#: src/components/ProfileCard.tsx:150
+#: src/components/ProfileCard.tsx:151
 msgid "{0, plural, one {# follower} other {# followers}}"
 msgstr "{0, plural, other {被 # 人关注}}"
 
 #. placeholder {0}: account().actor.followeesCount.totalCount
-#: src/components/ProfileCard.tsx:139
+#: src/components/ProfileCard.tsx:140
 msgid "{0, plural, one {# following} other {# following}}"
 msgstr "{0, plural, other {关注 # 人}}"
 
@@ -37,7 +37,7 @@ msgstr "登录链接已发送至您的邮箱。请检查收件箱。（或垃圾
 msgid "Account"
 msgstr "账户"
 
-#: src/routes/(root)/[username]/(profile)/articles.tsx:77
+#: src/routes/(root)/[username]/(profile)/articles.tsx:80
 #: src/components/ProfileTabs.tsx:47
 msgid "Articles"
 msgstr "文章"
@@ -101,6 +101,10 @@ msgstr "粉丝"
 #: src/components/VisibilityTag.tsx:76
 msgid "Followers only"
 msgstr "只粉丝可见"
+
+#: src/components/ProfileCard.tsx:161
+msgid "Following you"
+msgstr "关注了你"
 
 #: src/components/AppSidebar.tsx:290
 msgid "GitHub repository"
@@ -207,7 +211,7 @@ msgstr "悄悄公开"
 msgid "Read full article"
 msgstr "阅读完整文章"
 
-#: src/routes/(root)/[username]/(profile)/shares.tsx:77
+#: src/routes/(root)/[username]/(profile)/shares.tsx:80
 #: src/components/ProfileTabs.tsx:50
 msgid "Shares"
 msgstr "转帖"
@@ -254,7 +258,7 @@ msgstr "翻译自{0}"
 
 #. placeholder {0}: "OWNER"
 #. placeholder {1}: "RELATIVE_TIME"
-#: src/components/ProfileCard.tsx:116
+#: src/components/ProfileCard.tsx:117
 msgid "Verified that this link is owned by {0} {1}"
 msgstr "已于{1}验证此链接归{0}所有"
 

--- a/web-next/src/locales/zh-TW/messages.po
+++ b/web-next/src/locales/zh-TW/messages.po
@@ -14,12 +14,12 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. placeholder {0}: account().actor.followersCount.totalCount
-#: src/components/ProfileCard.tsx:150
+#: src/components/ProfileCard.tsx:151
 msgid "{0, plural, one {# follower} other {# followers}}"
 msgstr "{0, plural, other {被 # 人關注}}"
 
 #. placeholder {0}: account().actor.followeesCount.totalCount
-#: src/components/ProfileCard.tsx:139
+#: src/components/ProfileCard.tsx:140
 msgid "{0, plural, one {# following} other {# following}}"
 msgstr "{0, plural, other {關注 # 人}}"
 
@@ -37,7 +37,7 @@ msgstr "登入連結已傳送至您的郵箱。請檢查收件匣。（或垃圾
 msgid "Account"
 msgstr "帳戶"
 
-#: src/routes/(root)/[username]/(profile)/articles.tsx:77
+#: src/routes/(root)/[username]/(profile)/articles.tsx:80
 #: src/components/ProfileTabs.tsx:47
 msgid "Articles"
 msgstr "文章"
@@ -101,6 +101,10 @@ msgstr "粉絲"
 #: src/components/VisibilityTag.tsx:76
 msgid "Followers only"
 msgstr "只粉絲可見"
+
+#: src/components/ProfileCard.tsx:161
+msgid "Following you"
+msgstr "關注了你"
 
 #: src/components/AppSidebar.tsx:290
 msgid "GitHub repository"
@@ -207,7 +211,7 @@ msgstr "悄悄公開"
 msgid "Read full article"
 msgstr "閱讀完整文章"
 
-#: src/routes/(root)/[username]/(profile)/shares.tsx:77
+#: src/routes/(root)/[username]/(profile)/shares.tsx:80
 #: src/components/ProfileTabs.tsx:50
 msgid "Shares"
 msgstr "轉貼"
@@ -254,7 +258,7 @@ msgstr "翻譯自{0}"
 
 #. placeholder {0}: "OWNER"
 #. placeholder {1}: "RELATIVE_TIME"
-#: src/components/ProfileCard.tsx:116
+#: src/components/ProfileCard.tsx:117
 msgid "Verified that this link is owned by {0} {1}"
 msgstr "已於{1}驗證此連結歸{0}所有"
 

--- a/web-next/src/routes/(root)/[username]/(profile)/articles.tsx
+++ b/web-next/src/routes/(root)/[username]/(profile)/articles.tsx
@@ -30,7 +30,10 @@ export const route = {
 } satisfies RouteDefinition;
 
 const articlesPageQuery = graphql`
-  query articlesPageQuery($username: String!, $locale: Locale!) {
+  query articlesPageQuery(
+    $username: String!
+    $locale: Locale!
+  ) {
     accountByUsername(username: $username) {
       username
       actor {

--- a/web-next/src/routes/(root)/[username]/(profile)/shares.tsx
+++ b/web-next/src/routes/(root)/[username]/(profile)/shares.tsx
@@ -30,7 +30,10 @@ export const route = {
 } satisfies RouteDefinition;
 
 const sharesPageQuery = graphql`
-  query sharesPageQuery($username: String!, $locale: Locale!) {
+  query sharesPageQuery(
+    $username: String!
+    $locale: Locale!
+  ) {
     accountByUsername(username: $username) {
       username
       actor {


### PR DESCRIPTION
- Add follows/followsViewer/isFollowedBy fields to GraphQL Actor type
- Display "Following you" indicator on profile cards when applicable
- Update all locale translations for the new "Following you" text
- Add validation for UUID parameters in follow relationship queries
- Minor formatting improvements to GraphQL query structure

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new indicators to user profiles showing if an actor follows the viewer or is followed by another actor.
  * Profile cards now display a "Following you" label when applicable.

* **Localization**
  * Added translations for "Following you" in English, Japanese, Korean, Simplified Chinese, and Traditional Chinese.

* **Documentation**
  * Updated GraphQL schema documentation to reflect new profile relationship fields.

* **Style**
  * Reformatted GraphQL queries for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->