### PR TITLE
Implement SignUp in web-next

### DIFF
--- a/graphql/login.ts
+++ b/graphql/login.ts
@@ -3,7 +3,6 @@ import {
   createSession,
   deleteSession,
   getSession,
-  type Session,
 } from "@hackerspub/models/session";
 import {
   createSigninToken,
@@ -21,6 +20,7 @@ import { sql } from "drizzle-orm";
 import { parseTemplate } from "url-template";
 import { Account } from "./account.ts";
 import { builder } from "./builder.ts";
+import { SessionRef } from "./session.ts";
 import { EMAIL_FROM } from "./email.ts";
 
 const logger = getLogger(["hackerspub", "graphql", "login"]);
@@ -47,41 +47,6 @@ LoginChallengeRef.implement({
         });
         return account!;
       },
-    }),
-  }),
-});
-
-const SessionRef = builder.objectRef<Session>("Session");
-
-SessionRef.implement({
-  description: "A login session for an account.",
-  fields: (t) => ({
-    id: t.expose("id", {
-      type: "UUID",
-      description: "The access token for the session.",
-    }),
-    account: t.field({
-      type: Account,
-      async resolve(session, _, ctx) {
-        const account = await ctx.db.query.accountTable.findFirst({
-          where: { id: session.accountId },
-          with: { actor: true },
-        });
-        return account!;
-      },
-    }),
-    userAgent: t.exposeString("userAgent", {
-      description: "The user agent of the session.",
-      nullable: true,
-    }),
-    ipAddress: t.expose("ipAddress", {
-      type: "IP",
-      nullable: true,
-      description: "The IP address that created the session.",
-    }),
-    created: t.expose("created", {
-      type: "DateTime",
-      description: "The creation date of the session.",
     }),
   }),
 });

--- a/graphql/mod.ts
+++ b/graphql/mod.ts
@@ -6,6 +6,7 @@ import { builder } from "./builder.ts";
 import "./doc.ts";
 import "./login.ts";
 import "./poll.ts";
+import "./signup.ts";
 import "./post.ts";
 import "./reactable.ts";
 export type { Context } from "./builder.ts";

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -720,6 +720,15 @@ type Session {
   userAgent: String
 }
 
+enum SignupBioError {
+  BIO_TOO_LONG
+}
+
+enum SignupDisplayNameError {
+  DISPLAY_NAME_REQUIRED
+  DISPLAY_NAME_TOO_LONG
+}
+
 """
 A signup info containing email and inviter information for account creation.
 """
@@ -737,11 +746,18 @@ input SignupInput {
 
 union SignupResult = Session | SignupValidationErrors
 
+enum SignupUsernameError {
+  USERNAME_ALREADY_TAKEN
+  USERNAME_INVALID_CHARACTERS
+  USERNAME_REQUIRED
+  USERNAME_TOO_LONG
+}
+
 """Validation errors for signup fields."""
 type SignupValidationErrors {
-  bio: String
-  name: String
-  username: String
+  bio: SignupBioError
+  name: SignupDisplayNameError
+  username: SignupUsernameError
 }
 
 scalar URITemplate

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -369,6 +369,18 @@ type Mutation {
     """The token of the login challenge."""
     token: UUID!
   ): Session
+
+  """Complete the signup process by creating a new account and session."""
+  completeSignup(
+    """The verification code."""
+    code: String!
+
+    """The account creation data."""
+    input: SignupInput!
+
+    """The signup token."""
+    token: UUID!
+  ): SignupResult!
   createNote(input: CreateNoteInput!): CreateNotePayload!
   loginByEmail(
     """The email of the account to sign in."""
@@ -630,6 +642,15 @@ type Query {
   ): Document!
   node(id: ID!): Node
   nodes(ids: [ID!]!): [Node]!
+
+  """Verify a signup token and return the signup info if valid."""
+  verifySignupToken(
+    """The verification code."""
+    code: String!
+
+    """The signup token to verify."""
+    token: UUID!
+  ): SignupInfo
   viewer: Account
 }
 
@@ -697,6 +718,30 @@ type Session {
 
   """The user agent of the session."""
   userAgent: String
+}
+
+"""
+A signup info containing email and inviter information for account creation.
+"""
+type SignupInfo {
+  email: String!
+  inviter: Account
+}
+
+"""Input data for completing account signup."""
+input SignupInput {
+  bio: String!
+  name: String!
+  username: String!
+}
+
+union SignupResult = Session | SignupValidationErrors
+
+"""Validation errors for signup fields."""
+type SignupValidationErrors {
+  bio: String
+  name: String
+  username: String
 }
 
 scalar URITemplate

--- a/graphql/session.ts
+++ b/graphql/session.ts
@@ -18,7 +18,10 @@ SessionRef.implement({
           where: { id: session.accountId },
           with: { actor: true },
         });
-        return account!;
+        if (!account) {
+          throw new Error(`Account with ID ${session.accountId} not found.`);
+        }
+        return account;
       },
     }),
     userAgent: t.exposeString("userAgent", {

--- a/graphql/session.ts
+++ b/graphql/session.ts
@@ -1,0 +1,38 @@
+import type { Session } from "@hackerspub/models/session";
+import { Account } from "./account.ts";
+import { builder } from "./builder.ts";
+
+export const SessionRef = builder.objectRef<Session>("Session");
+
+SessionRef.implement({
+  description: "A login session for an account.",
+  fields: (t) => ({
+    id: t.expose("id", {
+      type: "UUID",
+      description: "The access token for the session.",
+    }),
+    account: t.field({
+      type: Account,
+      async resolve(session, _, ctx) {
+        const account = await ctx.db.query.accountTable.findFirst({
+          where: { id: session.accountId },
+          with: { actor: true },
+        });
+        return account!;
+      },
+    }),
+    userAgent: t.exposeString("userAgent", {
+      description: "The user agent of the session.",
+      nullable: true,
+    }),
+    ipAddress: t.expose("ipAddress", {
+      type: "IP",
+      nullable: true,
+      description: "The IP address that created the session.",
+    }),
+    created: t.expose("created", {
+      type: "DateTime",
+      description: "The creation date of the session.",
+    }),
+  }),
+});

--- a/graphql/signup.ts
+++ b/graphql/signup.ts
@@ -1,0 +1,271 @@
+import { syncActorFromAccount } from "@hackerspub/models/actor";
+import { follow } from "@hackerspub/models/following";
+import { createSession } from "@hackerspub/models/session";
+import { USERNAME_REGEXP } from "@hackerspub/models/signin";
+import {
+  createAccount,
+  deleteSignupToken,
+  getSignupToken,
+} from "@hackerspub/models/signup";
+import {
+  generateUuidV7,
+  type Uuid,
+  validateUuid,
+} from "@hackerspub/models/uuid";
+import { getLogger } from "@logtape/logtape";
+import { createGraphQLError } from "graphql-yoga";
+import { Account } from "./account.ts";
+import { builder } from "./builder.ts";
+import { SessionRef } from "./session.ts";
+
+const logger = getLogger(["hackerspub", "graphql", "signup"]);
+
+interface SignupInfo {
+  email: string;
+  inviterId?: Uuid;
+}
+
+interface SignupInput {
+  username: string;
+  name: string;
+  bio: string;
+}
+
+interface SignupValidationErrors {
+  username?: string;
+  name?: string;
+  bio?: string;
+}
+
+const SignupInfoRef = builder.objectRef<SignupInfo>(
+  "SignupInfo",
+);
+
+SignupInfoRef.implement({
+  description:
+    "A signup info containing email and inviter information for account creation.",
+  fields: (t) => ({
+    email: t.exposeString("email"),
+    inviter: t.field({
+      type: Account,
+      nullable: true,
+      async resolve(info, _, ctx) {
+        if (!info.inviterId) return null;
+        const account = await ctx.db.query.accountTable.findFirst({
+          where: { id: info.inviterId },
+          with: { actor: true },
+        });
+        return account || null;
+      },
+    }),
+  }),
+});
+
+const SignupInputRef = builder.inputRef<SignupInput>("SignupInput");
+
+SignupInputRef.implement({
+  description: "Input data for completing account signup.",
+  fields: (t) => ({
+    username: t.string({ required: true }),
+    name: t.string({ required: true }),
+    bio: t.string({ required: true }),
+  }),
+});
+
+const SignupValidationErrorsRef = builder.objectRef<SignupValidationErrors>(
+  "SignupValidationErrors",
+);
+
+SignupValidationErrorsRef.implement({
+  description: "Validation errors for signup fields.",
+  fields: (t) => ({
+    username: t.exposeString("username", { nullable: true }),
+    name: t.exposeString("name", { nullable: true }),
+    bio: t.exposeString("bio", { nullable: true }),
+  }),
+});
+
+const SignupResultRef = builder.unionType("SignupResult", {
+  types: [SessionRef, SignupValidationErrorsRef],
+  resolveType: (obj) => {
+    if ("accountId" in obj) return SessionRef;
+    return SignupValidationErrorsRef;
+  },
+});
+
+builder.queryFields((t) => ({
+  verifySignupToken: t.field({
+    type: SignupInfoRef,
+    nullable: true,
+    description: "Verify a signup token and return the signup info if valid.",
+    args: {
+      token: t.arg({
+        type: "UUID",
+        required: true,
+        description: "The signup token to verify.",
+      }),
+      code: t.arg.string({
+        required: true,
+        description: "The verification code.",
+      }),
+    },
+    async resolve(_, args, ctx) {
+      if (!validateUuid(args.token)) {
+        throw createGraphQLError("Invalid token format");
+      }
+
+      const signupToken = await getSignupToken(ctx.kv, args.token);
+      if (!signupToken) {
+        return null;
+      }
+
+      if (signupToken.code !== args.code) {
+        return null;
+      }
+
+      const existingAccount = await ctx.db.query.accountEmailTable.findFirst({
+        where: { email: signupToken.email },
+      });
+
+      if (existingAccount) {
+        return null;
+      }
+
+      return {
+        email: signupToken.email,
+        inviterId: signupToken.inviterId,
+      };
+    },
+  }),
+}));
+
+builder.mutationFields((t) => ({
+  completeSignup: t.field({
+    type: SignupResultRef,
+    description:
+      "Complete the signup process by creating a new account and session.",
+    args: {
+      token: t.arg({
+        type: "UUID",
+        required: true,
+        description: "The signup token.",
+      }),
+      code: t.arg.string({
+        required: true,
+        description: "The verification code.",
+      }),
+      input: t.arg({
+        type: SignupInputRef,
+        required: true,
+        description: "The account creation data.",
+      }),
+    },
+    async resolve(_, args, ctx) {
+      if (!validateUuid(args.token)) {
+        throw createGraphQLError("Invalid token format");
+      }
+
+      const signupToken = await getSignupToken(ctx.kv, args.token);
+      if (!signupToken) {
+        throw createGraphQLError("Invalid or expired signup token");
+      }
+
+      if (signupToken.code !== args.code) {
+        throw createGraphQLError("Invalid verification code");
+      }
+
+      const existingAccount = await ctx.db.query.accountEmailTable.findFirst({
+        where: { email: signupToken.email },
+      });
+
+      if (existingAccount) {
+        throw createGraphQLError("Email is already registered");
+      }
+
+      const { username, name, bio = "" } = args.input;
+      const trimmedUsername = username.trim().toLowerCase();
+      const trimmedName = name.trim();
+
+      // Collect validation errors
+      const errors: SignupValidationErrors = {};
+
+      // Validate username
+      if (!trimmedUsername) {
+        errors.username = "Username is required";
+      } else if (trimmedUsername.length > 50) {
+        errors.username = "Username is too long (maximum 50 characters)";
+      } else if (!trimmedUsername.match(USERNAME_REGEXP)) {
+        errors.username = "Username contains invalid characters";
+      } else {
+        const existingUser = await ctx.db.query.accountTable.findFirst({
+          where: { username: trimmedUsername },
+        });
+        if (existingUser) {
+          errors.username = "Username is already taken";
+        }
+      }
+
+      // Validate name
+      if (!trimmedName) {
+        errors.name = "Name is required";
+      } else if (trimmedName.length > 50) {
+        errors.name = "Name is too long (maximum 50 characters)";
+      }
+
+      // Validate bio
+      if (bio.length > 512) {
+        errors.bio = "Bio is too long (maximum 512 characters)";
+      }
+
+      // Return validation errors if any
+      if (errors.username || errors.name || errors.bio) {
+        return errors;
+      }
+
+      const account = await createAccount(ctx.db, signupToken, {
+        id: generateUuidV7(),
+        username: trimmedUsername,
+        name: trimmedName,
+        bio,
+        leftInvitations: 0,
+      });
+
+      if (!account) {
+        throw createGraphQLError("Failed to create account");
+      }
+
+      const actor = await syncActorFromAccount(ctx.fedCtx, {
+        ...account,
+        links: [],
+      });
+
+      await deleteSignupToken(ctx.kv, signupToken.token);
+
+      if (signupToken.inviterId) {
+        const inviter = await ctx.db.query.accountTable.findFirst({
+          where: { id: signupToken.inviterId },
+          with: { actor: true },
+        });
+
+        if (inviter) {
+          await follow(ctx.fedCtx, { ...account, actor }, inviter.actor);
+          await follow(ctx.fedCtx, inviter, actor);
+        }
+      }
+
+      logger.info("Account created successfully: {accountId}", {
+        accountId: account.id,
+      });
+
+      // Create session for the new account
+      const remoteAddr = ctx.connectionInfo?.remoteAddr;
+      const session = await createSession(ctx.kv, {
+        accountId: account.id,
+        userAgent: ctx.request.headers.get("user-agent") ?? null,
+        ipAddress: remoteAddr?.transport === "tcp" ? remoteAddr.hostname : null,
+      });
+
+      return session;
+    },
+  }),
+}));

--- a/models/deno.json
+++ b/models/deno.json
@@ -34,6 +34,7 @@
     "./timeline": "./timeline.ts",
     "./tx": "./tx.ts",
     "./url": "./url.ts",
+    "./userValidation": "./userValidation.ts",
     "./uuid": "./uuid.ts"
   },
   "lint": {

--- a/models/signin.ts
+++ b/models/signin.ts
@@ -1,5 +1,6 @@
 import { getLogger } from "@logtape/logtape";
 import type Keyv from "keyv";
+import { USERNAME_REGEXP } from "./userValidation.ts";
 import type { Uuid } from "./uuid.ts";
 
 const logger = getLogger(["hackerspub", "models", "signin"]);
@@ -10,7 +11,7 @@ export const EXPIRATION: Temporal.Duration = Temporal.Duration.from({
   hours: 12,
 });
 
-export const USERNAME_REGEXP = /^[a-z0-9_]{1,15}$/;
+export { USERNAME_REGEXP };
 
 export interface SigninToken {
   accountId: Uuid;

--- a/models/userValidation.ts
+++ b/models/userValidation.ts
@@ -1,0 +1,60 @@
+export const USERNAME_REGEXP = /^[a-z0-9_]{1,15}$/;
+
+export enum UsernameValidationError {
+  Required = "USERNAME_REQUIRED",
+  TooLong = "USERNAME_TOO_LONG",
+  InvalidCharacters = "USERNAME_INVALID_CHARACTERS",
+}
+
+export enum DisplayNameValidationError {
+  Required = "DISPLAY_NAME_REQUIRED",
+  TooLong = "DISPLAY_NAME_TOO_LONG",
+}
+
+export enum BioValidationError {
+  TooLong = "BIO_TOO_LONG",
+}
+
+export function validateUsername(
+  username: string,
+): UsernameValidationError | null {
+  const trimmedUsername = username.trim().toLowerCase();
+
+  if (!trimmedUsername) {
+    return UsernameValidationError.Required;
+  }
+
+  if (trimmedUsername.length > 15) {
+    return UsernameValidationError.TooLong;
+  }
+
+  if (!trimmedUsername.match(USERNAME_REGEXP)) {
+    return UsernameValidationError.InvalidCharacters;
+  }
+
+  return null;
+}
+
+export function validateDisplayName(
+  name: string,
+): DisplayNameValidationError | null {
+  const trimmedName = name.trim();
+
+  if (!trimmedName) {
+    return DisplayNameValidationError.Required;
+  }
+
+  if (trimmedName.length > 50) {
+    return DisplayNameValidationError.TooLong;
+  }
+
+  return null;
+}
+
+export function validateBio(bio: string): BioValidationError | null {
+  if (bio.length > 512) {
+    return BioValidationError.TooLong;
+  }
+
+  return null;
+}

--- a/web-next/src/components/ui/toast.tsx
+++ b/web-next/src/components/ui/toast.tsx
@@ -1,0 +1,172 @@
+import type { PolymorphicProps } from "@kobalte/core/polymorphic";
+import type {
+  ToastDescriptionProps,
+  ToastListProps,
+  ToastRegionProps,
+  ToastRootProps,
+  ToastTitleProps,
+} from "@kobalte/core/toast";
+import { Toast as ToastPrimitive } from "@kobalte/core/toast";
+import type { VariantProps } from "class-variance-authority";
+import { cva } from "class-variance-authority";
+import type {
+  ComponentProps,
+  ValidComponent,
+  VoidComponent,
+  VoidProps,
+} from "solid-js";
+import { mergeProps, splitProps } from "solid-js";
+import { Portal } from "solid-js/web";
+import { cn } from "~/lib/utils.ts";
+
+export const toastVariants = cva(
+  "group pointer-events-auto relative flex flex-col gap-3 w-full items-center justify-between overflow-hidden rounded-md border p-4 pr-6 shadow-lg transition-all data-[swipe=cancel]:translate-y-0 data-[swipe=end]:translate-y-[var(--kb-toast-swipe-end-y)] data-[swipe=move]:translate-y-[--kb-toast-swipe-move-y] data-[swipe=move]:transition-none data-[opened]:animate-in data-[closed]:animate-out data-[swipe=end]:animate-out data-[closed]:fade-out-80 data-[closed]:slide-out-to-top-full data-[closed]:sm:slide-out-to-bottom-full data-[opened]:slide-in-from-top-full data-[opened]:sm:slide-in-from-bottom-full",
+  {
+    variants: {
+      variant: {
+        default: "border bg-background",
+        destructive:
+          "destructive group border-destructive bg-destructive text-destructive-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
+
+type toastProps<T extends ValidComponent = "li"> =
+  & ToastRootProps<T>
+  & VariantProps<typeof toastVariants>
+  & {
+    class?: string;
+  };
+
+export const Toast = <T extends ValidComponent = "li">(
+  props: PolymorphicProps<T, toastProps<T>>,
+) => {
+  const [local, rest] = splitProps(props as toastProps, ["class", "variant"]);
+
+  return (
+    <ToastPrimitive
+      class={cn(toastVariants({ variant: local.variant }), local.class)}
+      {...rest}
+    />
+  );
+};
+
+type toastTitleProps<T extends ValidComponent = "div"> = ToastTitleProps<T> & {
+  class?: string;
+};
+
+export const ToastTitle = <T extends ValidComponent = "div">(
+  props: PolymorphicProps<T, toastTitleProps<T>>,
+) => {
+  const [local, rest] = splitProps(props as toastTitleProps, ["class"]);
+
+  return (
+    <ToastPrimitive.Title
+      class={cn("text-sm font-semibold [&+div]:text-xs", local.class)}
+      {...rest}
+    />
+  );
+};
+
+type toastDescriptionProps<T extends ValidComponent = "div"> =
+  & ToastDescriptionProps<T>
+  & {
+    class?: string;
+  };
+
+export const ToastDescription = <T extends ValidComponent = "div">(
+  props: PolymorphicProps<T, toastDescriptionProps<T>>,
+) => {
+  const [local, rest] = splitProps(props as toastDescriptionProps, ["class"]);
+
+  return (
+    <ToastPrimitive.Description
+      class={cn("text-sm opacity-90", local.class)}
+      {...rest}
+    />
+  );
+};
+
+type toastRegionProps<T extends ValidComponent = "div"> =
+  & ToastRegionProps<T>
+  & {
+    class?: string;
+  };
+
+export const ToastRegion = <T extends ValidComponent = "div">(
+  props: PolymorphicProps<T, toastRegionProps<T>>,
+) => {
+  const merge = mergeProps<toastRegionProps[]>(
+    {
+      swipeDirection: "down",
+    },
+    props,
+  );
+
+  return (
+    <Portal>
+      <ToastPrimitive.Region {...merge} />
+    </Portal>
+  );
+};
+
+type toastListProps<T extends ValidComponent = "ol"> = VoidProps<
+  ToastListProps<T> & {
+    class?: string;
+  }
+>;
+
+export const ToastList = <T extends ValidComponent = "ol">(
+  props: PolymorphicProps<T, toastListProps<T>>,
+) => {
+  const [local, rest] = splitProps(props as toastListProps, ["class"]);
+
+  return (
+    <ToastPrimitive.List
+      class={cn(
+        "fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse gap-2 p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]",
+        local.class,
+      )}
+      {...rest}
+    />
+  );
+};
+
+export const ToastContent = (props: ComponentProps<"div">) => {
+  const [local, rest] = splitProps(props, ["class", "children"]);
+
+  return (
+    <div class={cn("flex w-full flex-col", local.class)} {...rest}>
+      <div>{local.children}</div>
+      <ToastPrimitive.CloseButton class="absolute right-1 top-1 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none group-hover:opacity-100 group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          class="h-4 w-4"
+          viewBox="0 0 24 24"
+        >
+          <path
+            fill="none"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M18 6L6 18M6 6l12 12"
+          />
+          <title>Close</title>
+        </svg>
+      </ToastPrimitive.CloseButton>
+    </div>
+  );
+};
+
+export const ToastProgress: VoidComponent = () => {
+  return (
+    <ToastPrimitive.ProgressTrack class="h-1 w-full overflow-hidden rounded-xl bg-primary/20 group-[.destructive]:bg-background/20">
+      <ToastPrimitive.ProgressFill class="h-full w-[--kb-toast-progress-fill-width] bg-primary transition-all duration-150 ease-linear group-[.destructive]:bg-destructive-foreground" />
+    </ToastPrimitive.ProgressTrack>
+  );
+};

--- a/web-next/src/locales/en-US/messages.po
+++ b/web-next/src/locales/en-US/messages.po
@@ -70,14 +70,36 @@ msgstr "Articles"
 msgid "Articles only"
 msgstr "Articles only"
 
+#: src/routes/sign/up/[token].tsx:331
+msgid "Bio"
+msgstr "Bio"
+
+#: src/routes/sign/up/[token].tsx:136
+msgid "Bio is too long. Maximum length is 512 characters."
+msgstr "Bio is too long. Maximum length is 512 characters."
+
+#: src/components/AppSidebar.tsx:278
 #: src/routes/(root)/coc.tsx:53
 #: src/routes/(root)/coc.tsx:58
+#: src/routes/sign/up/[token].tsx:374
 msgid "Code of conduct"
 msgstr "Code of conduct"
+
+#: src/routes/sign/up/[token].tsx:402
+msgid "Creating account..."
+msgstr "Creating account..."
+
+#: src/routes/sign/up/[token].tsx:305
+msgid "Display name"
+msgstr "Display name"
 
 #: src/routes/sign/index.tsx:230
 msgid "Do you need an account? Hackers' Pub is invite-only—please ask a friend to invite you."
 msgstr "Do you need an account? Hackers' Pub is invite-only—please ask a friend to invite you."
+
+#: src/routes/sign/up/[token].tsx:260
+msgid "Email address"
+msgstr "Email address"
 
 #: src/routes/sign/index.tsx:208
 msgid "Email or username"
@@ -145,6 +167,10 @@ msgstr "Hackers' Pub"
 msgid "Home"
 msgstr "Home"
 
+#: src/routes/sign/up/[token].tsx:376
+msgid "I have read and agree to the Code of conduct."
+msgstr "I have read and agree to the Code of conduct."
+
 #: src/components/ActorArticleList.tsx:78
 msgid "Load more articles"
 msgstr "Load more articles"
@@ -179,6 +205,10 @@ msgstr "Loading more notes…"
 msgid "Loading more posts…"
 msgstr "Loading more posts…"
 
+#: src/routes/sign/up/[token].tsx:386
+msgid "Loading..."
+msgstr "Loading..."
+
 #: src/routes/(root)/markdown.tsx:53
 #: src/routes/(root)/markdown.tsx:58
 msgid "Markdown guide"
@@ -187,6 +217,14 @@ msgstr "Markdown guide"
 #: src/components/VisibilityTag.tsx:98
 msgid "Mentioned only"
 msgstr "Mentioned only"
+
+#: src/routes/sign/up/[token].tsx:126
+msgid "Name is required."
+msgstr "Name is required."
+
+#: src/routes/sign/up/[token].tsx:129
+msgid "Name is too long. Maximum length is 50 characters."
+msgstr "Name is too long. Maximum length is 50 characters."
 
 #: src/components/ActorFollowerList.tsx:90
 msgid "No followers found"
@@ -234,6 +272,10 @@ msgstr "Quiet public"
 msgid "Read full article"
 msgstr "Read full article"
 
+#: src/routes/sign/up/[token].tsx:380
+msgid "Read the full Code of conduct"
+msgstr "Read the full Code of conduct"
+
 #: src/components/ProfileTabs.tsx:51
 #: src/routes/(root)/[handle]/(profile)/shares.tsx:86
 msgid "Shares"
@@ -247,6 +289,11 @@ msgstr "Sign in"
 #: src/components/AppSidebar.tsx:267
 msgid "Sign out"
 msgstr "Sign out"
+
+#: src/routes/sign/up/[token].tsx:236
+#: src/routes/sign/up/[token].tsx:402
+msgid "Sign up"
+msgstr "Sign up"
 
 #: src/routes/sign/index.tsx:187
 msgid "Signing in Hackers' Pub"
@@ -264,6 +311,14 @@ msgstr "Summarized by LLM"
 msgid "Table of contents"
 msgstr "Table of contents"
 
+#: src/routes/sign/up/[token].tsx:335
+msgid "Tell us about yourself..."
+msgstr "Tell us about yourself..."
+
+#: src/routes/sign/up/[token].tsx:245
+msgid "The sign-up link is invalid. Please make sure you're using the correct link from the email you received."
+msgstr "The sign-up link is invalid. Please make sure you're using the correct link from the email you received."
+
 #. placeholder {0}: "GITHUB_REPOSITORY"
 #. placeholder {1}: "AGPL-3.0"
 #: src/components/AppSidebar.tsx:282
@@ -279,11 +334,31 @@ msgstr "Timeline"
 msgid "Translated from {0}"
 msgstr "Translated from {0}"
 
+#: src/routes/sign/up/[token].tsx:278
+msgid "Username"
+msgstr "Username"
+
+#: src/routes/sign/up/[token].tsx:119
+msgid "Username can only contain lowercase letters, numbers, and underscores."
+msgstr "Username can only contain lowercase letters, numbers, and underscores."
+
+#: src/routes/sign/up/[token].tsx:113
+msgid "Username is required."
+msgstr "Username is required."
+
+#: src/routes/sign/up/[token].tsx:116
+msgid "Username is too long. Maximum length is 50 characters."
+msgstr "Username is too long. Maximum length is 50 characters."
+
 #. placeholder {0}: "OWNER"
 #. placeholder {1}: "RELATIVE_TIME"
 #: src/components/ProfileCard.tsx:137
 msgid "Verified that this link is owned by {0} {1}"
 msgstr "Verified that this link is owned by {0} {1}"
+
+#: src/routes/sign/up/[token].tsx:240
+msgid "Verifying your invitation..."
+msgstr "Verifying your invitation..."
 
 #: src/components/VisibilityTag.tsx:79
 msgid "Visible only to the author's followers. The post will not appear in the public timeline, and only those who follow the author can see it."
@@ -301,6 +376,34 @@ msgstr "Visible to everyone, but does not appear in the public timeline. Only th
 msgid "Visible to everyone, including non-registered users. The post will appear in the public timeline as well."
 msgstr "Visible to everyone, including non-registered users. The post will appear in the public timeline as well."
 
+#: src/routes/sign/up/[token].tsx:250
+msgid "Welcome to Hackers' Pub! Please fill out the form below to complete your sign-up."
+msgstr "Welcome to Hackers' Pub! Please fill out the form below to complete your sign-up."
+
 #: src/components/AppSidebar.tsx:173
 msgid "Without shares"
 msgstr "Without shares"
+
+#: src/routes/sign/up/[token].tsx:350
+msgid "You were invited by"
+msgstr "You were invited by"
+
+#: src/routes/sign/up/[token].tsx:367
+msgid "You'll automatically follow each other when you sign up."
+msgstr "You'll automatically follow each other when you sign up."
+
+#: src/routes/sign/up/[token].tsx:343
+msgid "Your bio will be displayed on your profile. You can use Markdown to format it. Maximum 512 characters."
+msgstr "Your bio will be displayed on your profile. You can use Markdown to format it. Maximum 512 characters."
+
+#: src/routes/sign/up/[token].tsx:269
+msgid "Your email address will be used to sign in to your account."
+msgstr "Your email address will be used to sign in to your account."
+
+#: src/routes/sign/up/[token].tsx:321
+msgid "Your name will be displayed on your profile and in your posts."
+msgstr "Your name will be displayed on your profile and in your posts."
+
+#: src/routes/sign/up/[token].tsx:295
+msgid "Your username will be used to create your profile URL and your fediverse handle."
+msgstr "Your username will be used to create your profile URL and your fediverse handle."

--- a/web-next/src/locales/en-US/messages.po
+++ b/web-next/src/locales/en-US/messages.po
@@ -14,12 +14,12 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. placeholder {0}: actor().followersCount.totalCount
-#: src/components/ProfileCard.tsx:166
+#: src/components/ProfileCard.tsx:178
 msgid "{0, plural, one {# follower} other {# followers}}"
 msgstr "{0, plural, one {# follower} other {# followers}}"
 
 #. placeholder {0}: actor().followeesCount.totalCount
-#: src/components/ProfileCard.tsx:151
+#: src/components/ProfileCard.tsx:163
 msgid "{0, plural, one {# following} other {# following}}"
 msgstr "{0, plural, one {# following} other {# following}}"
 
@@ -30,26 +30,26 @@ msgid "{0} shared {1}"
 msgstr "{0} shared {1}"
 
 #. placeholder {0}: actor().rawName ?? actor().username
-#: src/routes/(root)/[handle]/(profile)/articles.tsx:72
-#: src/routes/(root)/[handle]/(profile)/articles.tsx:76
+#: src/routes/(root)/[handle]/(profile)/articles.tsx:73
+#: src/routes/(root)/[handle]/(profile)/articles.tsx:77
 msgid "{0}'s articles"
 msgstr "{0}'s articles"
 
 #. placeholder {0}: account().name
-#: src/routes/(root)/[handle]/(profile)/followers.tsx:72
-#: src/routes/(root)/[handle]/(profile)/followers.tsx:75
+#: src/routes/(root)/[handle]/(profile)/followers.tsx:73
+#: src/routes/(root)/[handle]/(profile)/followers.tsx:76
 msgid "{0}'s followers"
 msgstr "{0}'s followers"
 
 #. placeholder {0}: actor().rawName ?? actor().username
-#: src/routes/(root)/[handle]/(profile)/notes.tsx:73
-#: src/routes/(root)/[handle]/(profile)/notes.tsx:77
+#: src/routes/(root)/[handle]/(profile)/notes.tsx:74
+#: src/routes/(root)/[handle]/(profile)/notes.tsx:78
 msgid "{0}'s notes"
 msgstr "{0}'s notes"
 
 #. placeholder {0}: actor().rawName ?? actor().username
-#: src/routes/(root)/[handle]/(profile)/shares.tsx:74
-#: src/routes/(root)/[handle]/(profile)/shares.tsx:78
+#: src/routes/(root)/[handle]/(profile)/shares.tsx:75
+#: src/routes/(root)/[handle]/(profile)/shares.tsx:79
 msgid "{0}'s shares"
 msgstr "{0}'s shares"
 
@@ -61,8 +61,8 @@ msgstr "A sign-in link has been sent to your email. Please check your inbox (or 
 msgid "Account"
 msgstr "Account"
 
-#: src/routes/(root)/[handle]/(profile)/articles.tsx:83
 #: src/components/ProfileTabs.tsx:48
+#: src/routes/(root)/[handle]/(profile)/articles.tsx:84
 msgid "Articles"
 msgstr "Articles"
 
@@ -72,7 +72,6 @@ msgstr "Articles only"
 
 #: src/routes/(root)/coc.tsx:53
 #: src/routes/(root)/coc.tsx:58
-#: src/components/AppSidebar.tsx:278
 msgid "Code of conduct"
 msgstr "Code of conduct"
 
@@ -100,8 +99,8 @@ msgstr "Failed to load more followers; click to retry"
 msgid "Failed to load more notes; click to retry"
 msgstr "Failed to load more notes; click to retry"
 
-#: src/components/ActorSharedPostList.tsx:75
 #: src/components/ActorPostList.tsx:73
+#: src/components/ActorSharedPostList.tsx:75
 msgid "Failed to load more posts; click to retry"
 msgstr "Failed to load more posts; click to retry"
 
@@ -118,7 +117,7 @@ msgstr "Fediverse"
 msgid "Feed"
 msgstr "Feed"
 
-#: src/routes/(root)/[handle]/(profile)/followers.tsx:81
+#: src/routes/(root)/[handle]/(profile)/followers.tsx:82
 msgid "Followers"
 msgstr "Followers"
 
@@ -126,7 +125,7 @@ msgstr "Followers"
 msgid "Followers only"
 msgstr "Followers only"
 
-#: src/components/ProfileCard.tsx:176
+#: src/components/ProfileCard.tsx:188
 msgid "Following you"
 msgstr "Following you"
 
@@ -134,11 +133,11 @@ msgstr "Following you"
 msgid "GitHub repository"
 msgstr "GitHub repository"
 
-#: src/routes/sign.tsx:11
-#: src/routes/(root)/markdown.tsx:53
-#: src/routes/(root)/coc.tsx:53
 #: src/components/AppSidebar.tsx:91
 #: src/components/AppSidebar.tsx:135
+#: src/routes/(root)/coc.tsx:53
+#: src/routes/(root)/markdown.tsx:53
+#: src/routes/sign.tsx:11
 msgid "Hackers' Pub"
 msgstr "Hackers' Pub"
 
@@ -158,8 +157,8 @@ msgstr "Load more followers"
 msgid "Load more notes"
 msgstr "Load more notes"
 
-#: src/components/ActorSharedPostList.tsx:78
 #: src/components/ActorPostList.tsx:76
+#: src/components/ActorSharedPostList.tsx:78
 msgid "Load more posts"
 msgstr "Load more posts"
 
@@ -175,8 +174,8 @@ msgstr "Loading more followers…"
 msgid "Loading more notes…"
 msgstr "Loading more notes…"
 
-#: src/components/ActorSharedPostList.tsx:72
 #: src/components/ActorPostList.tsx:70
+#: src/components/ActorSharedPostList.tsx:72
 msgid "Loading more posts…"
 msgstr "Loading more posts…"
 
@@ -201,8 +200,8 @@ msgstr "No notes articles"
 msgid "No notes found"
 msgstr "No notes found"
 
-#: src/components/ActorSharedPostList.tsx:85
 #: src/components/ActorPostList.tsx:83
+#: src/components/ActorSharedPostList.tsx:85
 msgid "No posts found"
 msgstr "No posts found"
 
@@ -214,8 +213,8 @@ msgstr "No posts found"
 msgid "No such account in Hackers' Pub—please try again."
 msgstr "No such account in Hackers' Pub—please try again."
 
-#: src/routes/(root)/[handle]/(profile)/notes.tsx:84
 #: src/components/ProfileTabs.tsx:41
+#: src/routes/(root)/[handle]/(profile)/notes.tsx:85
 msgid "Notes"
 msgstr "Notes"
 
@@ -235,13 +234,13 @@ msgstr "Quiet public"
 msgid "Read full article"
 msgstr "Read full article"
 
-#: src/routes/(root)/[handle]/(profile)/shares.tsx:85
 #: src/components/ProfileTabs.tsx:51
+#: src/routes/(root)/[handle]/(profile)/shares.tsx:86
 msgid "Shares"
 msgstr "Shares"
 
-#: src/routes/sign/index.tsx:224
 #: src/components/AppSidebar.tsx:225
+#: src/routes/sign/index.tsx:224
 msgid "Sign in"
 msgstr "Sign in"
 
@@ -282,7 +281,7 @@ msgstr "Translated from {0}"
 
 #. placeholder {0}: "OWNER"
 #. placeholder {1}: "RELATIVE_TIME"
-#: src/components/ProfileCard.tsx:125
+#: src/components/ProfileCard.tsx:137
 msgid "Verified that this link is owned by {0} {1}"
 msgstr "Verified that this link is owned by {0} {1}"
 

--- a/web-next/src/locales/en-US/messages.po
+++ b/web-next/src/locales/en-US/messages.po
@@ -61,6 +61,10 @@ msgstr "A sign-in link has been sent to your email. Please check your inbox (or 
 msgid "Account"
 msgstr "Account"
 
+#: src/routes/sign/up/[token].tsx:307
+msgid "An error occurred during signup. Please try again."
+msgstr "An error occurred during signup. Please try again."
+
 #: src/components/ProfileTabs.tsx:48
 #: src/routes/(root)/[handle]/(profile)/articles.tsx:84
 msgid "Articles"
@@ -70,26 +74,26 @@ msgstr "Articles"
 msgid "Articles only"
 msgstr "Articles only"
 
-#: src/routes/sign/up/[token].tsx:379
+#: src/routes/sign/up/[token].tsx:423
 msgid "Bio"
 msgstr "Bio"
 
-#: src/routes/sign/up/[token].tsx:160
+#: src/routes/sign/up/[token].tsx:174
 msgid "Bio is too long. Maximum length is 512 characters."
 msgstr "Bio is too long. Maximum length is 512 characters."
 
 #: src/components/AppSidebar.tsx:278
 #: src/routes/(root)/coc.tsx:53
 #: src/routes/(root)/coc.tsx:58
-#: src/routes/sign/up/[token].tsx:422
+#: src/routes/sign/up/[token].tsx:470
 msgid "Code of conduct"
 msgstr "Code of conduct"
 
-#: src/routes/sign/up/[token].tsx:450
+#: src/routes/sign/up/[token].tsx:498
 msgid "Creating account..."
 msgstr "Creating account..."
 
-#: src/routes/sign/up/[token].tsx:353
+#: src/routes/sign/up/[token].tsx:397
 msgid "Display name"
 msgstr "Display name"
 
@@ -97,7 +101,7 @@ msgstr "Display name"
 msgid "Do you need an account? Hackers' Pub is invite-only—please ask a friend to invite you."
 msgstr "Do you need an account? Hackers' Pub is invite-only—please ask a friend to invite you."
 
-#: src/routes/sign/up/[token].tsx:308
+#: src/routes/sign/up/[token].tsx:350
 msgid "Email address"
 msgstr "Email address"
 
@@ -108,6 +112,10 @@ msgstr "Email or username"
 #: src/routes/sign/index.tsx:193
 msgid "Enter your email or username below to sign in."
 msgstr "Enter your email or username below to sign in."
+
+#: src/routes/sign/up/[token].tsx:304
+msgid "Error"
+msgstr "Error"
 
 #: src/components/ActorArticleList.tsx:75
 msgid "Failed to load more articles; click to retry"
@@ -167,7 +175,7 @@ msgstr "Hackers' Pub"
 msgid "Home"
 msgstr "Home"
 
-#: src/routes/sign/up/[token].tsx:424
+#: src/routes/sign/up/[token].tsx:472
 msgid "I have read and agree to the Code of conduct."
 msgstr "I have read and agree to the Code of conduct."
 
@@ -205,7 +213,7 @@ msgstr "Loading more notes…"
 msgid "Loading more posts…"
 msgstr "Loading more posts…"
 
-#: src/routes/sign/up/[token].tsx:434
+#: src/routes/sign/up/[token].tsx:482
 msgid "Loading..."
 msgstr "Loading..."
 
@@ -218,11 +226,11 @@ msgstr "Markdown guide"
 msgid "Mentioned only"
 msgstr "Mentioned only"
 
-#: src/routes/sign/up/[token].tsx:147
+#: src/routes/sign/up/[token].tsx:161
 msgid "Name is required."
 msgstr "Name is required."
 
-#: src/routes/sign/up/[token].tsx:149
+#: src/routes/sign/up/[token].tsx:163
 msgid "Name is too long. Maximum length is 50 characters."
 msgstr "Name is too long. Maximum length is 50 characters."
 
@@ -272,7 +280,7 @@ msgstr "Quiet public"
 msgid "Read full article"
 msgstr "Read full article"
 
-#: src/routes/sign/up/[token].tsx:428
+#: src/routes/sign/up/[token].tsx:476
 msgid "Read the full Code of conduct"
 msgstr "Read the full Code of conduct"
 
@@ -290,8 +298,8 @@ msgstr "Sign in"
 msgid "Sign out"
 msgstr "Sign out"
 
-#: src/routes/sign/up/[token].tsx:284
-#: src/routes/sign/up/[token].tsx:450
+#: src/routes/sign/up/[token].tsx:326
+#: src/routes/sign/up/[token].tsx:498
 msgid "Sign up"
 msgstr "Sign up"
 
@@ -311,11 +319,11 @@ msgstr "Summarized by LLM"
 msgid "Table of contents"
 msgstr "Table of contents"
 
-#: src/routes/sign/up/[token].tsx:383
+#: src/routes/sign/up/[token].tsx:427
 msgid "Tell us about yourself..."
 msgstr "Tell us about yourself..."
 
-#: src/routes/sign/up/[token].tsx:293
+#: src/routes/sign/up/[token].tsx:335
 msgid "The sign-up link is invalid. Please make sure you're using the correct link from the email you received."
 msgstr "The sign-up link is invalid. Please make sure you're using the correct link from the email you received."
 
@@ -334,23 +342,23 @@ msgstr "Timeline"
 msgid "Translated from {0}"
 msgstr "Translated from {0}"
 
-#: src/routes/sign/up/[token].tsx:326
+#: src/routes/sign/up/[token].tsx:370
 msgid "Username"
 msgstr "Username"
 
-#: src/routes/sign/up/[token].tsx:134
+#: src/routes/sign/up/[token].tsx:148
 msgid "Username can only contain lowercase letters, numbers, and underscores."
 msgstr "Username can only contain lowercase letters, numbers, and underscores."
 
-#: src/routes/sign/up/[token].tsx:136
+#: src/routes/sign/up/[token].tsx:150
 msgid "Username is already taken."
 msgstr "Username is already taken."
 
-#: src/routes/sign/up/[token].tsx:130
+#: src/routes/sign/up/[token].tsx:144
 msgid "Username is required."
 msgstr "Username is required."
 
-#: src/routes/sign/up/[token].tsx:132
+#: src/routes/sign/up/[token].tsx:146
 msgid "Username is too long. Maximum length is 15 characters."
 msgstr "Username is too long. Maximum length is 15 characters."
 
@@ -360,7 +368,7 @@ msgstr "Username is too long. Maximum length is 15 characters."
 msgid "Verified that this link is owned by {0} {1}"
 msgstr "Verified that this link is owned by {0} {1}"
 
-#: src/routes/sign/up/[token].tsx:288
+#: src/routes/sign/up/[token].tsx:330
 msgid "Verifying your invitation..."
 msgstr "Verifying your invitation..."
 
@@ -380,7 +388,7 @@ msgstr "Visible to everyone, but does not appear in the public timeline. Only th
 msgid "Visible to everyone, including non-registered users. The post will appear in the public timeline as well."
 msgstr "Visible to everyone, including non-registered users. The post will appear in the public timeline as well."
 
-#: src/routes/sign/up/[token].tsx:298
+#: src/routes/sign/up/[token].tsx:340
 msgid "Welcome to Hackers' Pub! Please fill out the form below to complete your sign-up."
 msgstr "Welcome to Hackers' Pub! Please fill out the form below to complete your sign-up."
 
@@ -388,26 +396,26 @@ msgstr "Welcome to Hackers' Pub! Please fill out the form below to complete your
 msgid "Without shares"
 msgstr "Without shares"
 
-#: src/routes/sign/up/[token].tsx:398
+#: src/routes/sign/up/[token].tsx:446
 msgid "You were invited by"
 msgstr "You were invited by"
 
-#: src/routes/sign/up/[token].tsx:415
+#: src/routes/sign/up/[token].tsx:463
 msgid "You'll automatically follow each other when you sign up."
 msgstr "You'll automatically follow each other when you sign up."
 
-#: src/routes/sign/up/[token].tsx:391
+#: src/routes/sign/up/[token].tsx:439
 msgid "Your bio will be displayed on your profile. You can use Markdown to format it. Maximum 512 characters."
 msgstr "Your bio will be displayed on your profile. You can use Markdown to format it. Maximum 512 characters."
 
-#: src/routes/sign/up/[token].tsx:317
+#: src/routes/sign/up/[token].tsx:359
 msgid "Your email address will be used to sign in to your account."
 msgstr "Your email address will be used to sign in to your account."
 
-#: src/routes/sign/up/[token].tsx:369
+#: src/routes/sign/up/[token].tsx:413
 msgid "Your name will be displayed on your profile and in your posts."
 msgstr "Your name will be displayed on your profile and in your posts."
 
-#: src/routes/sign/up/[token].tsx:343
+#: src/routes/sign/up/[token].tsx:387
 msgid "Your username will be used to create your profile URL and your fediverse handle."
 msgstr "Your username will be used to create your profile URL and your fediverse handle."

--- a/web-next/src/locales/en-US/messages.po
+++ b/web-next/src/locales/en-US/messages.po
@@ -70,26 +70,26 @@ msgstr "Articles"
 msgid "Articles only"
 msgstr "Articles only"
 
-#: src/routes/sign/up/[token].tsx:331
+#: src/routes/sign/up/[token].tsx:379
 msgid "Bio"
 msgstr "Bio"
 
-#: src/routes/sign/up/[token].tsx:136
+#: src/routes/sign/up/[token].tsx:160
 msgid "Bio is too long. Maximum length is 512 characters."
 msgstr "Bio is too long. Maximum length is 512 characters."
 
 #: src/components/AppSidebar.tsx:278
 #: src/routes/(root)/coc.tsx:53
 #: src/routes/(root)/coc.tsx:58
-#: src/routes/sign/up/[token].tsx:374
+#: src/routes/sign/up/[token].tsx:422
 msgid "Code of conduct"
 msgstr "Code of conduct"
 
-#: src/routes/sign/up/[token].tsx:402
+#: src/routes/sign/up/[token].tsx:450
 msgid "Creating account..."
 msgstr "Creating account..."
 
-#: src/routes/sign/up/[token].tsx:305
+#: src/routes/sign/up/[token].tsx:353
 msgid "Display name"
 msgstr "Display name"
 
@@ -97,7 +97,7 @@ msgstr "Display name"
 msgid "Do you need an account? Hackers' Pub is invite-only—please ask a friend to invite you."
 msgstr "Do you need an account? Hackers' Pub is invite-only—please ask a friend to invite you."
 
-#: src/routes/sign/up/[token].tsx:260
+#: src/routes/sign/up/[token].tsx:308
 msgid "Email address"
 msgstr "Email address"
 
@@ -167,7 +167,7 @@ msgstr "Hackers' Pub"
 msgid "Home"
 msgstr "Home"
 
-#: src/routes/sign/up/[token].tsx:376
+#: src/routes/sign/up/[token].tsx:424
 msgid "I have read and agree to the Code of conduct."
 msgstr "I have read and agree to the Code of conduct."
 
@@ -205,7 +205,7 @@ msgstr "Loading more notes…"
 msgid "Loading more posts…"
 msgstr "Loading more posts…"
 
-#: src/routes/sign/up/[token].tsx:386
+#: src/routes/sign/up/[token].tsx:434
 msgid "Loading..."
 msgstr "Loading..."
 
@@ -218,11 +218,11 @@ msgstr "Markdown guide"
 msgid "Mentioned only"
 msgstr "Mentioned only"
 
-#: src/routes/sign/up/[token].tsx:126
+#: src/routes/sign/up/[token].tsx:147
 msgid "Name is required."
 msgstr "Name is required."
 
-#: src/routes/sign/up/[token].tsx:129
+#: src/routes/sign/up/[token].tsx:149
 msgid "Name is too long. Maximum length is 50 characters."
 msgstr "Name is too long. Maximum length is 50 characters."
 
@@ -272,7 +272,7 @@ msgstr "Quiet public"
 msgid "Read full article"
 msgstr "Read full article"
 
-#: src/routes/sign/up/[token].tsx:380
+#: src/routes/sign/up/[token].tsx:428
 msgid "Read the full Code of conduct"
 msgstr "Read the full Code of conduct"
 
@@ -290,8 +290,8 @@ msgstr "Sign in"
 msgid "Sign out"
 msgstr "Sign out"
 
-#: src/routes/sign/up/[token].tsx:236
-#: src/routes/sign/up/[token].tsx:402
+#: src/routes/sign/up/[token].tsx:284
+#: src/routes/sign/up/[token].tsx:450
 msgid "Sign up"
 msgstr "Sign up"
 
@@ -311,11 +311,11 @@ msgstr "Summarized by LLM"
 msgid "Table of contents"
 msgstr "Table of contents"
 
-#: src/routes/sign/up/[token].tsx:335
+#: src/routes/sign/up/[token].tsx:383
 msgid "Tell us about yourself..."
 msgstr "Tell us about yourself..."
 
-#: src/routes/sign/up/[token].tsx:245
+#: src/routes/sign/up/[token].tsx:293
 msgid "The sign-up link is invalid. Please make sure you're using the correct link from the email you received."
 msgstr "The sign-up link is invalid. Please make sure you're using the correct link from the email you received."
 
@@ -334,21 +334,25 @@ msgstr "Timeline"
 msgid "Translated from {0}"
 msgstr "Translated from {0}"
 
-#: src/routes/sign/up/[token].tsx:278
+#: src/routes/sign/up/[token].tsx:326
 msgid "Username"
 msgstr "Username"
 
-#: src/routes/sign/up/[token].tsx:119
+#: src/routes/sign/up/[token].tsx:134
 msgid "Username can only contain lowercase letters, numbers, and underscores."
 msgstr "Username can only contain lowercase letters, numbers, and underscores."
 
-#: src/routes/sign/up/[token].tsx:113
+#: src/routes/sign/up/[token].tsx:136
+msgid "Username is already taken."
+msgstr "Username is already taken."
+
+#: src/routes/sign/up/[token].tsx:130
 msgid "Username is required."
 msgstr "Username is required."
 
-#: src/routes/sign/up/[token].tsx:116
-msgid "Username is too long. Maximum length is 50 characters."
-msgstr "Username is too long. Maximum length is 50 characters."
+#: src/routes/sign/up/[token].tsx:132
+msgid "Username is too long. Maximum length is 15 characters."
+msgstr "Username is too long. Maximum length is 15 characters."
 
 #. placeholder {0}: "OWNER"
 #. placeholder {1}: "RELATIVE_TIME"
@@ -356,7 +360,7 @@ msgstr "Username is too long. Maximum length is 50 characters."
 msgid "Verified that this link is owned by {0} {1}"
 msgstr "Verified that this link is owned by {0} {1}"
 
-#: src/routes/sign/up/[token].tsx:240
+#: src/routes/sign/up/[token].tsx:288
 msgid "Verifying your invitation..."
 msgstr "Verifying your invitation..."
 
@@ -376,7 +380,7 @@ msgstr "Visible to everyone, but does not appear in the public timeline. Only th
 msgid "Visible to everyone, including non-registered users. The post will appear in the public timeline as well."
 msgstr "Visible to everyone, including non-registered users. The post will appear in the public timeline as well."
 
-#: src/routes/sign/up/[token].tsx:250
+#: src/routes/sign/up/[token].tsx:298
 msgid "Welcome to Hackers' Pub! Please fill out the form below to complete your sign-up."
 msgstr "Welcome to Hackers' Pub! Please fill out the form below to complete your sign-up."
 
@@ -384,26 +388,26 @@ msgstr "Welcome to Hackers' Pub! Please fill out the form below to complete your
 msgid "Without shares"
 msgstr "Without shares"
 
-#: src/routes/sign/up/[token].tsx:350
+#: src/routes/sign/up/[token].tsx:398
 msgid "You were invited by"
 msgstr "You were invited by"
 
-#: src/routes/sign/up/[token].tsx:367
+#: src/routes/sign/up/[token].tsx:415
 msgid "You'll automatically follow each other when you sign up."
 msgstr "You'll automatically follow each other when you sign up."
 
-#: src/routes/sign/up/[token].tsx:343
+#: src/routes/sign/up/[token].tsx:391
 msgid "Your bio will be displayed on your profile. You can use Markdown to format it. Maximum 512 characters."
 msgstr "Your bio will be displayed on your profile. You can use Markdown to format it. Maximum 512 characters."
 
-#: src/routes/sign/up/[token].tsx:269
+#: src/routes/sign/up/[token].tsx:317
 msgid "Your email address will be used to sign in to your account."
 msgstr "Your email address will be used to sign in to your account."
 
-#: src/routes/sign/up/[token].tsx:321
+#: src/routes/sign/up/[token].tsx:369
 msgid "Your name will be displayed on your profile and in your posts."
 msgstr "Your name will be displayed on your profile and in your posts."
 
-#: src/routes/sign/up/[token].tsx:295
+#: src/routes/sign/up/[token].tsx:343
 msgid "Your username will be used to create your profile URL and your fediverse handle."
 msgstr "Your username will be used to create your profile URL and your fediverse handle."

--- a/web-next/src/locales/ja-JP/messages.po
+++ b/web-next/src/locales/ja-JP/messages.po
@@ -70,14 +70,36 @@ msgstr "記事"
 msgid "Articles only"
 msgstr "記事のみ"
 
+#: src/routes/sign/up/[token].tsx:331
+msgid "Bio"
+msgstr "自己紹介"
+
+#: src/routes/sign/up/[token].tsx:136
+msgid "Bio is too long. Maximum length is 512 characters."
+msgstr "自己紹介が長すぎます。最大512文字です。"
+
+#: src/components/AppSidebar.tsx:278
 #: src/routes/(root)/coc.tsx:53
 #: src/routes/(root)/coc.tsx:58
+#: src/routes/sign/up/[token].tsx:374
 msgid "Code of conduct"
 msgstr "行動規範"
+
+#: src/routes/sign/up/[token].tsx:402
+msgid "Creating account..."
+msgstr "アカウントを作成中..."
+
+#: src/routes/sign/up/[token].tsx:305
+msgid "Display name"
+msgstr "名前"
 
 #: src/routes/sign/index.tsx:230
 msgid "Do you need an account? Hackers' Pub is invite-only—please ask a friend to invite you."
 msgstr "アカウントが必要ですか？Hackers' Pubは招待制ですので、友人に招待をお願いしてください。"
+
+#: src/routes/sign/up/[token].tsx:260
+msgid "Email address"
+msgstr "メールアドレス"
 
 #: src/routes/sign/index.tsx:208
 msgid "Email or username"
@@ -145,6 +167,10 @@ msgstr "Hackers' Pub"
 msgid "Home"
 msgstr "ホーム"
 
+#: src/routes/sign/up/[token].tsx:376
+msgid "I have read and agree to the Code of conduct."
+msgstr "行動規範に同意します。"
+
 #: src/components/ActorArticleList.tsx:78
 msgid "Load more articles"
 msgstr "記事をもっと読み込む"
@@ -179,6 +205,10 @@ msgstr "投稿を読み込み中…"
 msgid "Loading more posts…"
 msgstr "コンテンツを読み込み中…"
 
+#: src/routes/sign/up/[token].tsx:386
+msgid "Loading..."
+msgstr "読み込み中..."
+
 #: src/routes/(root)/markdown.tsx:53
 #: src/routes/(root)/markdown.tsx:58
 msgid "Markdown guide"
@@ -187,6 +217,14 @@ msgstr "Markdown ガイド"
 #: src/components/VisibilityTag.tsx:98
 msgid "Mentioned only"
 msgstr "メンションされたユーザーのみ"
+
+#: src/routes/sign/up/[token].tsx:126
+msgid "Name is required."
+msgstr "名前は必須です。"
+
+#: src/routes/sign/up/[token].tsx:129
+msgid "Name is too long. Maximum length is 50 characters."
+msgstr "名前が長すぎます。最大50文字です。"
 
 #: src/components/ActorFollowerList.tsx:90
 msgid "No followers found"
@@ -234,6 +272,10 @@ msgstr "ひかえめな公開"
 msgid "Read full article"
 msgstr "記事全文を読む"
 
+#: src/routes/sign/up/[token].tsx:380
+msgid "Read the full Code of conduct"
+msgstr "行動規範の全文を読む"
+
 #: src/components/ProfileTabs.tsx:51
 #: src/routes/(root)/[handle]/(profile)/shares.tsx:86
 msgid "Shares"
@@ -247,6 +289,11 @@ msgstr "ログイン"
 #: src/components/AppSidebar.tsx:267
 msgid "Sign out"
 msgstr "ログアウト"
+
+#: src/routes/sign/up/[token].tsx:236
+#: src/routes/sign/up/[token].tsx:402
+msgid "Sign up"
+msgstr "登録"
 
 #: src/routes/sign/index.tsx:187
 msgid "Signing in Hackers' Pub"
@@ -264,6 +311,14 @@ msgstr "LLMによる要約"
 msgid "Table of contents"
 msgstr "目次"
 
+#: src/routes/sign/up/[token].tsx:335
+msgid "Tell us about yourself..."
+msgstr "自己紹介をお聞かせください..."
+
+#: src/routes/sign/up/[token].tsx:245
+msgid "The sign-up link is invalid. Please make sure you're using the correct link from the email you received."
+msgstr "登録リンクが無効です。受信したメールのリンクを正しく使用しているかご確認ください。"
+
 #. placeholder {0}: "GITHUB_REPOSITORY"
 #. placeholder {1}: "AGPL-3.0"
 #: src/components/AppSidebar.tsx:282
@@ -279,11 +334,31 @@ msgstr "タイムライン"
 msgid "Translated from {0}"
 msgstr "{0}から翻訳"
 
+#: src/routes/sign/up/[token].tsx:278
+msgid "Username"
+msgstr "ユーザー名"
+
+#: src/routes/sign/up/[token].tsx:119
+msgid "Username can only contain lowercase letters, numbers, and underscores."
+msgstr "ユーザー名には小文字、数字、アンダースコアのみ使用できます。"
+
+#: src/routes/sign/up/[token].tsx:113
+msgid "Username is required."
+msgstr "ユーザー名は必須です。"
+
+#: src/routes/sign/up/[token].tsx:116
+msgid "Username is too long. Maximum length is 50 characters."
+msgstr "ユーザー名が長すぎます。最大50文字です。"
+
 #. placeholder {0}: "OWNER"
 #. placeholder {1}: "RELATIVE_TIME"
 #: src/components/ProfileCard.tsx:137
 msgid "Verified that this link is owned by {0} {1}"
 msgstr "{1}に{0}さんがこのリンクの所有者であることを確認済み"
+
+#: src/routes/sign/up/[token].tsx:240
+msgid "Verifying your invitation..."
+msgstr "招待を確認中..."
 
 #: src/components/VisibilityTag.tsx:79
 msgid "Visible only to the author's followers. The post will not appear in the public timeline, and only those who follow the author can see it."
@@ -301,6 +376,34 @@ msgstr "誰でも閲覧できますが、公開タイムラインには表示さ
 msgid "Visible to everyone, including non-registered users. The post will appear in the public timeline as well."
 msgstr "未登録ユーザーを含む誰でも閲覧できます。公開タイムラインにも表示されます。"
 
+#: src/routes/sign/up/[token].tsx:250
+msgid "Welcome to Hackers' Pub! Please fill out the form below to complete your sign-up."
+msgstr "Hackers' Pubへようこそ！登録を完了するには以下のフォームにご記入ください。"
+
 #: src/components/AppSidebar.tsx:173
 msgid "Without shares"
 msgstr "共有除外"
+
+#: src/routes/sign/up/[token].tsx:350
+msgid "You were invited by"
+msgstr "あなたを招待した方"
+
+#: src/routes/sign/up/[token].tsx:367
+msgid "You'll automatically follow each other when you sign up."
+msgstr "登録したら自動的にお互いをフォローします。"
+
+#: src/routes/sign/up/[token].tsx:343
+msgid "Your bio will be displayed on your profile. You can use Markdown to format it. Maximum 512 characters."
+msgstr "自己紹介はプロフィールに表示されます。Markdownで書式設定できます。最大512文字です。"
+
+#: src/routes/sign/up/[token].tsx:269
+msgid "Your email address will be used to sign in to your account."
+msgstr "メールアドレスはアカウントへのログインに使用されます。"
+
+#: src/routes/sign/up/[token].tsx:321
+msgid "Your name will be displayed on your profile and in your posts."
+msgstr "名前はプロフィールとコンテンツに表示されます。"
+
+#: src/routes/sign/up/[token].tsx:295
+msgid "Your username will be used to create your profile URL and your fediverse handle."
+msgstr "ユーザー名はプロフィールURLとフェディバースハンドルの作成に使用されます。"

--- a/web-next/src/locales/ja-JP/messages.po
+++ b/web-next/src/locales/ja-JP/messages.po
@@ -61,6 +61,10 @@ msgstr "ログインリンクがメールに送信されました。受信トレ
 msgid "Account"
 msgstr "アカウント"
 
+#: src/routes/sign/up/[token].tsx:307
+msgid "An error occurred during signup. Please try again."
+msgstr "登録中にエラーが発生しました。もう一度お試しください。"
+
 #: src/components/ProfileTabs.tsx:48
 #: src/routes/(root)/[handle]/(profile)/articles.tsx:84
 msgid "Articles"
@@ -70,26 +74,26 @@ msgstr "記事"
 msgid "Articles only"
 msgstr "記事のみ"
 
-#: src/routes/sign/up/[token].tsx:379
+#: src/routes/sign/up/[token].tsx:423
 msgid "Bio"
 msgstr "自己紹介"
 
-#: src/routes/sign/up/[token].tsx:160
+#: src/routes/sign/up/[token].tsx:174
 msgid "Bio is too long. Maximum length is 512 characters."
 msgstr "自己紹介が長すぎます。最大512文字です。"
 
 #: src/components/AppSidebar.tsx:278
 #: src/routes/(root)/coc.tsx:53
 #: src/routes/(root)/coc.tsx:58
-#: src/routes/sign/up/[token].tsx:422
+#: src/routes/sign/up/[token].tsx:470
 msgid "Code of conduct"
 msgstr "行動規範"
 
-#: src/routes/sign/up/[token].tsx:450
+#: src/routes/sign/up/[token].tsx:498
 msgid "Creating account..."
 msgstr "アカウントを作成中..."
 
-#: src/routes/sign/up/[token].tsx:353
+#: src/routes/sign/up/[token].tsx:397
 msgid "Display name"
 msgstr "名前"
 
@@ -97,7 +101,7 @@ msgstr "名前"
 msgid "Do you need an account? Hackers' Pub is invite-only—please ask a friend to invite you."
 msgstr "アカウントが必要ですか？Hackers' Pubは招待制ですので、友人に招待をお願いしてください。"
 
-#: src/routes/sign/up/[token].tsx:308
+#: src/routes/sign/up/[token].tsx:350
 msgid "Email address"
 msgstr "メールアドレス"
 
@@ -108,6 +112,10 @@ msgstr "メールアドレスまたはユーザー名"
 #: src/routes/sign/index.tsx:193
 msgid "Enter your email or username below to sign in."
 msgstr "以下にメールアドレスまたはユーザー名を入力してログインしてください。"
+
+#: src/routes/sign/up/[token].tsx:304
+msgid "Error"
+msgstr "エラー"
 
 #: src/components/ActorArticleList.tsx:75
 msgid "Failed to load more articles; click to retry"
@@ -167,7 +175,7 @@ msgstr "Hackers' Pub"
 msgid "Home"
 msgstr "ホーム"
 
-#: src/routes/sign/up/[token].tsx:424
+#: src/routes/sign/up/[token].tsx:472
 msgid "I have read and agree to the Code of conduct."
 msgstr "行動規範に同意します。"
 
@@ -205,7 +213,7 @@ msgstr "投稿を読み込み中…"
 msgid "Loading more posts…"
 msgstr "コンテンツを読み込み中…"
 
-#: src/routes/sign/up/[token].tsx:434
+#: src/routes/sign/up/[token].tsx:482
 msgid "Loading..."
 msgstr "読み込み中..."
 
@@ -218,11 +226,11 @@ msgstr "Markdown ガイド"
 msgid "Mentioned only"
 msgstr "メンションされたユーザーのみ"
 
-#: src/routes/sign/up/[token].tsx:147
+#: src/routes/sign/up/[token].tsx:161
 msgid "Name is required."
 msgstr "名前は必須です。"
 
-#: src/routes/sign/up/[token].tsx:149
+#: src/routes/sign/up/[token].tsx:163
 msgid "Name is too long. Maximum length is 50 characters."
 msgstr "名前が長すぎます。最大50文字です。"
 
@@ -272,7 +280,7 @@ msgstr "ひかえめな公開"
 msgid "Read full article"
 msgstr "記事全文を読む"
 
-#: src/routes/sign/up/[token].tsx:428
+#: src/routes/sign/up/[token].tsx:476
 msgid "Read the full Code of conduct"
 msgstr "行動規範の全文を読む"
 
@@ -290,8 +298,8 @@ msgstr "ログイン"
 msgid "Sign out"
 msgstr "ログアウト"
 
-#: src/routes/sign/up/[token].tsx:284
-#: src/routes/sign/up/[token].tsx:450
+#: src/routes/sign/up/[token].tsx:326
+#: src/routes/sign/up/[token].tsx:498
 msgid "Sign up"
 msgstr "登録"
 
@@ -311,11 +319,11 @@ msgstr "LLMによる要約"
 msgid "Table of contents"
 msgstr "目次"
 
-#: src/routes/sign/up/[token].tsx:383
+#: src/routes/sign/up/[token].tsx:427
 msgid "Tell us about yourself..."
 msgstr "自己紹介をお聞かせください..."
 
-#: src/routes/sign/up/[token].tsx:293
+#: src/routes/sign/up/[token].tsx:335
 msgid "The sign-up link is invalid. Please make sure you're using the correct link from the email you received."
 msgstr "登録リンクが無効です。受信したメールのリンクを正しく使用しているかご確認ください。"
 
@@ -334,23 +342,23 @@ msgstr "タイムライン"
 msgid "Translated from {0}"
 msgstr "{0}から翻訳"
 
-#: src/routes/sign/up/[token].tsx:326
+#: src/routes/sign/up/[token].tsx:370
 msgid "Username"
 msgstr "ユーザー名"
 
-#: src/routes/sign/up/[token].tsx:134
+#: src/routes/sign/up/[token].tsx:148
 msgid "Username can only contain lowercase letters, numbers, and underscores."
 msgstr "ユーザー名には小文字、数字、アンダースコアのみ使用できます。"
 
-#: src/routes/sign/up/[token].tsx:136
+#: src/routes/sign/up/[token].tsx:150
 msgid "Username is already taken."
 msgstr "他のユーサーが使用しているユーサー名です。"
 
-#: src/routes/sign/up/[token].tsx:130
+#: src/routes/sign/up/[token].tsx:144
 msgid "Username is required."
 msgstr "ユーザー名は必須です。"
 
-#: src/routes/sign/up/[token].tsx:132
+#: src/routes/sign/up/[token].tsx:146
 msgid "Username is too long. Maximum length is 15 characters."
 msgstr "ユーザー名が長すぎます。最大15文字です。"
 
@@ -360,7 +368,7 @@ msgstr "ユーザー名が長すぎます。最大15文字です。"
 msgid "Verified that this link is owned by {0} {1}"
 msgstr "{1}に{0}さんがこのリンクの所有者であることを確認済み"
 
-#: src/routes/sign/up/[token].tsx:288
+#: src/routes/sign/up/[token].tsx:330
 msgid "Verifying your invitation..."
 msgstr "招待を確認中..."
 
@@ -380,7 +388,7 @@ msgstr "誰でも閲覧できますが、公開タイムラインには表示さ
 msgid "Visible to everyone, including non-registered users. The post will appear in the public timeline as well."
 msgstr "未登録ユーザーを含む誰でも閲覧できます。公開タイムラインにも表示されます。"
 
-#: src/routes/sign/up/[token].tsx:298
+#: src/routes/sign/up/[token].tsx:340
 msgid "Welcome to Hackers' Pub! Please fill out the form below to complete your sign-up."
 msgstr "Hackers' Pubへようこそ！登録を完了するには以下のフォームにご記入ください。"
 
@@ -388,26 +396,26 @@ msgstr "Hackers' Pubへようこそ！登録を完了するには以下のフォ
 msgid "Without shares"
 msgstr "共有除外"
 
-#: src/routes/sign/up/[token].tsx:398
+#: src/routes/sign/up/[token].tsx:446
 msgid "You were invited by"
 msgstr "あなたを招待した方"
 
-#: src/routes/sign/up/[token].tsx:415
+#: src/routes/sign/up/[token].tsx:463
 msgid "You'll automatically follow each other when you sign up."
 msgstr "登録したら自動的にお互いをフォローします。"
 
-#: src/routes/sign/up/[token].tsx:391
+#: src/routes/sign/up/[token].tsx:439
 msgid "Your bio will be displayed on your profile. You can use Markdown to format it. Maximum 512 characters."
 msgstr "自己紹介はプロフィールに表示されます。Markdownで書式設定できます。最大512文字です。"
 
-#: src/routes/sign/up/[token].tsx:317
+#: src/routes/sign/up/[token].tsx:359
 msgid "Your email address will be used to sign in to your account."
 msgstr "メールアドレスはアカウントへのログインに使用されます。"
 
-#: src/routes/sign/up/[token].tsx:369
+#: src/routes/sign/up/[token].tsx:413
 msgid "Your name will be displayed on your profile and in your posts."
 msgstr "名前はプロフィールとコンテンツに表示されます。"
 
-#: src/routes/sign/up/[token].tsx:343
+#: src/routes/sign/up/[token].tsx:387
 msgid "Your username will be used to create your profile URL and your fediverse handle."
 msgstr "ユーザー名はプロフィールURLとフェディバースハンドルの作成に使用されます。"

--- a/web-next/src/locales/ja-JP/messages.po
+++ b/web-next/src/locales/ja-JP/messages.po
@@ -70,26 +70,26 @@ msgstr "記事"
 msgid "Articles only"
 msgstr "記事のみ"
 
-#: src/routes/sign/up/[token].tsx:331
+#: src/routes/sign/up/[token].tsx:379
 msgid "Bio"
 msgstr "自己紹介"
 
-#: src/routes/sign/up/[token].tsx:136
+#: src/routes/sign/up/[token].tsx:160
 msgid "Bio is too long. Maximum length is 512 characters."
 msgstr "自己紹介が長すぎます。最大512文字です。"
 
 #: src/components/AppSidebar.tsx:278
 #: src/routes/(root)/coc.tsx:53
 #: src/routes/(root)/coc.tsx:58
-#: src/routes/sign/up/[token].tsx:374
+#: src/routes/sign/up/[token].tsx:422
 msgid "Code of conduct"
 msgstr "行動規範"
 
-#: src/routes/sign/up/[token].tsx:402
+#: src/routes/sign/up/[token].tsx:450
 msgid "Creating account..."
 msgstr "アカウントを作成中..."
 
-#: src/routes/sign/up/[token].tsx:305
+#: src/routes/sign/up/[token].tsx:353
 msgid "Display name"
 msgstr "名前"
 
@@ -97,7 +97,7 @@ msgstr "名前"
 msgid "Do you need an account? Hackers' Pub is invite-only—please ask a friend to invite you."
 msgstr "アカウントが必要ですか？Hackers' Pubは招待制ですので、友人に招待をお願いしてください。"
 
-#: src/routes/sign/up/[token].tsx:260
+#: src/routes/sign/up/[token].tsx:308
 msgid "Email address"
 msgstr "メールアドレス"
 
@@ -155,8 +155,8 @@ msgstr "あなたをフォロー中"
 msgid "GitHub repository"
 msgstr "GitHubリポジトリ"
 
-#: src/components/AppSidebar.tsx:135
 #: src/components/AppSidebar.tsx:91
+#: src/components/AppSidebar.tsx:135
 #: src/routes/(root)/coc.tsx:53
 #: src/routes/(root)/markdown.tsx:53
 #: src/routes/sign.tsx:11
@@ -167,7 +167,7 @@ msgstr "Hackers' Pub"
 msgid "Home"
 msgstr "ホーム"
 
-#: src/routes/sign/up/[token].tsx:376
+#: src/routes/sign/up/[token].tsx:424
 msgid "I have read and agree to the Code of conduct."
 msgstr "行動規範に同意します。"
 
@@ -205,7 +205,7 @@ msgstr "投稿を読み込み中…"
 msgid "Loading more posts…"
 msgstr "コンテンツを読み込み中…"
 
-#: src/routes/sign/up/[token].tsx:386
+#: src/routes/sign/up/[token].tsx:434
 msgid "Loading..."
 msgstr "読み込み中..."
 
@@ -218,11 +218,11 @@ msgstr "Markdown ガイド"
 msgid "Mentioned only"
 msgstr "メンションされたユーザーのみ"
 
-#: src/routes/sign/up/[token].tsx:126
+#: src/routes/sign/up/[token].tsx:147
 msgid "Name is required."
 msgstr "名前は必須です。"
 
-#: src/routes/sign/up/[token].tsx:129
+#: src/routes/sign/up/[token].tsx:149
 msgid "Name is too long. Maximum length is 50 characters."
 msgstr "名前が長すぎます。最大50文字です。"
 
@@ -272,7 +272,7 @@ msgstr "ひかえめな公開"
 msgid "Read full article"
 msgstr "記事全文を読む"
 
-#: src/routes/sign/up/[token].tsx:380
+#: src/routes/sign/up/[token].tsx:428
 msgid "Read the full Code of conduct"
 msgstr "行動規範の全文を読む"
 
@@ -290,8 +290,8 @@ msgstr "ログイン"
 msgid "Sign out"
 msgstr "ログアウト"
 
-#: src/routes/sign/up/[token].tsx:236
-#: src/routes/sign/up/[token].tsx:402
+#: src/routes/sign/up/[token].tsx:284
+#: src/routes/sign/up/[token].tsx:450
 msgid "Sign up"
 msgstr "登録"
 
@@ -311,11 +311,11 @@ msgstr "LLMによる要約"
 msgid "Table of contents"
 msgstr "目次"
 
-#: src/routes/sign/up/[token].tsx:335
+#: src/routes/sign/up/[token].tsx:383
 msgid "Tell us about yourself..."
 msgstr "自己紹介をお聞かせください..."
 
-#: src/routes/sign/up/[token].tsx:245
+#: src/routes/sign/up/[token].tsx:293
 msgid "The sign-up link is invalid. Please make sure you're using the correct link from the email you received."
 msgstr "登録リンクが無効です。受信したメールのリンクを正しく使用しているかご確認ください。"
 
@@ -334,21 +334,25 @@ msgstr "タイムライン"
 msgid "Translated from {0}"
 msgstr "{0}から翻訳"
 
-#: src/routes/sign/up/[token].tsx:278
+#: src/routes/sign/up/[token].tsx:326
 msgid "Username"
 msgstr "ユーザー名"
 
-#: src/routes/sign/up/[token].tsx:119
+#: src/routes/sign/up/[token].tsx:134
 msgid "Username can only contain lowercase letters, numbers, and underscores."
 msgstr "ユーザー名には小文字、数字、アンダースコアのみ使用できます。"
 
-#: src/routes/sign/up/[token].tsx:113
+#: src/routes/sign/up/[token].tsx:136
+msgid "Username is already taken."
+msgstr "他のユーサーが使用しているユーサー名です。"
+
+#: src/routes/sign/up/[token].tsx:130
 msgid "Username is required."
 msgstr "ユーザー名は必須です。"
 
-#: src/routes/sign/up/[token].tsx:116
-msgid "Username is too long. Maximum length is 50 characters."
-msgstr "ユーザー名が長すぎます。最大50文字です。"
+#: src/routes/sign/up/[token].tsx:132
+msgid "Username is too long. Maximum length is 15 characters."
+msgstr "ユーザー名が長すぎます。最大15文字です。"
 
 #. placeholder {0}: "OWNER"
 #. placeholder {1}: "RELATIVE_TIME"
@@ -356,7 +360,7 @@ msgstr "ユーザー名が長すぎます。最大50文字です。"
 msgid "Verified that this link is owned by {0} {1}"
 msgstr "{1}に{0}さんがこのリンクの所有者であることを確認済み"
 
-#: src/routes/sign/up/[token].tsx:240
+#: src/routes/sign/up/[token].tsx:288
 msgid "Verifying your invitation..."
 msgstr "招待を確認中..."
 
@@ -376,7 +380,7 @@ msgstr "誰でも閲覧できますが、公開タイムラインには表示さ
 msgid "Visible to everyone, including non-registered users. The post will appear in the public timeline as well."
 msgstr "未登録ユーザーを含む誰でも閲覧できます。公開タイムラインにも表示されます。"
 
-#: src/routes/sign/up/[token].tsx:250
+#: src/routes/sign/up/[token].tsx:298
 msgid "Welcome to Hackers' Pub! Please fill out the form below to complete your sign-up."
 msgstr "Hackers' Pubへようこそ！登録を完了するには以下のフォームにご記入ください。"
 
@@ -384,26 +388,26 @@ msgstr "Hackers' Pubへようこそ！登録を完了するには以下のフォ
 msgid "Without shares"
 msgstr "共有除外"
 
-#: src/routes/sign/up/[token].tsx:350
+#: src/routes/sign/up/[token].tsx:398
 msgid "You were invited by"
 msgstr "あなたを招待した方"
 
-#: src/routes/sign/up/[token].tsx:367
+#: src/routes/sign/up/[token].tsx:415
 msgid "You'll automatically follow each other when you sign up."
 msgstr "登録したら自動的にお互いをフォローします。"
 
-#: src/routes/sign/up/[token].tsx:343
+#: src/routes/sign/up/[token].tsx:391
 msgid "Your bio will be displayed on your profile. You can use Markdown to format it. Maximum 512 characters."
 msgstr "自己紹介はプロフィールに表示されます。Markdownで書式設定できます。最大512文字です。"
 
-#: src/routes/sign/up/[token].tsx:269
+#: src/routes/sign/up/[token].tsx:317
 msgid "Your email address will be used to sign in to your account."
 msgstr "メールアドレスはアカウントへのログインに使用されます。"
 
-#: src/routes/sign/up/[token].tsx:321
+#: src/routes/sign/up/[token].tsx:369
 msgid "Your name will be displayed on your profile and in your posts."
 msgstr "名前はプロフィールとコンテンツに表示されます。"
 
-#: src/routes/sign/up/[token].tsx:295
+#: src/routes/sign/up/[token].tsx:343
 msgid "Your username will be used to create your profile URL and your fediverse handle."
 msgstr "ユーザー名はプロフィールURLとフェディバースハンドルの作成に使用されます。"

--- a/web-next/src/locales/ja-JP/messages.po
+++ b/web-next/src/locales/ja-JP/messages.po
@@ -14,12 +14,12 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. placeholder {0}: actor().followersCount.totalCount
-#: src/components/ProfileCard.tsx:166
+#: src/components/ProfileCard.tsx:178
 msgid "{0, plural, one {# follower} other {# followers}}"
 msgstr "{0, plural, other {#フォロワー}}"
 
 #. placeholder {0}: actor().followeesCount.totalCount
-#: src/components/ProfileCard.tsx:151
+#: src/components/ProfileCard.tsx:163
 msgid "{0, plural, one {# following} other {# following}}"
 msgstr "{0, plural, other {#フォロー}}"
 
@@ -30,26 +30,26 @@ msgid "{0} shared {1}"
 msgstr "{0}さんが{1}に共有"
 
 #. placeholder {0}: actor().rawName ?? actor().username
-#: src/routes/(root)/[handle]/(profile)/articles.tsx:72
-#: src/routes/(root)/[handle]/(profile)/articles.tsx:76
+#: src/routes/(root)/[handle]/(profile)/articles.tsx:73
+#: src/routes/(root)/[handle]/(profile)/articles.tsx:77
 msgid "{0}'s articles"
 msgstr "{0}さんの記事"
 
 #. placeholder {0}: account().name
-#: src/routes/(root)/[handle]/(profile)/followers.tsx:72
-#: src/routes/(root)/[handle]/(profile)/followers.tsx:75
+#: src/routes/(root)/[handle]/(profile)/followers.tsx:73
+#: src/routes/(root)/[handle]/(profile)/followers.tsx:76
 msgid "{0}'s followers"
 msgstr "{0}さんのフォロワー"
 
 #. placeholder {0}: actor().rawName ?? actor().username
-#: src/routes/(root)/[handle]/(profile)/notes.tsx:73
-#: src/routes/(root)/[handle]/(profile)/notes.tsx:77
+#: src/routes/(root)/[handle]/(profile)/notes.tsx:74
+#: src/routes/(root)/[handle]/(profile)/notes.tsx:78
 msgid "{0}'s notes"
 msgstr "{0}さんの投稿"
 
 #. placeholder {0}: actor().rawName ?? actor().username
-#: src/routes/(root)/[handle]/(profile)/shares.tsx:74
-#: src/routes/(root)/[handle]/(profile)/shares.tsx:78
+#: src/routes/(root)/[handle]/(profile)/shares.tsx:75
+#: src/routes/(root)/[handle]/(profile)/shares.tsx:79
 msgid "{0}'s shares"
 msgstr "{0}さんの共有"
 
@@ -61,8 +61,8 @@ msgstr "ログインリンクがメールに送信されました。受信トレ
 msgid "Account"
 msgstr "アカウント"
 
-#: src/routes/(root)/[handle]/(profile)/articles.tsx:83
 #: src/components/ProfileTabs.tsx:48
+#: src/routes/(root)/[handle]/(profile)/articles.tsx:84
 msgid "Articles"
 msgstr "記事"
 
@@ -72,7 +72,6 @@ msgstr "記事のみ"
 
 #: src/routes/(root)/coc.tsx:53
 #: src/routes/(root)/coc.tsx:58
-#: src/components/AppSidebar.tsx:278
 msgid "Code of conduct"
 msgstr "行動規範"
 
@@ -100,8 +99,8 @@ msgstr "フォロワーの読み込みに失敗しました。クリックして
 msgid "Failed to load more notes; click to retry"
 msgstr "投稿の読み込みに失敗しました。クリックして再試行してください"
 
-#: src/components/ActorSharedPostList.tsx:75
 #: src/components/ActorPostList.tsx:73
+#: src/components/ActorSharedPostList.tsx:75
 msgid "Failed to load more posts; click to retry"
 msgstr "コンテンツの読み込みに失敗しました。クリックして再試行してください"
 
@@ -118,7 +117,7 @@ msgstr "フェディバース"
 msgid "Feed"
 msgstr "フィード"
 
-#: src/routes/(root)/[handle]/(profile)/followers.tsx:81
+#: src/routes/(root)/[handle]/(profile)/followers.tsx:82
 msgid "Followers"
 msgstr "フォロワー"
 
@@ -126,7 +125,7 @@ msgstr "フォロワー"
 msgid "Followers only"
 msgstr "フォロワーのみ"
 
-#: src/components/ProfileCard.tsx:176
+#: src/components/ProfileCard.tsx:188
 msgid "Following you"
 msgstr "あなたをフォロー中"
 
@@ -134,11 +133,11 @@ msgstr "あなたをフォロー中"
 msgid "GitHub repository"
 msgstr "GitHubリポジトリ"
 
-#: src/routes/sign.tsx:11
-#: src/routes/(root)/markdown.tsx:53
-#: src/routes/(root)/coc.tsx:53
-#: src/components/AppSidebar.tsx:91
 #: src/components/AppSidebar.tsx:135
+#: src/components/AppSidebar.tsx:91
+#: src/routes/(root)/coc.tsx:53
+#: src/routes/(root)/markdown.tsx:53
+#: src/routes/sign.tsx:11
 msgid "Hackers' Pub"
 msgstr "Hackers' Pub"
 
@@ -158,8 +157,8 @@ msgstr "フォロワーをもっと読み込む"
 msgid "Load more notes"
 msgstr "投稿をもっと読み込む"
 
-#: src/components/ActorSharedPostList.tsx:78
 #: src/components/ActorPostList.tsx:76
+#: src/components/ActorSharedPostList.tsx:78
 msgid "Load more posts"
 msgstr "コンテンツをもっと読み込む"
 
@@ -175,8 +174,8 @@ msgstr "フォロワーを読み込み中…"
 msgid "Loading more notes…"
 msgstr "投稿を読み込み中…"
 
-#: src/components/ActorSharedPostList.tsx:72
 #: src/components/ActorPostList.tsx:70
+#: src/components/ActorSharedPostList.tsx:72
 msgid "Loading more posts…"
 msgstr "コンテンツを読み込み中…"
 
@@ -201,8 +200,8 @@ msgstr "記事はありません"
 msgid "No notes found"
 msgstr "投稿はありません"
 
-#: src/components/ActorSharedPostList.tsx:85
 #: src/components/ActorPostList.tsx:83
+#: src/components/ActorSharedPostList.tsx:85
 msgid "No posts found"
 msgstr "コンテンツはありません"
 
@@ -214,8 +213,8 @@ msgstr "コンテンツはありません"
 msgid "No such account in Hackers' Pub—please try again."
 msgstr "Hackers' Pubにそのようなアカウントはありません。もう一度お試しください。"
 
-#: src/routes/(root)/[handle]/(profile)/notes.tsx:84
 #: src/components/ProfileTabs.tsx:41
+#: src/routes/(root)/[handle]/(profile)/notes.tsx:85
 msgid "Notes"
 msgstr "投稿"
 
@@ -235,13 +234,13 @@ msgstr "ひかえめな公開"
 msgid "Read full article"
 msgstr "記事全文を読む"
 
-#: src/routes/(root)/[handle]/(profile)/shares.tsx:85
 #: src/components/ProfileTabs.tsx:51
+#: src/routes/(root)/[handle]/(profile)/shares.tsx:86
 msgid "Shares"
 msgstr "共有"
 
-#: src/routes/sign/index.tsx:224
 #: src/components/AppSidebar.tsx:225
+#: src/routes/sign/index.tsx:224
 msgid "Sign in"
 msgstr "ログイン"
 
@@ -282,7 +281,7 @@ msgstr "{0}から翻訳"
 
 #. placeholder {0}: "OWNER"
 #. placeholder {1}: "RELATIVE_TIME"
-#: src/components/ProfileCard.tsx:125
+#: src/components/ProfileCard.tsx:137
 msgid "Verified that this link is owned by {0} {1}"
 msgstr "{1}に{0}さんがこのリンクの所有者であることを確認済み"
 

--- a/web-next/src/locales/ko-KR/messages.po
+++ b/web-next/src/locales/ko-KR/messages.po
@@ -70,15 +70,36 @@ msgstr "게시글"
 msgid "Articles only"
 msgstr "게시글만"
 
+#: src/routes/sign/up/[token].tsx:331
+msgid "Bio"
+msgstr "약력"
+
+#: src/routes/sign/up/[token].tsx:136
+msgid "Bio is too long. Maximum length is 512 characters."
+msgstr "약력이 너무 깁니다. 최대 길이는 512자입니다."
+
 #: src/components/AppSidebar.tsx:278
 #: src/routes/(root)/coc.tsx:53
 #: src/routes/(root)/coc.tsx:58
+#: src/routes/sign/up/[token].tsx:374
 msgid "Code of conduct"
 msgstr "행동 강령"
+
+#: src/routes/sign/up/[token].tsx:402
+msgid "Creating account..."
+msgstr ""
+
+#: src/routes/sign/up/[token].tsx:305
+msgid "Display name"
+msgstr "이름"
 
 #: src/routes/sign/index.tsx:230
 msgid "Do you need an account? Hackers' Pub is invite-only—please ask a friend to invite you."
 msgstr "계정이 필요하신가요? Hackers' Pub은 초대 전용입니다. 친구에게 초대를 요청해주세요."
+
+#: src/routes/sign/up/[token].tsx:260
+msgid "Email address"
+msgstr "이메일 주소"
 
 #: src/routes/sign/index.tsx:208
 msgid "Email or username"
@@ -146,6 +167,10 @@ msgstr "Hackers' Pub"
 msgid "Home"
 msgstr "홈"
 
+#: src/routes/sign/up/[token].tsx:376
+msgid "I have read and agree to the Code of conduct."
+msgstr "Hackers' Pub의 행동 강령을 읽고 동의합니다."
+
 #: src/components/ActorArticleList.tsx:78
 msgid "Load more articles"
 msgstr "게시글 더 불러오기"
@@ -180,6 +205,10 @@ msgstr "단문 불러오는 중…"
 msgid "Loading more posts…"
 msgstr "콘텐츠 불러오는 중…"
 
+#: src/routes/sign/up/[token].tsx:386
+msgid "Loading..."
+msgstr ""
+
 #: src/routes/(root)/markdown.tsx:53
 #: src/routes/(root)/markdown.tsx:58
 msgid "Markdown guide"
@@ -188,6 +217,14 @@ msgstr "Markdown 가이드"
 #: src/components/VisibilityTag.tsx:98
 msgid "Mentioned only"
 msgstr "언급된 사용자만"
+
+#: src/routes/sign/up/[token].tsx:126
+msgid "Name is required."
+msgstr "이름은 필수입니다."
+
+#: src/routes/sign/up/[token].tsx:129
+msgid "Name is too long. Maximum length is 50 characters."
+msgstr "이름이 너무 깁니다. 최대 길이는 50자입니다."
 
 #: src/components/ActorFollowerList.tsx:90
 msgid "No followers found"
@@ -235,6 +272,10 @@ msgstr "조용히 공개"
 msgid "Read full article"
 msgstr "게시글 전체 읽기"
 
+#: src/routes/sign/up/[token].tsx:380
+msgid "Read the full Code of conduct"
+msgstr ""
+
 #: src/components/ProfileTabs.tsx:51
 #: src/routes/(root)/[handle]/(profile)/shares.tsx:86
 msgid "Shares"
@@ -248,6 +289,11 @@ msgstr "로그인"
 #: src/components/AppSidebar.tsx:267
 msgid "Sign out"
 msgstr "로그아웃"
+
+#: src/routes/sign/up/[token].tsx:236
+#: src/routes/sign/up/[token].tsx:402
+msgid "Sign up"
+msgstr "가입"
 
 #: src/routes/sign/index.tsx:187
 msgid "Signing in Hackers' Pub"
@@ -265,6 +311,14 @@ msgstr "LLM 요약"
 msgid "Table of contents"
 msgstr "목차"
 
+#: src/routes/sign/up/[token].tsx:335
+msgid "Tell us about yourself..."
+msgstr ""
+
+#: src/routes/sign/up/[token].tsx:245
+msgid "The sign-up link is invalid. Please make sure you're using the correct link from the email you received."
+msgstr "가입 링크가 유효하지 않습니다. 이메일로 받은 링크를 사용하고 있는지 확인해주세요."
+
 #. placeholder {0}: "GITHUB_REPOSITORY"
 #. placeholder {1}: "AGPL-3.0"
 #: src/components/AppSidebar.tsx:282
@@ -280,11 +334,31 @@ msgstr "타임라인"
 msgid "Translated from {0}"
 msgstr "{0}에서 번역됨"
 
+#: src/routes/sign/up/[token].tsx:278
+msgid "Username"
+msgstr "아이디"
+
+#: src/routes/sign/up/[token].tsx:119
+msgid "Username can only contain lowercase letters, numbers, and underscores."
+msgstr "아이디는 영문 소문자, 숫자, 밑줄(_)만 사용할 수 있습니다."
+
+#: src/routes/sign/up/[token].tsx:113
+msgid "Username is required."
+msgstr "아이디는 필수입니다."
+
+#: src/routes/sign/up/[token].tsx:116
+msgid "Username is too long. Maximum length is 50 characters."
+msgstr "아이디가 너무 깁니다. 최대 길이는 50자입니다."
+
 #. placeholder {0}: "OWNER"
 #. placeholder {1}: "RELATIVE_TIME"
 #: src/components/ProfileCard.tsx:137
 msgid "Verified that this link is owned by {0} {1}"
 msgstr "{1}에 {0} 님이 이 링크의 소유자임이 확인됨"
+
+#: src/routes/sign/up/[token].tsx:240
+msgid "Verifying your invitation..."
+msgstr "초대장을 확인하고 있습니다..."
 
 #: src/components/VisibilityTag.tsx:79
 msgid "Visible only to the author's followers. The post will not appear in the public timeline, and only those who follow the author can see it."
@@ -302,6 +376,34 @@ msgstr "모든 사람이 볼 수 있지만 공개 타임라인에는 표시되�
 msgid "Visible to everyone, including non-registered users. The post will appear in the public timeline as well."
 msgstr "미가입 사용자를 포함해 모든 사람이 볼 수 있습니다. 공개 타임라인에도 표시됩니다."
 
+#: src/routes/sign/up/[token].tsx:250
+msgid "Welcome to Hackers' Pub! Please fill out the form below to complete your sign-up."
+msgstr "Hackers' Pub에 오신 것을 환영합니다! 가입을 완료하려면 아래 양식을 작성해주세요."
+
 #: src/components/AppSidebar.tsx:173
 msgid "Without shares"
 msgstr "공유 제외"
+
+#: src/routes/sign/up/[token].tsx:350
+msgid "You were invited by"
+msgstr "당신을 초대한 분"
+
+#: src/routes/sign/up/[token].tsx:367
+msgid "You'll automatically follow each other when you sign up."
+msgstr "가입 시 자동으로 서로 팔로우 하게 됩니다."
+
+#: src/routes/sign/up/[token].tsx:343
+msgid "Your bio will be displayed on your profile. You can use Markdown to format it. Maximum 512 characters."
+msgstr "약력은 프로필에 표시됩니다. Markdown을 사용할 수 있습니다. 최대 512자입니다."
+
+#: src/routes/sign/up/[token].tsx:269
+msgid "Your email address will be used to sign in to your account."
+msgstr "이메일 주소는 계정에 로그인할 때 사용됩니다."
+
+#: src/routes/sign/up/[token].tsx:321
+msgid "Your name will be displayed on your profile and in your posts."
+msgstr "이름은 프로필과 콘텐츠에 표시됩니다."
+
+#: src/routes/sign/up/[token].tsx:295
+msgid "Your username will be used to create your profile URL and your fediverse handle."
+msgstr "아이디는 프로필 URL과 연합우주(fediverse) 핸들로 사용됩니다."

--- a/web-next/src/locales/ko-KR/messages.po
+++ b/web-next/src/locales/ko-KR/messages.po
@@ -14,12 +14,12 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. placeholder {0}: actor().followersCount.totalCount
-#: src/components/ProfileCard.tsx:166
+#: src/components/ProfileCard.tsx:178
 msgid "{0, plural, one {# follower} other {# followers}}"
 msgstr "{0, plural, other {# 팔로워}}"
 
 #. placeholder {0}: actor().followeesCount.totalCount
-#: src/components/ProfileCard.tsx:151
+#: src/components/ProfileCard.tsx:163
 msgid "{0, plural, one {# following} other {# following}}"
 msgstr "{0, plural, other {# 팔로잉}}"
 
@@ -30,26 +30,26 @@ msgid "{0} shared {1}"
 msgstr "{0} 님이 {1}에 공유함"
 
 #. placeholder {0}: actor().rawName ?? actor().username
-#: src/routes/(root)/[handle]/(profile)/articles.tsx:72
-#: src/routes/(root)/[handle]/(profile)/articles.tsx:76
+#: src/routes/(root)/[handle]/(profile)/articles.tsx:73
+#: src/routes/(root)/[handle]/(profile)/articles.tsx:77
 msgid "{0}'s articles"
 msgstr "{0} 님의 게시글"
 
 #. placeholder {0}: account().name
-#: src/routes/(root)/[handle]/(profile)/followers.tsx:72
-#: src/routes/(root)/[handle]/(profile)/followers.tsx:75
+#: src/routes/(root)/[handle]/(profile)/followers.tsx:73
+#: src/routes/(root)/[handle]/(profile)/followers.tsx:76
 msgid "{0}'s followers"
 msgstr "{0} 님의 팔로워"
 
 #. placeholder {0}: actor().rawName ?? actor().username
-#: src/routes/(root)/[handle]/(profile)/notes.tsx:73
-#: src/routes/(root)/[handle]/(profile)/notes.tsx:77
+#: src/routes/(root)/[handle]/(profile)/notes.tsx:74
+#: src/routes/(root)/[handle]/(profile)/notes.tsx:78
 msgid "{0}'s notes"
 msgstr "{0} 님의 단문"
 
 #. placeholder {0}: actor().rawName ?? actor().username
-#: src/routes/(root)/[handle]/(profile)/shares.tsx:74
-#: src/routes/(root)/[handle]/(profile)/shares.tsx:78
+#: src/routes/(root)/[handle]/(profile)/shares.tsx:75
+#: src/routes/(root)/[handle]/(profile)/shares.tsx:79
 msgid "{0}'s shares"
 msgstr "{0} 님의 공유"
 
@@ -61,8 +61,8 @@ msgstr "로그인 링크가 이메일로 전송되었습니다. 받은 편지함
 msgid "Account"
 msgstr "계정"
 
-#: src/routes/(root)/[handle]/(profile)/articles.tsx:83
 #: src/components/ProfileTabs.tsx:48
+#: src/routes/(root)/[handle]/(profile)/articles.tsx:84
 msgid "Articles"
 msgstr "게시글"
 
@@ -70,9 +70,9 @@ msgstr "게시글"
 msgid "Articles only"
 msgstr "게시글만"
 
+#: src/components/AppSidebar.tsx:278
 #: src/routes/(root)/coc.tsx:53
 #: src/routes/(root)/coc.tsx:58
-#: src/components/AppSidebar.tsx:278
 msgid "Code of conduct"
 msgstr "행동 강령"
 
@@ -100,8 +100,8 @@ msgstr "팔로워 불러오기 실패. 클릭하여 재시도하세요"
 msgid "Failed to load more notes; click to retry"
 msgstr "단문 불러오기 실패. 클릭하여 재시도하세요"
 
-#: src/components/ActorSharedPostList.tsx:75
 #: src/components/ActorPostList.tsx:73
+#: src/components/ActorSharedPostList.tsx:75
 msgid "Failed to load more posts; click to retry"
 msgstr "콘텐츠 불러오기 실패. 클릭하여 재시도하세요"
 
@@ -118,7 +118,7 @@ msgstr "연합우주"
 msgid "Feed"
 msgstr "피드"
 
-#: src/routes/(root)/[handle]/(profile)/followers.tsx:81
+#: src/routes/(root)/[handle]/(profile)/followers.tsx:82
 msgid "Followers"
 msgstr "팔로워"
 
@@ -126,7 +126,7 @@ msgstr "팔로워"
 msgid "Followers only"
 msgstr "팔로워만"
 
-#: src/components/ProfileCard.tsx:176
+#: src/components/ProfileCard.tsx:188
 msgid "Following you"
 msgstr "당신을 팔로우합니다"
 
@@ -134,11 +134,11 @@ msgstr "당신을 팔로우합니다"
 msgid "GitHub repository"
 msgstr "GitHub 저장소"
 
-#: src/routes/sign.tsx:11
-#: src/routes/(root)/markdown.tsx:53
-#: src/routes/(root)/coc.tsx:53
 #: src/components/AppSidebar.tsx:91
 #: src/components/AppSidebar.tsx:135
+#: src/routes/(root)/coc.tsx:53
+#: src/routes/(root)/markdown.tsx:53
+#: src/routes/sign.tsx:11
 msgid "Hackers' Pub"
 msgstr "Hackers' Pub"
 
@@ -158,8 +158,8 @@ msgstr "팔로워 더 불러오기"
 msgid "Load more notes"
 msgstr "단문 더 불러오기"
 
-#: src/components/ActorSharedPostList.tsx:78
 #: src/components/ActorPostList.tsx:76
+#: src/components/ActorSharedPostList.tsx:78
 msgid "Load more posts"
 msgstr "콘텐츠 더 불러오기"
 
@@ -175,8 +175,8 @@ msgstr "팔로워 불러오는 중…"
 msgid "Loading more notes…"
 msgstr "단문 불러오는 중…"
 
-#: src/components/ActorSharedPostList.tsx:72
 #: src/components/ActorPostList.tsx:70
+#: src/components/ActorSharedPostList.tsx:72
 msgid "Loading more posts…"
 msgstr "콘텐츠 불러오는 중…"
 
@@ -201,8 +201,8 @@ msgstr "게시글이 없습니다"
 msgid "No notes found"
 msgstr "단문이 없습니다"
 
-#: src/components/ActorSharedPostList.tsx:85
 #: src/components/ActorPostList.tsx:83
+#: src/components/ActorSharedPostList.tsx:85
 msgid "No posts found"
 msgstr "콘텐츠가 없습니다"
 
@@ -214,8 +214,8 @@ msgstr "콘텐츠가 없습니다"
 msgid "No such account in Hackers' Pub—please try again."
 msgstr "Hackers' Pub에 해당 계정이 없습니다. 다시 시도해주세요."
 
-#: src/routes/(root)/[handle]/(profile)/notes.tsx:84
 #: src/components/ProfileTabs.tsx:41
+#: src/routes/(root)/[handle]/(profile)/notes.tsx:85
 msgid "Notes"
 msgstr "단문"
 
@@ -235,13 +235,13 @@ msgstr "조용히 공개"
 msgid "Read full article"
 msgstr "게시글 전체 읽기"
 
-#: src/routes/(root)/[handle]/(profile)/shares.tsx:85
 #: src/components/ProfileTabs.tsx:51
+#: src/routes/(root)/[handle]/(profile)/shares.tsx:86
 msgid "Shares"
 msgstr "공유"
 
-#: src/routes/sign/index.tsx:224
 #: src/components/AppSidebar.tsx:225
+#: src/routes/sign/index.tsx:224
 msgid "Sign in"
 msgstr "로그인"
 
@@ -282,7 +282,7 @@ msgstr "{0}에서 번역됨"
 
 #. placeholder {0}: "OWNER"
 #. placeholder {1}: "RELATIVE_TIME"
-#: src/components/ProfileCard.tsx:125
+#: src/components/ProfileCard.tsx:137
 msgid "Verified that this link is owned by {0} {1}"
 msgstr "{1}에 {0} 님이 이 링크의 소유자임이 확인됨"
 

--- a/web-next/src/locales/ko-KR/messages.po
+++ b/web-next/src/locales/ko-KR/messages.po
@@ -87,7 +87,7 @@ msgstr "행동 강령"
 
 #: src/routes/sign/up/[token].tsx:402
 msgid "Creating account..."
-msgstr ""
+msgstr "계정을 생성하는 중..."
 
 #: src/routes/sign/up/[token].tsx:305
 msgid "Display name"
@@ -207,7 +207,7 @@ msgstr "콘텐츠 불러오는 중…"
 
 #: src/routes/sign/up/[token].tsx:386
 msgid "Loading..."
-msgstr ""
+msgstr "로딩 중…"
 
 #: src/routes/(root)/markdown.tsx:53
 #: src/routes/(root)/markdown.tsx:58
@@ -274,7 +274,7 @@ msgstr "게시글 전체 읽기"
 
 #: src/routes/sign/up/[token].tsx:380
 msgid "Read the full Code of conduct"
-msgstr ""
+msgstr "행동 강령 전문을 읽으세요."
 
 #: src/components/ProfileTabs.tsx:51
 #: src/routes/(root)/[handle]/(profile)/shares.tsx:86
@@ -313,7 +313,7 @@ msgstr "목차"
 
 #: src/routes/sign/up/[token].tsx:335
 msgid "Tell us about yourself..."
-msgstr ""
+msgstr "당신에 대해서 이야기 해주세요…"
 
 #: src/routes/sign/up/[token].tsx:245
 msgid "The sign-up link is invalid. Please make sure you're using the correct link from the email you received."

--- a/web-next/src/locales/ko-KR/messages.po
+++ b/web-next/src/locales/ko-KR/messages.po
@@ -61,6 +61,10 @@ msgstr "로그인 링크가 이메일로 전송되었습니다. 받은 편지함
 msgid "Account"
 msgstr "계정"
 
+#: src/routes/sign/up/[token].tsx:307
+msgid "An error occurred during signup. Please try again."
+msgstr "가입중에 오류가 발생했습니다. 다시 시도해 주시기 바랍니다."
+
 #: src/components/ProfileTabs.tsx:48
 #: src/routes/(root)/[handle]/(profile)/articles.tsx:84
 msgid "Articles"
@@ -70,26 +74,26 @@ msgstr "게시글"
 msgid "Articles only"
 msgstr "게시글만"
 
-#: src/routes/sign/up/[token].tsx:379
+#: src/routes/sign/up/[token].tsx:423
 msgid "Bio"
 msgstr "약력"
 
-#: src/routes/sign/up/[token].tsx:160
+#: src/routes/sign/up/[token].tsx:174
 msgid "Bio is too long. Maximum length is 512 characters."
 msgstr "약력이 너무 깁니다. 최대 길이는 512자입니다."
 
 #: src/components/AppSidebar.tsx:278
 #: src/routes/(root)/coc.tsx:53
 #: src/routes/(root)/coc.tsx:58
-#: src/routes/sign/up/[token].tsx:422
+#: src/routes/sign/up/[token].tsx:470
 msgid "Code of conduct"
 msgstr "행동 강령"
 
-#: src/routes/sign/up/[token].tsx:450
+#: src/routes/sign/up/[token].tsx:498
 msgid "Creating account..."
 msgstr "계정을 생성하는 중..."
 
-#: src/routes/sign/up/[token].tsx:353
+#: src/routes/sign/up/[token].tsx:397
 msgid "Display name"
 msgstr "이름"
 
@@ -97,7 +101,7 @@ msgstr "이름"
 msgid "Do you need an account? Hackers' Pub is invite-only—please ask a friend to invite you."
 msgstr "계정이 필요하신가요? Hackers' Pub은 초대 전용입니다. 친구에게 초대를 요청해주세요."
 
-#: src/routes/sign/up/[token].tsx:308
+#: src/routes/sign/up/[token].tsx:350
 msgid "Email address"
 msgstr "이메일 주소"
 
@@ -108,6 +112,10 @@ msgstr "이메일 또는 아이디"
 #: src/routes/sign/index.tsx:193
 msgid "Enter your email or username below to sign in."
 msgstr "로그인하려면 아래에 이메일 또는 아이디를 입력해주세요."
+
+#: src/routes/sign/up/[token].tsx:304
+msgid "Error"
+msgstr "오류"
 
 #: src/components/ActorArticleList.tsx:75
 msgid "Failed to load more articles; click to retry"
@@ -167,7 +175,7 @@ msgstr "Hackers' Pub"
 msgid "Home"
 msgstr "홈"
 
-#: src/routes/sign/up/[token].tsx:424
+#: src/routes/sign/up/[token].tsx:472
 msgid "I have read and agree to the Code of conduct."
 msgstr "Hackers' Pub의 행동 강령을 읽고 동의합니다."
 
@@ -205,7 +213,7 @@ msgstr "단문 불러오는 중…"
 msgid "Loading more posts…"
 msgstr "콘텐츠 불러오는 중…"
 
-#: src/routes/sign/up/[token].tsx:434
+#: src/routes/sign/up/[token].tsx:482
 msgid "Loading..."
 msgstr "로딩 중…"
 
@@ -218,11 +226,11 @@ msgstr "Markdown 가이드"
 msgid "Mentioned only"
 msgstr "언급된 사용자만"
 
-#: src/routes/sign/up/[token].tsx:147
+#: src/routes/sign/up/[token].tsx:161
 msgid "Name is required."
 msgstr "이름은 필수입니다."
 
-#: src/routes/sign/up/[token].tsx:149
+#: src/routes/sign/up/[token].tsx:163
 msgid "Name is too long. Maximum length is 50 characters."
 msgstr "이름이 너무 깁니다. 최대 길이는 50자입니다."
 
@@ -272,7 +280,7 @@ msgstr "조용히 공개"
 msgid "Read full article"
 msgstr "게시글 전체 읽기"
 
-#: src/routes/sign/up/[token].tsx:428
+#: src/routes/sign/up/[token].tsx:476
 msgid "Read the full Code of conduct"
 msgstr "행동 강령 전문을 읽으세요."
 
@@ -290,8 +298,8 @@ msgstr "로그인"
 msgid "Sign out"
 msgstr "로그아웃"
 
-#: src/routes/sign/up/[token].tsx:284
-#: src/routes/sign/up/[token].tsx:450
+#: src/routes/sign/up/[token].tsx:326
+#: src/routes/sign/up/[token].tsx:498
 msgid "Sign up"
 msgstr "가입"
 
@@ -311,11 +319,11 @@ msgstr "LLM 요약"
 msgid "Table of contents"
 msgstr "목차"
 
-#: src/routes/sign/up/[token].tsx:383
+#: src/routes/sign/up/[token].tsx:427
 msgid "Tell us about yourself..."
 msgstr "당신에 대해서 이야기 해주세요…"
 
-#: src/routes/sign/up/[token].tsx:293
+#: src/routes/sign/up/[token].tsx:335
 msgid "The sign-up link is invalid. Please make sure you're using the correct link from the email you received."
 msgstr "가입 링크가 유효하지 않습니다. 이메일로 받은 링크를 사용하고 있는지 확인해주세요."
 
@@ -334,23 +342,23 @@ msgstr "타임라인"
 msgid "Translated from {0}"
 msgstr "{0}에서 번역됨"
 
-#: src/routes/sign/up/[token].tsx:326
+#: src/routes/sign/up/[token].tsx:370
 msgid "Username"
 msgstr "아이디"
 
-#: src/routes/sign/up/[token].tsx:134
+#: src/routes/sign/up/[token].tsx:148
 msgid "Username can only contain lowercase letters, numbers, and underscores."
 msgstr "아이디는 영문 소문자, 숫자, 밑줄(_)만 사용할 수 있습니다."
 
-#: src/routes/sign/up/[token].tsx:136
+#: src/routes/sign/up/[token].tsx:150
 msgid "Username is already taken."
 msgstr "다른 사용자가 사용하고 있는 아이디입니다."
 
-#: src/routes/sign/up/[token].tsx:130
+#: src/routes/sign/up/[token].tsx:144
 msgid "Username is required."
 msgstr "아이디는 필수입니다."
 
-#: src/routes/sign/up/[token].tsx:132
+#: src/routes/sign/up/[token].tsx:146
 msgid "Username is too long. Maximum length is 15 characters."
 msgstr "아이디가 너무 깁니다. 최대 길이는 15자입니다."
 
@@ -360,7 +368,7 @@ msgstr "아이디가 너무 깁니다. 최대 길이는 15자입니다."
 msgid "Verified that this link is owned by {0} {1}"
 msgstr "{1}에 {0} 님이 이 링크의 소유자임이 확인됨"
 
-#: src/routes/sign/up/[token].tsx:288
+#: src/routes/sign/up/[token].tsx:330
 msgid "Verifying your invitation..."
 msgstr "초대장을 확인하고 있습니다..."
 
@@ -380,7 +388,7 @@ msgstr "모든 사람이 볼 수 있지만 공개 타임라인에는 표시되�
 msgid "Visible to everyone, including non-registered users. The post will appear in the public timeline as well."
 msgstr "미가입 사용자를 포함해 모든 사람이 볼 수 있습니다. 공개 타임라인에도 표시됩니다."
 
-#: src/routes/sign/up/[token].tsx:298
+#: src/routes/sign/up/[token].tsx:340
 msgid "Welcome to Hackers' Pub! Please fill out the form below to complete your sign-up."
 msgstr "Hackers' Pub에 오신 것을 환영합니다! 가입을 완료하려면 아래 양식을 작성해주세요."
 
@@ -388,26 +396,26 @@ msgstr "Hackers' Pub에 오신 것을 환영합니다! 가입을 완료하려면
 msgid "Without shares"
 msgstr "공유 제외"
 
-#: src/routes/sign/up/[token].tsx:398
+#: src/routes/sign/up/[token].tsx:446
 msgid "You were invited by"
 msgstr "당신을 초대한 분"
 
-#: src/routes/sign/up/[token].tsx:415
+#: src/routes/sign/up/[token].tsx:463
 msgid "You'll automatically follow each other when you sign up."
 msgstr "가입 시 자동으로 서로 팔로우 하게 됩니다."
 
-#: src/routes/sign/up/[token].tsx:391
+#: src/routes/sign/up/[token].tsx:439
 msgid "Your bio will be displayed on your profile. You can use Markdown to format it. Maximum 512 characters."
 msgstr "약력은 프로필에 표시됩니다. Markdown을 사용할 수 있습니다. 최대 512자입니다."
 
-#: src/routes/sign/up/[token].tsx:317
+#: src/routes/sign/up/[token].tsx:359
 msgid "Your email address will be used to sign in to your account."
 msgstr "이메일 주소는 계정에 로그인할 때 사용됩니다."
 
-#: src/routes/sign/up/[token].tsx:369
+#: src/routes/sign/up/[token].tsx:413
 msgid "Your name will be displayed on your profile and in your posts."
 msgstr "이름은 프로필과 콘텐츠에 표시됩니다."
 
-#: src/routes/sign/up/[token].tsx:343
+#: src/routes/sign/up/[token].tsx:387
 msgid "Your username will be used to create your profile URL and your fediverse handle."
 msgstr "아이디는 프로필 URL과 연합우주(fediverse) 핸들로 사용됩니다."

--- a/web-next/src/locales/ko-KR/messages.po
+++ b/web-next/src/locales/ko-KR/messages.po
@@ -70,26 +70,26 @@ msgstr "게시글"
 msgid "Articles only"
 msgstr "게시글만"
 
-#: src/routes/sign/up/[token].tsx:331
+#: src/routes/sign/up/[token].tsx:379
 msgid "Bio"
 msgstr "약력"
 
-#: src/routes/sign/up/[token].tsx:136
+#: src/routes/sign/up/[token].tsx:160
 msgid "Bio is too long. Maximum length is 512 characters."
 msgstr "약력이 너무 깁니다. 최대 길이는 512자입니다."
 
 #: src/components/AppSidebar.tsx:278
 #: src/routes/(root)/coc.tsx:53
 #: src/routes/(root)/coc.tsx:58
-#: src/routes/sign/up/[token].tsx:374
+#: src/routes/sign/up/[token].tsx:422
 msgid "Code of conduct"
 msgstr "행동 강령"
 
-#: src/routes/sign/up/[token].tsx:402
+#: src/routes/sign/up/[token].tsx:450
 msgid "Creating account..."
 msgstr "계정을 생성하는 중..."
 
-#: src/routes/sign/up/[token].tsx:305
+#: src/routes/sign/up/[token].tsx:353
 msgid "Display name"
 msgstr "이름"
 
@@ -97,7 +97,7 @@ msgstr "이름"
 msgid "Do you need an account? Hackers' Pub is invite-only—please ask a friend to invite you."
 msgstr "계정이 필요하신가요? Hackers' Pub은 초대 전용입니다. 친구에게 초대를 요청해주세요."
 
-#: src/routes/sign/up/[token].tsx:260
+#: src/routes/sign/up/[token].tsx:308
 msgid "Email address"
 msgstr "이메일 주소"
 
@@ -167,7 +167,7 @@ msgstr "Hackers' Pub"
 msgid "Home"
 msgstr "홈"
 
-#: src/routes/sign/up/[token].tsx:376
+#: src/routes/sign/up/[token].tsx:424
 msgid "I have read and agree to the Code of conduct."
 msgstr "Hackers' Pub의 행동 강령을 읽고 동의합니다."
 
@@ -205,7 +205,7 @@ msgstr "단문 불러오는 중…"
 msgid "Loading more posts…"
 msgstr "콘텐츠 불러오는 중…"
 
-#: src/routes/sign/up/[token].tsx:386
+#: src/routes/sign/up/[token].tsx:434
 msgid "Loading..."
 msgstr "로딩 중…"
 
@@ -218,11 +218,11 @@ msgstr "Markdown 가이드"
 msgid "Mentioned only"
 msgstr "언급된 사용자만"
 
-#: src/routes/sign/up/[token].tsx:126
+#: src/routes/sign/up/[token].tsx:147
 msgid "Name is required."
 msgstr "이름은 필수입니다."
 
-#: src/routes/sign/up/[token].tsx:129
+#: src/routes/sign/up/[token].tsx:149
 msgid "Name is too long. Maximum length is 50 characters."
 msgstr "이름이 너무 깁니다. 최대 길이는 50자입니다."
 
@@ -272,7 +272,7 @@ msgstr "조용히 공개"
 msgid "Read full article"
 msgstr "게시글 전체 읽기"
 
-#: src/routes/sign/up/[token].tsx:380
+#: src/routes/sign/up/[token].tsx:428
 msgid "Read the full Code of conduct"
 msgstr "행동 강령 전문을 읽으세요."
 
@@ -290,8 +290,8 @@ msgstr "로그인"
 msgid "Sign out"
 msgstr "로그아웃"
 
-#: src/routes/sign/up/[token].tsx:236
-#: src/routes/sign/up/[token].tsx:402
+#: src/routes/sign/up/[token].tsx:284
+#: src/routes/sign/up/[token].tsx:450
 msgid "Sign up"
 msgstr "가입"
 
@@ -311,11 +311,11 @@ msgstr "LLM 요약"
 msgid "Table of contents"
 msgstr "목차"
 
-#: src/routes/sign/up/[token].tsx:335
+#: src/routes/sign/up/[token].tsx:383
 msgid "Tell us about yourself..."
 msgstr "당신에 대해서 이야기 해주세요…"
 
-#: src/routes/sign/up/[token].tsx:245
+#: src/routes/sign/up/[token].tsx:293
 msgid "The sign-up link is invalid. Please make sure you're using the correct link from the email you received."
 msgstr "가입 링크가 유효하지 않습니다. 이메일로 받은 링크를 사용하고 있는지 확인해주세요."
 
@@ -334,21 +334,25 @@ msgstr "타임라인"
 msgid "Translated from {0}"
 msgstr "{0}에서 번역됨"
 
-#: src/routes/sign/up/[token].tsx:278
+#: src/routes/sign/up/[token].tsx:326
 msgid "Username"
 msgstr "아이디"
 
-#: src/routes/sign/up/[token].tsx:119
+#: src/routes/sign/up/[token].tsx:134
 msgid "Username can only contain lowercase letters, numbers, and underscores."
 msgstr "아이디는 영문 소문자, 숫자, 밑줄(_)만 사용할 수 있습니다."
 
-#: src/routes/sign/up/[token].tsx:113
+#: src/routes/sign/up/[token].tsx:136
+msgid "Username is already taken."
+msgstr "다른 사용자가 사용하고 있는 아이디입니다."
+
+#: src/routes/sign/up/[token].tsx:130
 msgid "Username is required."
 msgstr "아이디는 필수입니다."
 
-#: src/routes/sign/up/[token].tsx:116
-msgid "Username is too long. Maximum length is 50 characters."
-msgstr "아이디가 너무 깁니다. 최대 길이는 50자입니다."
+#: src/routes/sign/up/[token].tsx:132
+msgid "Username is too long. Maximum length is 15 characters."
+msgstr "아이디가 너무 깁니다. 최대 길이는 15자입니다."
 
 #. placeholder {0}: "OWNER"
 #. placeholder {1}: "RELATIVE_TIME"
@@ -356,7 +360,7 @@ msgstr "아이디가 너무 깁니다. 최대 길이는 50자입니다."
 msgid "Verified that this link is owned by {0} {1}"
 msgstr "{1}에 {0} 님이 이 링크의 소유자임이 확인됨"
 
-#: src/routes/sign/up/[token].tsx:240
+#: src/routes/sign/up/[token].tsx:288
 msgid "Verifying your invitation..."
 msgstr "초대장을 확인하고 있습니다..."
 
@@ -376,7 +380,7 @@ msgstr "모든 사람이 볼 수 있지만 공개 타임라인에는 표시되�
 msgid "Visible to everyone, including non-registered users. The post will appear in the public timeline as well."
 msgstr "미가입 사용자를 포함해 모든 사람이 볼 수 있습니다. 공개 타임라인에도 표시됩니다."
 
-#: src/routes/sign/up/[token].tsx:250
+#: src/routes/sign/up/[token].tsx:298
 msgid "Welcome to Hackers' Pub! Please fill out the form below to complete your sign-up."
 msgstr "Hackers' Pub에 오신 것을 환영합니다! 가입을 완료하려면 아래 양식을 작성해주세요."
 
@@ -384,26 +388,26 @@ msgstr "Hackers' Pub에 오신 것을 환영합니다! 가입을 완료하려면
 msgid "Without shares"
 msgstr "공유 제외"
 
-#: src/routes/sign/up/[token].tsx:350
+#: src/routes/sign/up/[token].tsx:398
 msgid "You were invited by"
 msgstr "당신을 초대한 분"
 
-#: src/routes/sign/up/[token].tsx:367
+#: src/routes/sign/up/[token].tsx:415
 msgid "You'll automatically follow each other when you sign up."
 msgstr "가입 시 자동으로 서로 팔로우 하게 됩니다."
 
-#: src/routes/sign/up/[token].tsx:343
+#: src/routes/sign/up/[token].tsx:391
 msgid "Your bio will be displayed on your profile. You can use Markdown to format it. Maximum 512 characters."
 msgstr "약력은 프로필에 표시됩니다. Markdown을 사용할 수 있습니다. 최대 512자입니다."
 
-#: src/routes/sign/up/[token].tsx:269
+#: src/routes/sign/up/[token].tsx:317
 msgid "Your email address will be used to sign in to your account."
 msgstr "이메일 주소는 계정에 로그인할 때 사용됩니다."
 
-#: src/routes/sign/up/[token].tsx:321
+#: src/routes/sign/up/[token].tsx:369
 msgid "Your name will be displayed on your profile and in your posts."
 msgstr "이름은 프로필과 콘텐츠에 표시됩니다."
 
-#: src/routes/sign/up/[token].tsx:295
+#: src/routes/sign/up/[token].tsx:343
 msgid "Your username will be used to create your profile URL and your fediverse handle."
 msgstr "아이디는 프로필 URL과 연합우주(fediverse) 핸들로 사용됩니다."

--- a/web-next/src/locales/zh-CN/messages.po
+++ b/web-next/src/locales/zh-CN/messages.po
@@ -87,7 +87,7 @@ msgstr "行为准则"
 
 #: src/routes/sign/up/[token].tsx:402
 msgid "Creating account..."
-msgstr ""
+msgstr "正在创建账户..."
 
 #: src/routes/sign/up/[token].tsx:305
 msgid "Display name"
@@ -207,7 +207,7 @@ msgstr "加载更多内容中…"
 
 #: src/routes/sign/up/[token].tsx:386
 msgid "Loading..."
-msgstr ""
+msgstr "正在加载..."
 
 #: src/routes/(root)/markdown.tsx:53
 #: src/routes/(root)/markdown.tsx:58
@@ -274,7 +274,7 @@ msgstr "阅读完整文章"
 
 #: src/routes/sign/up/[token].tsx:380
 msgid "Read the full Code of conduct"
-msgstr ""
+msgstr "阅读完整的行为准则"
 
 #: src/components/ProfileTabs.tsx:51
 #: src/routes/(root)/[handle]/(profile)/shares.tsx:86
@@ -313,7 +313,7 @@ msgstr "目录"
 
 #: src/routes/sign/up/[token].tsx:335
 msgid "Tell us about yourself..."
-msgstr ""
+msgstr "请告诉我们关于您自己的信息..."
 
 #: src/routes/sign/up/[token].tsx:245
 msgid "The sign-up link is invalid. Please make sure you're using the correct link from the email you received."

--- a/web-next/src/locales/zh-CN/messages.po
+++ b/web-next/src/locales/zh-CN/messages.po
@@ -14,12 +14,12 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. placeholder {0}: actor().followersCount.totalCount
-#: src/components/ProfileCard.tsx:166
+#: src/components/ProfileCard.tsx:178
 msgid "{0, plural, one {# follower} other {# followers}}"
 msgstr "{0, plural, other {被 # 人关注}}"
 
 #. placeholder {0}: actor().followeesCount.totalCount
-#: src/components/ProfileCard.tsx:151
+#: src/components/ProfileCard.tsx:163
 msgid "{0, plural, one {# following} other {# following}}"
 msgstr "{0, plural, other {关注 # 人}}"
 
@@ -30,26 +30,26 @@ msgid "{0} shared {1}"
 msgstr "{0}在{1}转帖了"
 
 #. placeholder {0}: actor().rawName ?? actor().username
-#: src/routes/(root)/[handle]/(profile)/articles.tsx:72
-#: src/routes/(root)/[handle]/(profile)/articles.tsx:76
+#: src/routes/(root)/[handle]/(profile)/articles.tsx:73
+#: src/routes/(root)/[handle]/(profile)/articles.tsx:77
 msgid "{0}'s articles"
 msgstr "{0}的文章"
 
 #. placeholder {0}: account().name
-#: src/routes/(root)/[handle]/(profile)/followers.tsx:72
-#: src/routes/(root)/[handle]/(profile)/followers.tsx:75
+#: src/routes/(root)/[handle]/(profile)/followers.tsx:73
+#: src/routes/(root)/[handle]/(profile)/followers.tsx:76
 msgid "{0}'s followers"
 msgstr "{0}的粉丝"
 
 #. placeholder {0}: actor().rawName ?? actor().username
-#: src/routes/(root)/[handle]/(profile)/notes.tsx:73
-#: src/routes/(root)/[handle]/(profile)/notes.tsx:77
+#: src/routes/(root)/[handle]/(profile)/notes.tsx:74
+#: src/routes/(root)/[handle]/(profile)/notes.tsx:78
 msgid "{0}'s notes"
 msgstr "{0}的帖子"
 
 #. placeholder {0}: actor().rawName ?? actor().username
-#: src/routes/(root)/[handle]/(profile)/shares.tsx:74
-#: src/routes/(root)/[handle]/(profile)/shares.tsx:78
+#: src/routes/(root)/[handle]/(profile)/shares.tsx:75
+#: src/routes/(root)/[handle]/(profile)/shares.tsx:79
 msgid "{0}'s shares"
 msgstr "{0}的转帖"
 
@@ -61,8 +61,8 @@ msgstr "登录链接已发送至您的邮箱。请检查收件箱。（或垃圾
 msgid "Account"
 msgstr "账户"
 
-#: src/routes/(root)/[handle]/(profile)/articles.tsx:83
 #: src/components/ProfileTabs.tsx:48
+#: src/routes/(root)/[handle]/(profile)/articles.tsx:84
 msgid "Articles"
 msgstr "文章"
 
@@ -70,9 +70,9 @@ msgstr "文章"
 msgid "Articles only"
 msgstr "仅文章"
 
+#: src/components/AppSidebar.tsx:278
 #: src/routes/(root)/coc.tsx:53
 #: src/routes/(root)/coc.tsx:58
-#: src/components/AppSidebar.tsx:278
 msgid "Code of conduct"
 msgstr "行为准则"
 
@@ -100,8 +100,8 @@ msgstr "加载更多粉丝失败，点击重试"
 msgid "Failed to load more notes; click to retry"
 msgstr "加载更多帖子失败，点击重试"
 
-#: src/components/ActorSharedPostList.tsx:75
 #: src/components/ActorPostList.tsx:73
+#: src/components/ActorSharedPostList.tsx:75
 msgid "Failed to load more posts; click to retry"
 msgstr "加载更多内容失败，点击重试"
 
@@ -118,7 +118,7 @@ msgstr "联邦宇宙"
 msgid "Feed"
 msgstr "订阅流"
 
-#: src/routes/(root)/[handle]/(profile)/followers.tsx:81
+#: src/routes/(root)/[handle]/(profile)/followers.tsx:82
 msgid "Followers"
 msgstr "粉丝"
 
@@ -126,7 +126,7 @@ msgstr "粉丝"
 msgid "Followers only"
 msgstr "只粉丝可见"
 
-#: src/components/ProfileCard.tsx:176
+#: src/components/ProfileCard.tsx:188
 msgid "Following you"
 msgstr "关注了你"
 
@@ -134,11 +134,11 @@ msgstr "关注了你"
 msgid "GitHub repository"
 msgstr "GitHub 仓库"
 
-#: src/routes/sign.tsx:11
-#: src/routes/(root)/markdown.tsx:53
-#: src/routes/(root)/coc.tsx:53
 #: src/components/AppSidebar.tsx:91
 #: src/components/AppSidebar.tsx:135
+#: src/routes/(root)/coc.tsx:53
+#: src/routes/(root)/markdown.tsx:53
+#: src/routes/sign.tsx:11
 msgid "Hackers' Pub"
 msgstr "Hackers' Pub"
 
@@ -158,8 +158,8 @@ msgstr "加载更多粉丝"
 msgid "Load more notes"
 msgstr "加载更多帖子"
 
-#: src/components/ActorSharedPostList.tsx:78
 #: src/components/ActorPostList.tsx:76
+#: src/components/ActorSharedPostList.tsx:78
 msgid "Load more posts"
 msgstr "加载更多内容"
 
@@ -175,8 +175,8 @@ msgstr "加载更多粉丝中…"
 msgid "Loading more notes…"
 msgstr "加载更多帖子中…"
 
-#: src/components/ActorSharedPostList.tsx:72
 #: src/components/ActorPostList.tsx:70
+#: src/components/ActorSharedPostList.tsx:72
 msgid "Loading more posts…"
 msgstr "加载更多内容中…"
 
@@ -201,8 +201,8 @@ msgstr "未找到文章"
 msgid "No notes found"
 msgstr "未找到帖子"
 
-#: src/components/ActorSharedPostList.tsx:85
 #: src/components/ActorPostList.tsx:83
+#: src/components/ActorSharedPostList.tsx:85
 msgid "No posts found"
 msgstr "未找到内容"
 
@@ -214,8 +214,8 @@ msgstr "未找到内容"
 msgid "No such account in Hackers' Pub—please try again."
 msgstr "Hackers' Pub 中无此账户，请重试。"
 
-#: src/routes/(root)/[handle]/(profile)/notes.tsx:84
 #: src/components/ProfileTabs.tsx:41
+#: src/routes/(root)/[handle]/(profile)/notes.tsx:85
 msgid "Notes"
 msgstr "帖子"
 
@@ -235,13 +235,13 @@ msgstr "悄悄公开"
 msgid "Read full article"
 msgstr "阅读完整文章"
 
-#: src/routes/(root)/[handle]/(profile)/shares.tsx:85
 #: src/components/ProfileTabs.tsx:51
+#: src/routes/(root)/[handle]/(profile)/shares.tsx:86
 msgid "Shares"
 msgstr "转帖"
 
-#: src/routes/sign/index.tsx:224
 #: src/components/AppSidebar.tsx:225
+#: src/routes/sign/index.tsx:224
 msgid "Sign in"
 msgstr "登录"
 
@@ -282,7 +282,7 @@ msgstr "翻译自{0}"
 
 #. placeholder {0}: "OWNER"
 #. placeholder {1}: "RELATIVE_TIME"
-#: src/components/ProfileCard.tsx:125
+#: src/components/ProfileCard.tsx:137
 msgid "Verified that this link is owned by {0} {1}"
 msgstr "已于{1}验证此链接归{0}所有"
 

--- a/web-next/src/locales/zh-CN/messages.po
+++ b/web-next/src/locales/zh-CN/messages.po
@@ -70,26 +70,26 @@ msgstr "文章"
 msgid "Articles only"
 msgstr "仅文章"
 
-#: src/routes/sign/up/[token].tsx:331
+#: src/routes/sign/up/[token].tsx:379
 msgid "Bio"
 msgstr "个人简介"
 
-#: src/routes/sign/up/[token].tsx:136
+#: src/routes/sign/up/[token].tsx:160
 msgid "Bio is too long. Maximum length is 512 characters."
 msgstr "个人简介太长。不能长于 512 字符。"
 
 #: src/components/AppSidebar.tsx:278
 #: src/routes/(root)/coc.tsx:53
 #: src/routes/(root)/coc.tsx:58
-#: src/routes/sign/up/[token].tsx:374
+#: src/routes/sign/up/[token].tsx:422
 msgid "Code of conduct"
 msgstr "行为准则"
 
-#: src/routes/sign/up/[token].tsx:402
+#: src/routes/sign/up/[token].tsx:450
 msgid "Creating account..."
 msgstr "正在创建账户..."
 
-#: src/routes/sign/up/[token].tsx:305
+#: src/routes/sign/up/[token].tsx:353
 msgid "Display name"
 msgstr "昵称"
 
@@ -97,7 +97,7 @@ msgstr "昵称"
 msgid "Do you need an account? Hackers' Pub is invite-only—please ask a friend to invite you."
 msgstr "需要创建账户吗？Hackers' Pub 仅限邀请，请联系朋友邀请您。"
 
-#: src/routes/sign/up/[token].tsx:260
+#: src/routes/sign/up/[token].tsx:308
 msgid "Email address"
 msgstr "电子邮件地址"
 
@@ -167,7 +167,7 @@ msgstr "Hackers' Pub"
 msgid "Home"
 msgstr "首页"
 
-#: src/routes/sign/up/[token].tsx:376
+#: src/routes/sign/up/[token].tsx:424
 msgid "I have read and agree to the Code of conduct."
 msgstr "我同意 Hackers' Pub 的行为准则。"
 
@@ -205,7 +205,7 @@ msgstr "加载更多帖子中…"
 msgid "Loading more posts…"
 msgstr "加载更多内容中…"
 
-#: src/routes/sign/up/[token].tsx:386
+#: src/routes/sign/up/[token].tsx:434
 msgid "Loading..."
 msgstr "正在加载..."
 
@@ -218,11 +218,11 @@ msgstr "Markdown 指南"
 msgid "Mentioned only"
 msgstr "只提及用户可见"
 
-#: src/routes/sign/up/[token].tsx:126
+#: src/routes/sign/up/[token].tsx:147
 msgid "Name is required."
 msgstr "需要昵称"
 
-#: src/routes/sign/up/[token].tsx:129
+#: src/routes/sign/up/[token].tsx:149
 msgid "Name is too long. Maximum length is 50 characters."
 msgstr "用户名太长。不能长于 50 字符。"
 
@@ -272,7 +272,7 @@ msgstr "悄悄公开"
 msgid "Read full article"
 msgstr "阅读完整文章"
 
-#: src/routes/sign/up/[token].tsx:380
+#: src/routes/sign/up/[token].tsx:428
 msgid "Read the full Code of conduct"
 msgstr "阅读完整的行为准则"
 
@@ -290,8 +290,8 @@ msgstr "登录"
 msgid "Sign out"
 msgstr "登出"
 
-#: src/routes/sign/up/[token].tsx:236
-#: src/routes/sign/up/[token].tsx:402
+#: src/routes/sign/up/[token].tsx:284
+#: src/routes/sign/up/[token].tsx:450
 msgid "Sign up"
 msgstr "注册"
 
@@ -311,11 +311,11 @@ msgstr "由 AI 生成的摘要"
 msgid "Table of contents"
 msgstr "目录"
 
-#: src/routes/sign/up/[token].tsx:335
+#: src/routes/sign/up/[token].tsx:383
 msgid "Tell us about yourself..."
 msgstr "请告诉我们关于您自己的信息..."
 
-#: src/routes/sign/up/[token].tsx:245
+#: src/routes/sign/up/[token].tsx:293
 msgid "The sign-up link is invalid. Please make sure you're using the correct link from the email you received."
 msgstr "注册链接无效。请确保你使用的是你收到的正确邮件链接。"
 
@@ -334,21 +334,25 @@ msgstr "时间线"
 msgid "Translated from {0}"
 msgstr "翻译自{0}"
 
-#: src/routes/sign/up/[token].tsx:278
+#: src/routes/sign/up/[token].tsx:326
 msgid "Username"
 msgstr "用户名"
 
-#: src/routes/sign/up/[token].tsx:119
+#: src/routes/sign/up/[token].tsx:134
 msgid "Username can only contain lowercase letters, numbers, and underscores."
 msgstr "用户名只能包含小写字母、数字以及下划线。"
 
-#: src/routes/sign/up/[token].tsx:113
+#: src/routes/sign/up/[token].tsx:136
+msgid "Username is already taken."
+msgstr "用户名已被占用。"
+
+#: src/routes/sign/up/[token].tsx:130
 msgid "Username is required."
 msgstr "需要用户名"
 
-#: src/routes/sign/up/[token].tsx:116
-msgid "Username is too long. Maximum length is 50 characters."
-msgstr "用户名太长。不能长于 50 字符。"
+#: src/routes/sign/up/[token].tsx:132
+msgid "Username is too long. Maximum length is 15 characters."
+msgstr "用户名太长。不能长于 15 字符。"
 
 #. placeholder {0}: "OWNER"
 #. placeholder {1}: "RELATIVE_TIME"
@@ -356,7 +360,7 @@ msgstr "用户名太长。不能长于 50 字符。"
 msgid "Verified that this link is owned by {0} {1}"
 msgstr "已于{1}验证此链接归{0}所有"
 
-#: src/routes/sign/up/[token].tsx:240
+#: src/routes/sign/up/[token].tsx:288
 msgid "Verifying your invitation..."
 msgstr "正在验证您的邀请..."
 
@@ -376,7 +380,7 @@ msgstr "所有人都可以看到，但不会出现在公共时间线中。只有
 msgid "Visible to everyone, including non-registered users. The post will appear in the public timeline as well."
 msgstr "包括未注册用户在内的所有人都可以看到。内容也会出现在公共时间线中。"
 
-#: src/routes/sign/up/[token].tsx:250
+#: src/routes/sign/up/[token].tsx:298
 msgid "Welcome to Hackers' Pub! Please fill out the form below to complete your sign-up."
 msgstr "欢迎来到 Hackers' Pub！请填写以下表单完成注册。"
 
@@ -384,26 +388,26 @@ msgstr "欢迎来到 Hackers' Pub！请填写以下表单完成注册。"
 msgid "Without shares"
 msgstr "不含转帖"
 
-#: src/routes/sign/up/[token].tsx:350
+#: src/routes/sign/up/[token].tsx:398
 msgid "You were invited by"
 msgstr "您被以下用户邀请"
 
-#: src/routes/sign/up/[token].tsx:367
+#: src/routes/sign/up/[token].tsx:415
 msgid "You'll automatically follow each other when you sign up."
 msgstr "您在注册时将自动互相关注。"
 
-#: src/routes/sign/up/[token].tsx:343
+#: src/routes/sign/up/[token].tsx:391
 msgid "Your bio will be displayed on your profile. You can use Markdown to format it. Maximum 512 characters."
 msgstr "你的个人简介将在你的个人资料页面显示。你可以用 Markdown 文档格式化。最大 512 字符。"
 
-#: src/routes/sign/up/[token].tsx:269
+#: src/routes/sign/up/[token].tsx:317
 msgid "Your email address will be used to sign in to your account."
 msgstr "你的电子邮件地址将用于登录。"
 
-#: src/routes/sign/up/[token].tsx:321
+#: src/routes/sign/up/[token].tsx:369
 msgid "Your name will be displayed on your profile and in your posts."
 msgstr "你的昵称将在你的个人资料页面和你的帖文中显示。"
 
-#: src/routes/sign/up/[token].tsx:295
+#: src/routes/sign/up/[token].tsx:343
 msgid "Your username will be used to create your profile URL and your fediverse handle."
 msgstr "你的用户名将被用来创建你的个人资料 URL 和你的 Fediverse 用户名（handle）。"

--- a/web-next/src/locales/zh-CN/messages.po
+++ b/web-next/src/locales/zh-CN/messages.po
@@ -70,15 +70,36 @@ msgstr "文章"
 msgid "Articles only"
 msgstr "仅文章"
 
+#: src/routes/sign/up/[token].tsx:331
+msgid "Bio"
+msgstr "个人简介"
+
+#: src/routes/sign/up/[token].tsx:136
+msgid "Bio is too long. Maximum length is 512 characters."
+msgstr "个人简介太长。不能长于 512 字符。"
+
 #: src/components/AppSidebar.tsx:278
 #: src/routes/(root)/coc.tsx:53
 #: src/routes/(root)/coc.tsx:58
+#: src/routes/sign/up/[token].tsx:374
 msgid "Code of conduct"
 msgstr "行为准则"
+
+#: src/routes/sign/up/[token].tsx:402
+msgid "Creating account..."
+msgstr ""
+
+#: src/routes/sign/up/[token].tsx:305
+msgid "Display name"
+msgstr "昵称"
 
 #: src/routes/sign/index.tsx:230
 msgid "Do you need an account? Hackers' Pub is invite-only—please ask a friend to invite you."
 msgstr "需要创建账户吗？Hackers' Pub 仅限邀请，请联系朋友邀请您。"
+
+#: src/routes/sign/up/[token].tsx:260
+msgid "Email address"
+msgstr "电子邮件地址"
 
 #: src/routes/sign/index.tsx:208
 msgid "Email or username"
@@ -146,6 +167,10 @@ msgstr "Hackers' Pub"
 msgid "Home"
 msgstr "首页"
 
+#: src/routes/sign/up/[token].tsx:376
+msgid "I have read and agree to the Code of conduct."
+msgstr "我同意 Hackers' Pub 的行为准则。"
+
 #: src/components/ActorArticleList.tsx:78
 msgid "Load more articles"
 msgstr "加载更多文章"
@@ -180,6 +205,10 @@ msgstr "加载更多帖子中…"
 msgid "Loading more posts…"
 msgstr "加载更多内容中…"
 
+#: src/routes/sign/up/[token].tsx:386
+msgid "Loading..."
+msgstr ""
+
 #: src/routes/(root)/markdown.tsx:53
 #: src/routes/(root)/markdown.tsx:58
 msgid "Markdown guide"
@@ -188,6 +217,14 @@ msgstr "Markdown 指南"
 #: src/components/VisibilityTag.tsx:98
 msgid "Mentioned only"
 msgstr "只提及用户可见"
+
+#: src/routes/sign/up/[token].tsx:126
+msgid "Name is required."
+msgstr "需要昵称"
+
+#: src/routes/sign/up/[token].tsx:129
+msgid "Name is too long. Maximum length is 50 characters."
+msgstr "用户名太长。不能长于 50 字符。"
 
 #: src/components/ActorFollowerList.tsx:90
 msgid "No followers found"
@@ -235,6 +272,10 @@ msgstr "悄悄公开"
 msgid "Read full article"
 msgstr "阅读完整文章"
 
+#: src/routes/sign/up/[token].tsx:380
+msgid "Read the full Code of conduct"
+msgstr ""
+
 #: src/components/ProfileTabs.tsx:51
 #: src/routes/(root)/[handle]/(profile)/shares.tsx:86
 msgid "Shares"
@@ -248,6 +289,11 @@ msgstr "登录"
 #: src/components/AppSidebar.tsx:267
 msgid "Sign out"
 msgstr "登出"
+
+#: src/routes/sign/up/[token].tsx:236
+#: src/routes/sign/up/[token].tsx:402
+msgid "Sign up"
+msgstr "注册"
 
 #: src/routes/sign/index.tsx:187
 msgid "Signing in Hackers' Pub"
@@ -265,6 +311,14 @@ msgstr "由 AI 生成的摘要"
 msgid "Table of contents"
 msgstr "目录"
 
+#: src/routes/sign/up/[token].tsx:335
+msgid "Tell us about yourself..."
+msgstr ""
+
+#: src/routes/sign/up/[token].tsx:245
+msgid "The sign-up link is invalid. Please make sure you're using the correct link from the email you received."
+msgstr "注册链接无效。请确保你使用的是你收到的正确邮件链接。"
+
 #. placeholder {0}: "GITHUB_REPOSITORY"
 #. placeholder {1}: "AGPL-3.0"
 #: src/components/AppSidebar.tsx:282
@@ -280,11 +334,31 @@ msgstr "时间线"
 msgid "Translated from {0}"
 msgstr "翻译自{0}"
 
+#: src/routes/sign/up/[token].tsx:278
+msgid "Username"
+msgstr "用户名"
+
+#: src/routes/sign/up/[token].tsx:119
+msgid "Username can only contain lowercase letters, numbers, and underscores."
+msgstr "用户名只能包含小写字母、数字以及下划线。"
+
+#: src/routes/sign/up/[token].tsx:113
+msgid "Username is required."
+msgstr "需要用户名"
+
+#: src/routes/sign/up/[token].tsx:116
+msgid "Username is too long. Maximum length is 50 characters."
+msgstr "用户名太长。不能长于 50 字符。"
+
 #. placeholder {0}: "OWNER"
 #. placeholder {1}: "RELATIVE_TIME"
 #: src/components/ProfileCard.tsx:137
 msgid "Verified that this link is owned by {0} {1}"
 msgstr "已于{1}验证此链接归{0}所有"
+
+#: src/routes/sign/up/[token].tsx:240
+msgid "Verifying your invitation..."
+msgstr "正在验证您的邀请..."
 
 #: src/components/VisibilityTag.tsx:79
 msgid "Visible only to the author's followers. The post will not appear in the public timeline, and only those who follow the author can see it."
@@ -302,6 +376,34 @@ msgstr "所有人都可以看到，但不会出现在公共时间线中。只有
 msgid "Visible to everyone, including non-registered users. The post will appear in the public timeline as well."
 msgstr "包括未注册用户在内的所有人都可以看到。内容也会出现在公共时间线中。"
 
+#: src/routes/sign/up/[token].tsx:250
+msgid "Welcome to Hackers' Pub! Please fill out the form below to complete your sign-up."
+msgstr "欢迎来到 Hackers' Pub！请填写以下表单完成注册。"
+
 #: src/components/AppSidebar.tsx:173
 msgid "Without shares"
 msgstr "不含转帖"
+
+#: src/routes/sign/up/[token].tsx:350
+msgid "You were invited by"
+msgstr "您被以下用户邀请"
+
+#: src/routes/sign/up/[token].tsx:367
+msgid "You'll automatically follow each other when you sign up."
+msgstr "您在注册时将自动互相关注。"
+
+#: src/routes/sign/up/[token].tsx:343
+msgid "Your bio will be displayed on your profile. You can use Markdown to format it. Maximum 512 characters."
+msgstr "你的个人简介将在你的个人资料页面显示。你可以用 Markdown 文档格式化。最大 512 字符。"
+
+#: src/routes/sign/up/[token].tsx:269
+msgid "Your email address will be used to sign in to your account."
+msgstr "你的电子邮件地址将用于登录。"
+
+#: src/routes/sign/up/[token].tsx:321
+msgid "Your name will be displayed on your profile and in your posts."
+msgstr "你的昵称将在你的个人资料页面和你的帖文中显示。"
+
+#: src/routes/sign/up/[token].tsx:295
+msgid "Your username will be used to create your profile URL and your fediverse handle."
+msgstr "你的用户名将被用来创建你的个人资料 URL 和你的 Fediverse 用户名（handle）。"

--- a/web-next/src/locales/zh-CN/messages.po
+++ b/web-next/src/locales/zh-CN/messages.po
@@ -61,6 +61,10 @@ msgstr "登录链接已发送至您的邮箱。请检查收件箱。（或垃圾
 msgid "Account"
 msgstr "账户"
 
+#: src/routes/sign/up/[token].tsx:307
+msgid "An error occurred during signup. Please try again."
+msgstr "注册过程中发生错误。请重新尝试。"
+
 #: src/components/ProfileTabs.tsx:48
 #: src/routes/(root)/[handle]/(profile)/articles.tsx:84
 msgid "Articles"
@@ -70,26 +74,26 @@ msgstr "文章"
 msgid "Articles only"
 msgstr "仅文章"
 
-#: src/routes/sign/up/[token].tsx:379
+#: src/routes/sign/up/[token].tsx:423
 msgid "Bio"
 msgstr "个人简介"
 
-#: src/routes/sign/up/[token].tsx:160
+#: src/routes/sign/up/[token].tsx:174
 msgid "Bio is too long. Maximum length is 512 characters."
 msgstr "个人简介太长。不能长于 512 字符。"
 
 #: src/components/AppSidebar.tsx:278
 #: src/routes/(root)/coc.tsx:53
 #: src/routes/(root)/coc.tsx:58
-#: src/routes/sign/up/[token].tsx:422
+#: src/routes/sign/up/[token].tsx:470
 msgid "Code of conduct"
 msgstr "行为准则"
 
-#: src/routes/sign/up/[token].tsx:450
+#: src/routes/sign/up/[token].tsx:498
 msgid "Creating account..."
 msgstr "正在创建账户..."
 
-#: src/routes/sign/up/[token].tsx:353
+#: src/routes/sign/up/[token].tsx:397
 msgid "Display name"
 msgstr "昵称"
 
@@ -97,7 +101,7 @@ msgstr "昵称"
 msgid "Do you need an account? Hackers' Pub is invite-only—please ask a friend to invite you."
 msgstr "需要创建账户吗？Hackers' Pub 仅限邀请，请联系朋友邀请您。"
 
-#: src/routes/sign/up/[token].tsx:308
+#: src/routes/sign/up/[token].tsx:350
 msgid "Email address"
 msgstr "电子邮件地址"
 
@@ -108,6 +112,10 @@ msgstr "邮箱或用户名"
 #: src/routes/sign/index.tsx:193
 msgid "Enter your email or username below to sign in."
 msgstr "请在下方输入您的邮箱或用户名以登录。"
+
+#: src/routes/sign/up/[token].tsx:304
+msgid "Error"
+msgstr "错误"
 
 #: src/components/ActorArticleList.tsx:75
 msgid "Failed to load more articles; click to retry"
@@ -167,7 +175,7 @@ msgstr "Hackers' Pub"
 msgid "Home"
 msgstr "首页"
 
-#: src/routes/sign/up/[token].tsx:424
+#: src/routes/sign/up/[token].tsx:472
 msgid "I have read and agree to the Code of conduct."
 msgstr "我同意 Hackers' Pub 的行为准则。"
 
@@ -205,7 +213,7 @@ msgstr "加载更多帖子中…"
 msgid "Loading more posts…"
 msgstr "加载更多内容中…"
 
-#: src/routes/sign/up/[token].tsx:434
+#: src/routes/sign/up/[token].tsx:482
 msgid "Loading..."
 msgstr "正在加载..."
 
@@ -218,11 +226,11 @@ msgstr "Markdown 指南"
 msgid "Mentioned only"
 msgstr "只提及用户可见"
 
-#: src/routes/sign/up/[token].tsx:147
+#: src/routes/sign/up/[token].tsx:161
 msgid "Name is required."
 msgstr "需要昵称"
 
-#: src/routes/sign/up/[token].tsx:149
+#: src/routes/sign/up/[token].tsx:163
 msgid "Name is too long. Maximum length is 50 characters."
 msgstr "用户名太长。不能长于 50 字符。"
 
@@ -272,7 +280,7 @@ msgstr "悄悄公开"
 msgid "Read full article"
 msgstr "阅读完整文章"
 
-#: src/routes/sign/up/[token].tsx:428
+#: src/routes/sign/up/[token].tsx:476
 msgid "Read the full Code of conduct"
 msgstr "阅读完整的行为准则"
 
@@ -290,8 +298,8 @@ msgstr "登录"
 msgid "Sign out"
 msgstr "登出"
 
-#: src/routes/sign/up/[token].tsx:284
-#: src/routes/sign/up/[token].tsx:450
+#: src/routes/sign/up/[token].tsx:326
+#: src/routes/sign/up/[token].tsx:498
 msgid "Sign up"
 msgstr "注册"
 
@@ -311,11 +319,11 @@ msgstr "由 AI 生成的摘要"
 msgid "Table of contents"
 msgstr "目录"
 
-#: src/routes/sign/up/[token].tsx:383
+#: src/routes/sign/up/[token].tsx:427
 msgid "Tell us about yourself..."
 msgstr "请告诉我们关于您自己的信息..."
 
-#: src/routes/sign/up/[token].tsx:293
+#: src/routes/sign/up/[token].tsx:335
 msgid "The sign-up link is invalid. Please make sure you're using the correct link from the email you received."
 msgstr "注册链接无效。请确保你使用的是你收到的正确邮件链接。"
 
@@ -334,23 +342,23 @@ msgstr "时间线"
 msgid "Translated from {0}"
 msgstr "翻译自{0}"
 
-#: src/routes/sign/up/[token].tsx:326
+#: src/routes/sign/up/[token].tsx:370
 msgid "Username"
 msgstr "用户名"
 
-#: src/routes/sign/up/[token].tsx:134
+#: src/routes/sign/up/[token].tsx:148
 msgid "Username can only contain lowercase letters, numbers, and underscores."
 msgstr "用户名只能包含小写字母、数字以及下划线。"
 
-#: src/routes/sign/up/[token].tsx:136
+#: src/routes/sign/up/[token].tsx:150
 msgid "Username is already taken."
 msgstr "用户名已被占用。"
 
-#: src/routes/sign/up/[token].tsx:130
+#: src/routes/sign/up/[token].tsx:144
 msgid "Username is required."
 msgstr "需要用户名"
 
-#: src/routes/sign/up/[token].tsx:132
+#: src/routes/sign/up/[token].tsx:146
 msgid "Username is too long. Maximum length is 15 characters."
 msgstr "用户名太长。不能长于 15 字符。"
 
@@ -360,7 +368,7 @@ msgstr "用户名太长。不能长于 15 字符。"
 msgid "Verified that this link is owned by {0} {1}"
 msgstr "已于{1}验证此链接归{0}所有"
 
-#: src/routes/sign/up/[token].tsx:288
+#: src/routes/sign/up/[token].tsx:330
 msgid "Verifying your invitation..."
 msgstr "正在验证您的邀请..."
 
@@ -380,7 +388,7 @@ msgstr "所有人都可以看到，但不会出现在公共时间线中。只有
 msgid "Visible to everyone, including non-registered users. The post will appear in the public timeline as well."
 msgstr "包括未注册用户在内的所有人都可以看到。内容也会出现在公共时间线中。"
 
-#: src/routes/sign/up/[token].tsx:298
+#: src/routes/sign/up/[token].tsx:340
 msgid "Welcome to Hackers' Pub! Please fill out the form below to complete your sign-up."
 msgstr "欢迎来到 Hackers' Pub！请填写以下表单完成注册。"
 
@@ -388,26 +396,26 @@ msgstr "欢迎来到 Hackers' Pub！请填写以下表单完成注册。"
 msgid "Without shares"
 msgstr "不含转帖"
 
-#: src/routes/sign/up/[token].tsx:398
+#: src/routes/sign/up/[token].tsx:446
 msgid "You were invited by"
 msgstr "您被以下用户邀请"
 
-#: src/routes/sign/up/[token].tsx:415
+#: src/routes/sign/up/[token].tsx:463
 msgid "You'll automatically follow each other when you sign up."
 msgstr "您在注册时将自动互相关注。"
 
-#: src/routes/sign/up/[token].tsx:391
+#: src/routes/sign/up/[token].tsx:439
 msgid "Your bio will be displayed on your profile. You can use Markdown to format it. Maximum 512 characters."
 msgstr "你的个人简介将在你的个人资料页面显示。你可以用 Markdown 文档格式化。最大 512 字符。"
 
-#: src/routes/sign/up/[token].tsx:317
+#: src/routes/sign/up/[token].tsx:359
 msgid "Your email address will be used to sign in to your account."
 msgstr "你的电子邮件地址将用于登录。"
 
-#: src/routes/sign/up/[token].tsx:369
+#: src/routes/sign/up/[token].tsx:413
 msgid "Your name will be displayed on your profile and in your posts."
 msgstr "你的昵称将在你的个人资料页面和你的帖文中显示。"
 
-#: src/routes/sign/up/[token].tsx:343
+#: src/routes/sign/up/[token].tsx:387
 msgid "Your username will be used to create your profile URL and your fediverse handle."
 msgstr "你的用户名将被用来创建你的个人资料 URL 和你的 Fediverse 用户名（handle）。"

--- a/web-next/src/locales/zh-TW/messages.po
+++ b/web-next/src/locales/zh-TW/messages.po
@@ -14,12 +14,12 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. placeholder {0}: actor().followersCount.totalCount
-#: src/components/ProfileCard.tsx:166
+#: src/components/ProfileCard.tsx:178
 msgid "{0, plural, one {# follower} other {# followers}}"
 msgstr "{0, plural, other {被 # 人關注}}"
 
 #. placeholder {0}: actor().followeesCount.totalCount
-#: src/components/ProfileCard.tsx:151
+#: src/components/ProfileCard.tsx:163
 msgid "{0, plural, one {# following} other {# following}}"
 msgstr "{0, plural, other {關注 # 人}}"
 
@@ -30,26 +30,26 @@ msgid "{0} shared {1}"
 msgstr "{0}在{1}轉貼了"
 
 #. placeholder {0}: actor().rawName ?? actor().username
-#: src/routes/(root)/[handle]/(profile)/articles.tsx:72
-#: src/routes/(root)/[handle]/(profile)/articles.tsx:76
+#: src/routes/(root)/[handle]/(profile)/articles.tsx:73
+#: src/routes/(root)/[handle]/(profile)/articles.tsx:77
 msgid "{0}'s articles"
 msgstr "{0}的文章"
 
 #. placeholder {0}: account().name
-#: src/routes/(root)/[handle]/(profile)/followers.tsx:72
-#: src/routes/(root)/[handle]/(profile)/followers.tsx:75
+#: src/routes/(root)/[handle]/(profile)/followers.tsx:73
+#: src/routes/(root)/[handle]/(profile)/followers.tsx:76
 msgid "{0}'s followers"
 msgstr "{0}的粉絲"
 
 #. placeholder {0}: actor().rawName ?? actor().username
-#: src/routes/(root)/[handle]/(profile)/notes.tsx:73
-#: src/routes/(root)/[handle]/(profile)/notes.tsx:77
+#: src/routes/(root)/[handle]/(profile)/notes.tsx:74
+#: src/routes/(root)/[handle]/(profile)/notes.tsx:78
 msgid "{0}'s notes"
 msgstr "{0}的貼文"
 
 #. placeholder {0}: actor().rawName ?? actor().username
-#: src/routes/(root)/[handle]/(profile)/shares.tsx:74
-#: src/routes/(root)/[handle]/(profile)/shares.tsx:78
+#: src/routes/(root)/[handle]/(profile)/shares.tsx:75
+#: src/routes/(root)/[handle]/(profile)/shares.tsx:79
 msgid "{0}'s shares"
 msgstr "{0}的轉貼"
 
@@ -61,8 +61,8 @@ msgstr "登入連結已傳送至您的郵箱。請檢查收件匣。（或垃圾
 msgid "Account"
 msgstr "帳戶"
 
-#: src/routes/(root)/[handle]/(profile)/articles.tsx:83
 #: src/components/ProfileTabs.tsx:48
+#: src/routes/(root)/[handle]/(profile)/articles.tsx:84
 msgid "Articles"
 msgstr "文章"
 
@@ -70,9 +70,9 @@ msgstr "文章"
 msgid "Articles only"
 msgstr "僅文章"
 
+#: src/components/AppSidebar.tsx:278
 #: src/routes/(root)/coc.tsx:53
 #: src/routes/(root)/coc.tsx:58
-#: src/components/AppSidebar.tsx:278
 msgid "Code of conduct"
 msgstr "行為準則"
 
@@ -100,8 +100,8 @@ msgstr "載入更多粉絲失敗，點擊重試"
 msgid "Failed to load more notes; click to retry"
 msgstr "載入更多貼文失敗，點擊重試"
 
-#: src/components/ActorSharedPostList.tsx:75
 #: src/components/ActorPostList.tsx:73
+#: src/components/ActorSharedPostList.tsx:75
 msgid "Failed to load more posts; click to retry"
 msgstr "載入更多內容失敗，點擊重試"
 
@@ -118,7 +118,7 @@ msgstr "聯邦宇宙"
 msgid "Feed"
 msgstr "訂閱流"
 
-#: src/routes/(root)/[handle]/(profile)/followers.tsx:81
+#: src/routes/(root)/[handle]/(profile)/followers.tsx:82
 msgid "Followers"
 msgstr "粉絲"
 
@@ -126,7 +126,7 @@ msgstr "粉絲"
 msgid "Followers only"
 msgstr "只粉絲可見"
 
-#: src/components/ProfileCard.tsx:176
+#: src/components/ProfileCard.tsx:188
 msgid "Following you"
 msgstr "關注了你"
 
@@ -134,11 +134,11 @@ msgstr "關注了你"
 msgid "GitHub repository"
 msgstr "GitHub 儲存庫"
 
-#: src/routes/sign.tsx:11
-#: src/routes/(root)/markdown.tsx:53
-#: src/routes/(root)/coc.tsx:53
 #: src/components/AppSidebar.tsx:91
 #: src/components/AppSidebar.tsx:135
+#: src/routes/(root)/coc.tsx:53
+#: src/routes/(root)/markdown.tsx:53
+#: src/routes/sign.tsx:11
 msgid "Hackers' Pub"
 msgstr "Hackers' Pub"
 
@@ -158,8 +158,8 @@ msgstr "載入更多粉絲"
 msgid "Load more notes"
 msgstr "載入更多貼文"
 
-#: src/components/ActorSharedPostList.tsx:78
 #: src/components/ActorPostList.tsx:76
+#: src/components/ActorSharedPostList.tsx:78
 msgid "Load more posts"
 msgstr "載入更多內容"
 
@@ -175,8 +175,8 @@ msgstr "載入更多粉絲中…"
 msgid "Loading more notes…"
 msgstr "載入更多貼文中…"
 
-#: src/components/ActorSharedPostList.tsx:72
 #: src/components/ActorPostList.tsx:70
+#: src/components/ActorSharedPostList.tsx:72
 msgid "Loading more posts…"
 msgstr "載入更多內容中…"
 
@@ -201,8 +201,8 @@ msgstr "未找到文章"
 msgid "No notes found"
 msgstr "未找到貼文"
 
-#: src/components/ActorSharedPostList.tsx:85
 #: src/components/ActorPostList.tsx:83
+#: src/components/ActorSharedPostList.tsx:85
 msgid "No posts found"
 msgstr "未找到內容"
 
@@ -214,8 +214,8 @@ msgstr "未找到內容"
 msgid "No such account in Hackers' Pub—please try again."
 msgstr "Hackers' Pub 中無此帳戶，請重試。"
 
-#: src/routes/(root)/[handle]/(profile)/notes.tsx:84
 #: src/components/ProfileTabs.tsx:41
+#: src/routes/(root)/[handle]/(profile)/notes.tsx:85
 msgid "Notes"
 msgstr "貼文"
 
@@ -235,13 +235,13 @@ msgstr "悄悄公開"
 msgid "Read full article"
 msgstr "閱讀完整文章"
 
-#: src/routes/(root)/[handle]/(profile)/shares.tsx:85
 #: src/components/ProfileTabs.tsx:51
+#: src/routes/(root)/[handle]/(profile)/shares.tsx:86
 msgid "Shares"
 msgstr "轉貼"
 
-#: src/routes/sign/index.tsx:224
 #: src/components/AppSidebar.tsx:225
+#: src/routes/sign/index.tsx:224
 msgid "Sign in"
 msgstr "登入"
 
@@ -282,7 +282,7 @@ msgstr "翻譯自{0}"
 
 #. placeholder {0}: "OWNER"
 #. placeholder {1}: "RELATIVE_TIME"
-#: src/components/ProfileCard.tsx:125
+#: src/components/ProfileCard.tsx:137
 msgid "Verified that this link is owned by {0} {1}"
 msgstr "已於{1}驗證此連結歸{0}所有"
 

--- a/web-next/src/locales/zh-TW/messages.po
+++ b/web-next/src/locales/zh-TW/messages.po
@@ -61,6 +61,10 @@ msgstr "登入連結已傳送至您的郵箱。請檢查收件匣。（或垃圾
 msgid "Account"
 msgstr "帳戶"
 
+#: src/routes/sign/up/[token].tsx:307
+msgid "An error occurred during signup. Please try again."
+msgstr "註冊過程中發生錯誤。請重試。"
+
 #: src/components/ProfileTabs.tsx:48
 #: src/routes/(root)/[handle]/(profile)/articles.tsx:84
 msgid "Articles"
@@ -70,26 +74,26 @@ msgstr "文章"
 msgid "Articles only"
 msgstr "僅文章"
 
-#: src/routes/sign/up/[token].tsx:379
+#: src/routes/sign/up/[token].tsx:423
 msgid "Bio"
 msgstr "個人簡介"
 
-#: src/routes/sign/up/[token].tsx:160
+#: src/routes/sign/up/[token].tsx:174
 msgid "Bio is too long. Maximum length is 512 characters."
 msgstr "個人簡介太長。不能長於 512 字元。"
 
 #: src/components/AppSidebar.tsx:278
 #: src/routes/(root)/coc.tsx:53
 #: src/routes/(root)/coc.tsx:58
-#: src/routes/sign/up/[token].tsx:422
+#: src/routes/sign/up/[token].tsx:470
 msgid "Code of conduct"
 msgstr "行為準則"
 
-#: src/routes/sign/up/[token].tsx:450
+#: src/routes/sign/up/[token].tsx:498
 msgid "Creating account..."
 msgstr "創建帳戶..."
 
-#: src/routes/sign/up/[token].tsx:353
+#: src/routes/sign/up/[token].tsx:397
 msgid "Display name"
 msgstr "暱稱"
 
@@ -97,7 +101,7 @@ msgstr "暱稱"
 msgid "Do you need an account? Hackers' Pub is invite-only—please ask a friend to invite you."
 msgstr "需要建立帳戶嗎？Hackers' Pub 僅限邀請，請聯繫朋友邀請您。"
 
-#: src/routes/sign/up/[token].tsx:308
+#: src/routes/sign/up/[token].tsx:350
 msgid "Email address"
 msgstr "電子郵件地址"
 
@@ -108,6 +112,10 @@ msgstr "電子郵件或使用者名稱"
 #: src/routes/sign/index.tsx:193
 msgid "Enter your email or username below to sign in."
 msgstr "請在下方輸入您的電子郵件或使用者名稱以登入。"
+
+#: src/routes/sign/up/[token].tsx:304
+msgid "Error"
+msgstr "錯誤"
 
 #: src/components/ActorArticleList.tsx:75
 msgid "Failed to load more articles; click to retry"
@@ -167,7 +175,7 @@ msgstr "Hackers' Pub"
 msgid "Home"
 msgstr "首頁"
 
-#: src/routes/sign/up/[token].tsx:424
+#: src/routes/sign/up/[token].tsx:472
 msgid "I have read and agree to the Code of conduct."
 msgstr "我同意 Hackers' Pub 的行為準則。"
 
@@ -205,7 +213,7 @@ msgstr "載入更多貼文中…"
 msgid "Loading more posts…"
 msgstr "載入更多內容中…"
 
-#: src/routes/sign/up/[token].tsx:434
+#: src/routes/sign/up/[token].tsx:482
 msgid "Loading..."
 msgstr "載入中..."
 
@@ -218,11 +226,11 @@ msgstr "Markdown 指南"
 msgid "Mentioned only"
 msgstr "只提及使用者可見"
 
-#: src/routes/sign/up/[token].tsx:147
+#: src/routes/sign/up/[token].tsx:161
 msgid "Name is required."
 msgstr "需要暱稱"
 
-#: src/routes/sign/up/[token].tsx:149
+#: src/routes/sign/up/[token].tsx:163
 msgid "Name is too long. Maximum length is 50 characters."
 msgstr "使用者名稱太長。不能長於 50 字元。"
 
@@ -272,7 +280,7 @@ msgstr "悄悄公開"
 msgid "Read full article"
 msgstr "閱讀完整文章"
 
-#: src/routes/sign/up/[token].tsx:428
+#: src/routes/sign/up/[token].tsx:476
 msgid "Read the full Code of conduct"
 msgstr "閱讀完整的行為守則"
 
@@ -290,8 +298,8 @@ msgstr "登入"
 msgid "Sign out"
 msgstr "登出"
 
-#: src/routes/sign/up/[token].tsx:284
-#: src/routes/sign/up/[token].tsx:450
+#: src/routes/sign/up/[token].tsx:326
+#: src/routes/sign/up/[token].tsx:498
 msgid "Sign up"
 msgstr "註冊"
 
@@ -311,11 +319,11 @@ msgstr "由 AI 生成的摘要"
 msgid "Table of contents"
 msgstr "目錄"
 
-#: src/routes/sign/up/[token].tsx:383
+#: src/routes/sign/up/[token].tsx:427
 msgid "Tell us about yourself..."
 msgstr "介紹您自己..."
 
-#: src/routes/sign/up/[token].tsx:293
+#: src/routes/sign/up/[token].tsx:335
 msgid "The sign-up link is invalid. Please make sure you're using the correct link from the email you received."
 msgstr "註冊連結無效。請確保你使用的是你收到的正確郵件連結。"
 
@@ -334,23 +342,23 @@ msgstr "時間軸"
 msgid "Translated from {0}"
 msgstr "翻譯自{0}"
 
-#: src/routes/sign/up/[token].tsx:326
+#: src/routes/sign/up/[token].tsx:370
 msgid "Username"
 msgstr "使用者名稱"
 
-#: src/routes/sign/up/[token].tsx:134
+#: src/routes/sign/up/[token].tsx:148
 msgid "Username can only contain lowercase letters, numbers, and underscores."
 msgstr "使用者名稱只能包含小寫字母、數字以及底線。"
 
-#: src/routes/sign/up/[token].tsx:136
+#: src/routes/sign/up/[token].tsx:150
 msgid "Username is already taken."
 msgstr "用戶名已被佔用。"
 
-#: src/routes/sign/up/[token].tsx:130
+#: src/routes/sign/up/[token].tsx:144
 msgid "Username is required."
 msgstr "需要使用者名稱"
 
-#: src/routes/sign/up/[token].tsx:132
+#: src/routes/sign/up/[token].tsx:146
 msgid "Username is too long. Maximum length is 15 characters."
 msgstr "使用者名稱太長。不能長於 15 字元。"
 
@@ -360,7 +368,7 @@ msgstr "使用者名稱太長。不能長於 15 字元。"
 msgid "Verified that this link is owned by {0} {1}"
 msgstr "已於{1}驗證此連結歸{0}所有"
 
-#: src/routes/sign/up/[token].tsx:288
+#: src/routes/sign/up/[token].tsx:330
 msgid "Verifying your invitation..."
 msgstr "驗證您的邀請..."
 
@@ -380,7 +388,7 @@ msgstr "所有人都可以看到，但不會出現在公共時間軸中。只有
 msgid "Visible to everyone, including non-registered users. The post will appear in the public timeline as well."
 msgstr "包括未註冊使用者在內的所有人都可以看到。內容也會出現在公共時間軸中。"
 
-#: src/routes/sign/up/[token].tsx:298
+#: src/routes/sign/up/[token].tsx:340
 msgid "Welcome to Hackers' Pub! Please fill out the form below to complete your sign-up."
 msgstr "歡迎來到 Hackers' Pub！請填寫以下表單完成註冊。"
 
@@ -388,26 +396,26 @@ msgstr "歡迎來到 Hackers' Pub！請填寫以下表單完成註冊。"
 msgid "Without shares"
 msgstr "不含轉貼"
 
-#: src/routes/sign/up/[token].tsx:398
+#: src/routes/sign/up/[token].tsx:446
 msgid "You were invited by"
 msgstr "您的邀請人"
 
-#: src/routes/sign/up/[token].tsx:415
+#: src/routes/sign/up/[token].tsx:463
 msgid "You'll automatically follow each other when you sign up."
 msgstr "註冊後您將自動追蹤對方。"
 
-#: src/routes/sign/up/[token].tsx:391
+#: src/routes/sign/up/[token].tsx:439
 msgid "Your bio will be displayed on your profile. You can use Markdown to format it. Maximum 512 characters."
 msgstr "你的個人簡介將在你的個人資料頁面顯示。你可以用 Markdown 文件格式化。最大 512 字元。"
 
-#: src/routes/sign/up/[token].tsx:317
+#: src/routes/sign/up/[token].tsx:359
 msgid "Your email address will be used to sign in to your account."
 msgstr "你的電子郵件地址將用於登入。"
 
-#: src/routes/sign/up/[token].tsx:369
+#: src/routes/sign/up/[token].tsx:413
 msgid "Your name will be displayed on your profile and in your posts."
 msgstr "你的暱稱將在你的個人資料頁面和你的貼文中顯示。"
 
-#: src/routes/sign/up/[token].tsx:343
+#: src/routes/sign/up/[token].tsx:387
 msgid "Your username will be used to create your profile URL and your fediverse handle."
 msgstr "你的使用者名稱將被用來創建你的個人資料 URL 和你的 Fediverse 使用者名稱（handle）。"

--- a/web-next/src/locales/zh-TW/messages.po
+++ b/web-next/src/locales/zh-TW/messages.po
@@ -70,15 +70,36 @@ msgstr "文章"
 msgid "Articles only"
 msgstr "僅文章"
 
+#: src/routes/sign/up/[token].tsx:331
+msgid "Bio"
+msgstr "個人簡介"
+
+#: src/routes/sign/up/[token].tsx:136
+msgid "Bio is too long. Maximum length is 512 characters."
+msgstr "個人簡介太長。不能長於 512 字元。"
+
 #: src/components/AppSidebar.tsx:278
 #: src/routes/(root)/coc.tsx:53
 #: src/routes/(root)/coc.tsx:58
+#: src/routes/sign/up/[token].tsx:374
 msgid "Code of conduct"
 msgstr "行為準則"
+
+#: src/routes/sign/up/[token].tsx:402
+msgid "Creating account..."
+msgstr ""
+
+#: src/routes/sign/up/[token].tsx:305
+msgid "Display name"
+msgstr "暱稱"
 
 #: src/routes/sign/index.tsx:230
 msgid "Do you need an account? Hackers' Pub is invite-only—please ask a friend to invite you."
 msgstr "需要建立帳戶嗎？Hackers' Pub 僅限邀請，請聯繫朋友邀請您。"
+
+#: src/routes/sign/up/[token].tsx:260
+msgid "Email address"
+msgstr "電子郵件地址"
 
 #: src/routes/sign/index.tsx:208
 msgid "Email or username"
@@ -146,6 +167,10 @@ msgstr "Hackers' Pub"
 msgid "Home"
 msgstr "首頁"
 
+#: src/routes/sign/up/[token].tsx:376
+msgid "I have read and agree to the Code of conduct."
+msgstr "我同意 Hackers' Pub 的行為準則。"
+
 #: src/components/ActorArticleList.tsx:78
 msgid "Load more articles"
 msgstr "載入更多文章"
@@ -180,6 +205,10 @@ msgstr "載入更多貼文中…"
 msgid "Loading more posts…"
 msgstr "載入更多內容中…"
 
+#: src/routes/sign/up/[token].tsx:386
+msgid "Loading..."
+msgstr ""
+
 #: src/routes/(root)/markdown.tsx:53
 #: src/routes/(root)/markdown.tsx:58
 msgid "Markdown guide"
@@ -188,6 +217,14 @@ msgstr "Markdown 指南"
 #: src/components/VisibilityTag.tsx:98
 msgid "Mentioned only"
 msgstr "只提及使用者可見"
+
+#: src/routes/sign/up/[token].tsx:126
+msgid "Name is required."
+msgstr "需要暱稱"
+
+#: src/routes/sign/up/[token].tsx:129
+msgid "Name is too long. Maximum length is 50 characters."
+msgstr "使用者名稱太長。不能長於 50 字元。"
 
 #: src/components/ActorFollowerList.tsx:90
 msgid "No followers found"
@@ -235,6 +272,10 @@ msgstr "悄悄公開"
 msgid "Read full article"
 msgstr "閱讀完整文章"
 
+#: src/routes/sign/up/[token].tsx:380
+msgid "Read the full Code of conduct"
+msgstr ""
+
 #: src/components/ProfileTabs.tsx:51
 #: src/routes/(root)/[handle]/(profile)/shares.tsx:86
 msgid "Shares"
@@ -248,6 +289,11 @@ msgstr "登入"
 #: src/components/AppSidebar.tsx:267
 msgid "Sign out"
 msgstr "登出"
+
+#: src/routes/sign/up/[token].tsx:236
+#: src/routes/sign/up/[token].tsx:402
+msgid "Sign up"
+msgstr "註冊"
 
 #: src/routes/sign/index.tsx:187
 msgid "Signing in Hackers' Pub"
@@ -265,6 +311,14 @@ msgstr "由 AI 生成的摘要"
 msgid "Table of contents"
 msgstr "目錄"
 
+#: src/routes/sign/up/[token].tsx:335
+msgid "Tell us about yourself..."
+msgstr ""
+
+#: src/routes/sign/up/[token].tsx:245
+msgid "The sign-up link is invalid. Please make sure you're using the correct link from the email you received."
+msgstr "註冊連結無效。請確保你使用的是你收到的正確郵件連結。"
+
 #. placeholder {0}: "GITHUB_REPOSITORY"
 #. placeholder {1}: "AGPL-3.0"
 #: src/components/AppSidebar.tsx:282
@@ -280,11 +334,31 @@ msgstr "時間軸"
 msgid "Translated from {0}"
 msgstr "翻譯自{0}"
 
+#: src/routes/sign/up/[token].tsx:278
+msgid "Username"
+msgstr "使用者名稱"
+
+#: src/routes/sign/up/[token].tsx:119
+msgid "Username can only contain lowercase letters, numbers, and underscores."
+msgstr "使用者名稱只能包含小寫字母、數字以及底線。"
+
+#: src/routes/sign/up/[token].tsx:113
+msgid "Username is required."
+msgstr "需要使用者名稱"
+
+#: src/routes/sign/up/[token].tsx:116
+msgid "Username is too long. Maximum length is 50 characters."
+msgstr "使用者名稱太長。不能長於 50 字元。"
+
 #. placeholder {0}: "OWNER"
 #. placeholder {1}: "RELATIVE_TIME"
 #: src/components/ProfileCard.tsx:137
 msgid "Verified that this link is owned by {0} {1}"
 msgstr "已於{1}驗證此連結歸{0}所有"
+
+#: src/routes/sign/up/[token].tsx:240
+msgid "Verifying your invitation..."
+msgstr "驗證您的邀請..."
 
 #: src/components/VisibilityTag.tsx:79
 msgid "Visible only to the author's followers. The post will not appear in the public timeline, and only those who follow the author can see it."
@@ -302,6 +376,34 @@ msgstr "所有人都可以看到，但不會出現在公共時間軸中。只有
 msgid "Visible to everyone, including non-registered users. The post will appear in the public timeline as well."
 msgstr "包括未註冊使用者在內的所有人都可以看到。內容也會出現在公共時間軸中。"
 
+#: src/routes/sign/up/[token].tsx:250
+msgid "Welcome to Hackers' Pub! Please fill out the form below to complete your sign-up."
+msgstr "歡迎來到 Hackers' Pub！請填寫以下表單完成註冊。"
+
 #: src/components/AppSidebar.tsx:173
 msgid "Without shares"
 msgstr "不含轉貼"
+
+#: src/routes/sign/up/[token].tsx:350
+msgid "You were invited by"
+msgstr "您的邀請人"
+
+#: src/routes/sign/up/[token].tsx:367
+msgid "You'll automatically follow each other when you sign up."
+msgstr "註冊後您將自動追蹤對方。"
+
+#: src/routes/sign/up/[token].tsx:343
+msgid "Your bio will be displayed on your profile. You can use Markdown to format it. Maximum 512 characters."
+msgstr "你的個人簡介將在你的個人資料頁面顯示。你可以用 Markdown 文件格式化。最大 512 字元。"
+
+#: src/routes/sign/up/[token].tsx:269
+msgid "Your email address will be used to sign in to your account."
+msgstr "你的電子郵件地址將用於登入。"
+
+#: src/routes/sign/up/[token].tsx:321
+msgid "Your name will be displayed on your profile and in your posts."
+msgstr "你的暱稱將在你的個人資料頁面和你的貼文中顯示。"
+
+#: src/routes/sign/up/[token].tsx:295
+msgid "Your username will be used to create your profile URL and your fediverse handle."
+msgstr "你的使用者名稱將被用來創建你的個人資料 URL 和你的 Fediverse 使用者名稱（handle）。"

--- a/web-next/src/locales/zh-TW/messages.po
+++ b/web-next/src/locales/zh-TW/messages.po
@@ -70,26 +70,26 @@ msgstr "文章"
 msgid "Articles only"
 msgstr "僅文章"
 
-#: src/routes/sign/up/[token].tsx:331
+#: src/routes/sign/up/[token].tsx:379
 msgid "Bio"
 msgstr "個人簡介"
 
-#: src/routes/sign/up/[token].tsx:136
+#: src/routes/sign/up/[token].tsx:160
 msgid "Bio is too long. Maximum length is 512 characters."
 msgstr "個人簡介太長。不能長於 512 字元。"
 
 #: src/components/AppSidebar.tsx:278
 #: src/routes/(root)/coc.tsx:53
 #: src/routes/(root)/coc.tsx:58
-#: src/routes/sign/up/[token].tsx:374
+#: src/routes/sign/up/[token].tsx:422
 msgid "Code of conduct"
 msgstr "行為準則"
 
-#: src/routes/sign/up/[token].tsx:402
+#: src/routes/sign/up/[token].tsx:450
 msgid "Creating account..."
 msgstr "創建帳戶..."
 
-#: src/routes/sign/up/[token].tsx:305
+#: src/routes/sign/up/[token].tsx:353
 msgid "Display name"
 msgstr "暱稱"
 
@@ -97,7 +97,7 @@ msgstr "暱稱"
 msgid "Do you need an account? Hackers' Pub is invite-only—please ask a friend to invite you."
 msgstr "需要建立帳戶嗎？Hackers' Pub 僅限邀請，請聯繫朋友邀請您。"
 
-#: src/routes/sign/up/[token].tsx:260
+#: src/routes/sign/up/[token].tsx:308
 msgid "Email address"
 msgstr "電子郵件地址"
 
@@ -167,7 +167,7 @@ msgstr "Hackers' Pub"
 msgid "Home"
 msgstr "首頁"
 
-#: src/routes/sign/up/[token].tsx:376
+#: src/routes/sign/up/[token].tsx:424
 msgid "I have read and agree to the Code of conduct."
 msgstr "我同意 Hackers' Pub 的行為準則。"
 
@@ -205,7 +205,7 @@ msgstr "載入更多貼文中…"
 msgid "Loading more posts…"
 msgstr "載入更多內容中…"
 
-#: src/routes/sign/up/[token].tsx:386
+#: src/routes/sign/up/[token].tsx:434
 msgid "Loading..."
 msgstr "載入中..."
 
@@ -218,11 +218,11 @@ msgstr "Markdown 指南"
 msgid "Mentioned only"
 msgstr "只提及使用者可見"
 
-#: src/routes/sign/up/[token].tsx:126
+#: src/routes/sign/up/[token].tsx:147
 msgid "Name is required."
 msgstr "需要暱稱"
 
-#: src/routes/sign/up/[token].tsx:129
+#: src/routes/sign/up/[token].tsx:149
 msgid "Name is too long. Maximum length is 50 characters."
 msgstr "使用者名稱太長。不能長於 50 字元。"
 
@@ -272,7 +272,7 @@ msgstr "悄悄公開"
 msgid "Read full article"
 msgstr "閱讀完整文章"
 
-#: src/routes/sign/up/[token].tsx:380
+#: src/routes/sign/up/[token].tsx:428
 msgid "Read the full Code of conduct"
 msgstr "閱讀完整的行為守則"
 
@@ -290,8 +290,8 @@ msgstr "登入"
 msgid "Sign out"
 msgstr "登出"
 
-#: src/routes/sign/up/[token].tsx:236
-#: src/routes/sign/up/[token].tsx:402
+#: src/routes/sign/up/[token].tsx:284
+#: src/routes/sign/up/[token].tsx:450
 msgid "Sign up"
 msgstr "註冊"
 
@@ -311,11 +311,11 @@ msgstr "由 AI 生成的摘要"
 msgid "Table of contents"
 msgstr "目錄"
 
-#: src/routes/sign/up/[token].tsx:335
+#: src/routes/sign/up/[token].tsx:383
 msgid "Tell us about yourself..."
 msgstr "介紹您自己..."
 
-#: src/routes/sign/up/[token].tsx:245
+#: src/routes/sign/up/[token].tsx:293
 msgid "The sign-up link is invalid. Please make sure you're using the correct link from the email you received."
 msgstr "註冊連結無效。請確保你使用的是你收到的正確郵件連結。"
 
@@ -334,21 +334,25 @@ msgstr "時間軸"
 msgid "Translated from {0}"
 msgstr "翻譯自{0}"
 
-#: src/routes/sign/up/[token].tsx:278
+#: src/routes/sign/up/[token].tsx:326
 msgid "Username"
 msgstr "使用者名稱"
 
-#: src/routes/sign/up/[token].tsx:119
+#: src/routes/sign/up/[token].tsx:134
 msgid "Username can only contain lowercase letters, numbers, and underscores."
 msgstr "使用者名稱只能包含小寫字母、數字以及底線。"
 
-#: src/routes/sign/up/[token].tsx:113
+#: src/routes/sign/up/[token].tsx:136
+msgid "Username is already taken."
+msgstr "用戶名已被佔用。"
+
+#: src/routes/sign/up/[token].tsx:130
 msgid "Username is required."
 msgstr "需要使用者名稱"
 
-#: src/routes/sign/up/[token].tsx:116
-msgid "Username is too long. Maximum length is 50 characters."
-msgstr "使用者名稱太長。不能長於 50 字元。"
+#: src/routes/sign/up/[token].tsx:132
+msgid "Username is too long. Maximum length is 15 characters."
+msgstr "使用者名稱太長。不能長於 15 字元。"
 
 #. placeholder {0}: "OWNER"
 #. placeholder {1}: "RELATIVE_TIME"
@@ -356,7 +360,7 @@ msgstr "使用者名稱太長。不能長於 50 字元。"
 msgid "Verified that this link is owned by {0} {1}"
 msgstr "已於{1}驗證此連結歸{0}所有"
 
-#: src/routes/sign/up/[token].tsx:240
+#: src/routes/sign/up/[token].tsx:288
 msgid "Verifying your invitation..."
 msgstr "驗證您的邀請..."
 
@@ -376,7 +380,7 @@ msgstr "所有人都可以看到，但不會出現在公共時間軸中。只有
 msgid "Visible to everyone, including non-registered users. The post will appear in the public timeline as well."
 msgstr "包括未註冊使用者在內的所有人都可以看到。內容也會出現在公共時間軸中。"
 
-#: src/routes/sign/up/[token].tsx:250
+#: src/routes/sign/up/[token].tsx:298
 msgid "Welcome to Hackers' Pub! Please fill out the form below to complete your sign-up."
 msgstr "歡迎來到 Hackers' Pub！請填寫以下表單完成註冊。"
 
@@ -384,26 +388,26 @@ msgstr "歡迎來到 Hackers' Pub！請填寫以下表單完成註冊。"
 msgid "Without shares"
 msgstr "不含轉貼"
 
-#: src/routes/sign/up/[token].tsx:350
+#: src/routes/sign/up/[token].tsx:398
 msgid "You were invited by"
 msgstr "您的邀請人"
 
-#: src/routes/sign/up/[token].tsx:367
+#: src/routes/sign/up/[token].tsx:415
 msgid "You'll automatically follow each other when you sign up."
 msgstr "註冊後您將自動追蹤對方。"
 
-#: src/routes/sign/up/[token].tsx:343
+#: src/routes/sign/up/[token].tsx:391
 msgid "Your bio will be displayed on your profile. You can use Markdown to format it. Maximum 512 characters."
 msgstr "你的個人簡介將在你的個人資料頁面顯示。你可以用 Markdown 文件格式化。最大 512 字元。"
 
-#: src/routes/sign/up/[token].tsx:269
+#: src/routes/sign/up/[token].tsx:317
 msgid "Your email address will be used to sign in to your account."
 msgstr "你的電子郵件地址將用於登入。"
 
-#: src/routes/sign/up/[token].tsx:321
+#: src/routes/sign/up/[token].tsx:369
 msgid "Your name will be displayed on your profile and in your posts."
 msgstr "你的暱稱將在你的個人資料頁面和你的貼文中顯示。"
 
-#: src/routes/sign/up/[token].tsx:295
+#: src/routes/sign/up/[token].tsx:343
 msgid "Your username will be used to create your profile URL and your fediverse handle."
 msgstr "你的使用者名稱將被用來創建你的個人資料 URL 和你的 Fediverse 使用者名稱（handle）。"

--- a/web-next/src/locales/zh-TW/messages.po
+++ b/web-next/src/locales/zh-TW/messages.po
@@ -87,7 +87,7 @@ msgstr "行為準則"
 
 #: src/routes/sign/up/[token].tsx:402
 msgid "Creating account..."
-msgstr ""
+msgstr "創建帳戶..."
 
 #: src/routes/sign/up/[token].tsx:305
 msgid "Display name"
@@ -207,7 +207,7 @@ msgstr "載入更多內容中…"
 
 #: src/routes/sign/up/[token].tsx:386
 msgid "Loading..."
-msgstr ""
+msgstr "載入中..."
 
 #: src/routes/(root)/markdown.tsx:53
 #: src/routes/(root)/markdown.tsx:58
@@ -274,7 +274,7 @@ msgstr "閱讀完整文章"
 
 #: src/routes/sign/up/[token].tsx:380
 msgid "Read the full Code of conduct"
-msgstr ""
+msgstr "閱讀完整的行為守則"
 
 #: src/components/ProfileTabs.tsx:51
 #: src/routes/(root)/[handle]/(profile)/shares.tsx:86
@@ -313,7 +313,7 @@ msgstr "目錄"
 
 #: src/routes/sign/up/[token].tsx:335
 msgid "Tell us about yourself..."
-msgstr ""
+msgstr "介紹您自己..."
 
 #: src/routes/sign/up/[token].tsx:245
 msgid "The sign-up link is invalid. Please make sure you're using the correct link from the email you received."

--- a/web-next/src/routes/sign/in/[token].tsx
+++ b/web-next/src/routes/sign/in/[token].tsx
@@ -1,3 +1,4 @@
+import { EXPIRATION } from "@hackerspub/models/session";
 import { validateUuid } from "@hackerspub/models/uuid";
 import { redirect } from "@solidjs/router";
 import type { APIEvent } from "@solidjs/start/server";
@@ -45,7 +46,7 @@ export async function GET({ params, nativeEvent }: APIEvent) {
   setCookie(nativeEvent, "session", sessionId, {
     httpOnly: true,
     path: "/",
-    expires: new Date(Date.now() + 365 * 60 * 60 * 24 * 1000), // 365 days
+    expires: new Date(Date.now() + EXPIRATION.total("millisecond")),
     secure: getRequestProtocol(nativeEvent) === "https",
   });
   const next = typeof query.next === "string" ? query.next : "/";

--- a/web-next/src/routes/sign/up/[token].tsx
+++ b/web-next/src/routes/sign/up/[token].tsx
@@ -1,0 +1,432 @@
+import type { Uuid } from "@hackerspub/models/uuid";
+import { validateUuid } from "@hackerspub/models/uuid";
+import { type RouteSectionProps } from "@solidjs/router";
+import { fetchQuery, graphql } from "relay-runtime";
+import { createEffect, createSignal, Show } from "solid-js";
+import { getRequestEvent } from "solid-js/web";
+import {
+  createMutation,
+  createPreloadedQuery,
+  loadQuery,
+  useRelayEnvironment,
+} from "solid-relay";
+import { getRequestProtocol, setCookie } from "vinxi/http";
+import { DocumentView } from "~/components/DocumentView.tsx";
+import { Button } from "~/components/ui/button.tsx";
+import {
+  TextField,
+  TextFieldInput,
+  TextFieldLabel,
+  TextFieldTextArea,
+} from "~/components/ui/text-field.tsx";
+import { useLingui } from "~/lib/i18n/macro.d.ts";
+import { createEnvironment } from "~/RelayEnvironment.tsx";
+import type { TokenCodeOfConductQuery } from "./__generated__/TokenCodeOfConductQuery.graphql.ts";
+import type { TokenCompleteSignupMutation } from "./__generated__/TokenCompleteSignupMutation.graphql.ts";
+import type { TokenVerifySignupTokenQuery } from "./__generated__/TokenVerifySignupTokenQuery.graphql.ts";
+
+const verifySignupTokenQuery = graphql`
+  query TokenVerifySignupTokenQuery($token: UUID!, $code: String!) {
+    verifySignupToken(token: $token, code: $code) {
+      email
+      inviter {
+        name
+        handle
+        avatarUrl
+      }
+    }
+  }
+`;
+
+const completeSignupMutation = graphql`
+  mutation TokenCompleteSignupMutation($token: UUID!, $code: String!, $input: SignupInput!) {
+    completeSignup(token: $token, code: $code, input: $input) {
+      __typename
+      ... on Session {
+        id
+        account {
+          id
+          name
+          username
+          bio
+        }
+      }
+      ... on SignupValidationErrors {
+        username
+        name
+        bio
+      }
+    }
+  }
+`;
+
+const codeOfConductQuery = graphql`
+  query TokenCodeOfConductQuery($locale: Locale!) {
+    codeOfConduct(locale: $locale) {
+      ...DocumentView_document
+    }
+  }
+`;
+
+const setSessionCookie = async (sessionId: Uuid) => {
+  "use server";
+  const event = getRequestEvent();
+  if (event == null) return false;
+  setCookie(event.nativeEvent, "session", sessionId, {
+    httpOnly: true,
+    path: "/",
+    expires: new Date(Date.now() + 365 * 60 * 60 * 24 * 1000), // 365 days
+    secure: getRequestProtocol(event.nativeEvent) === "https",
+  });
+  return true;
+};
+
+type SignupInfo = NonNullable<
+  TokenVerifySignupTokenQuery["response"]["verifySignupToken"]
+>;
+
+export default function SignupPage(props: RouteSectionProps) {
+  const { t, i18n } = useLingui();
+  const [signupInfo, setSignupInfo] = createSignal<SignupInfo | null>(null);
+  const [verifying, setVerifying] = createSignal(true);
+  const [invalid, setInvalid] = createSignal(false);
+  const [submitting, setSubmitting] = createSignal(false);
+  const [fieldErrors, setFieldErrors] = createSignal({
+    username: "",
+    name: "",
+    bio: "",
+  });
+
+  const codeOfConductData = createPreloadedQuery<TokenCodeOfConductQuery>(
+    codeOfConductQuery,
+    () =>
+      loadQuery<TokenCodeOfConductQuery>(
+        useRelayEnvironment()(),
+        codeOfConductQuery,
+        { locale: i18n.locale },
+      ),
+  );
+
+  let usernameInput: HTMLInputElement | undefined;
+  let nameInput: HTMLInputElement | undefined;
+  let bioInput: HTMLTextAreaElement | undefined;
+
+  const [completeSignup] = createMutation<TokenCompleteSignupMutation>(
+    completeSignupMutation,
+  );
+
+  // Validation functions
+  const validateUsername = (username: string) => {
+    if (!username.trim()) {
+      return t`Username is required.`;
+    }
+    if (username.length > 50) {
+      return t`Username is too long. Maximum length is 50 characters.`;
+    }
+    if (!/^[A-Za-z0-9_]+$/.test(username)) {
+      return t`Username can only contain lowercase letters, numbers, and underscores.`;
+    }
+    return "";
+  };
+
+  const validateName = (name: string) => {
+    if (!name.trim()) {
+      return t`Name is required.`;
+    }
+    if (name.length > 50) {
+      return t`Name is too long. Maximum length is 50 characters.`;
+    }
+    return "";
+  };
+
+  const validateBio = (bio: string) => {
+    if (bio.length > 512) {
+      return t`Bio is too long. Maximum length is 512 characters.`;
+    }
+    return "";
+  };
+
+  // Field blur handlers for validation
+  const handleUsernameBlur = () => {
+    if (usernameInput) {
+      const error = validateUsername(usernameInput.value);
+      setFieldErrors((prev) => ({ ...prev, username: error }));
+    }
+  };
+
+  const handleNameBlur = () => {
+    if (nameInput) {
+      const error = validateName(nameInput.value);
+      setFieldErrors((prev) => ({ ...prev, name: error }));
+    }
+  };
+
+  const handleBioBlur = () => {
+    if (bioInput) {
+      const error = validateBio(bioInput.value);
+      setFieldErrors((prev) => ({ ...prev, bio: error }));
+    }
+  };
+
+  createEffect(() => {
+    const token = props.params.token;
+    const code = new URLSearchParams(window.location.search).get("code");
+
+    if (!token || !code || !validateUuid(token)) {
+      setInvalid(true);
+      setVerifying(false);
+      return;
+    }
+
+    fetchQuery<TokenVerifySignupTokenQuery>(
+      createEnvironment(),
+      verifySignupTokenQuery,
+      { token, code },
+    ).subscribe({
+      next: (response) => {
+        setVerifying(false);
+        if (response.verifySignupToken) {
+          setSignupInfo(response.verifySignupToken);
+        } else {
+          setInvalid(true);
+        }
+      },
+      error: () => {
+        setVerifying(false);
+        setInvalid(true);
+      },
+    });
+  });
+
+  function onSubmit(event: SubmitEvent) {
+    event.preventDefault();
+
+    if (!signupInfo() || !usernameInput || !nameInput) return;
+
+    const username = usernameInput.value.trim();
+    const name = nameInput.value.trim();
+    const bio = bioInput?.value?.trim() || "";
+
+    setSubmitting(true);
+
+    completeSignup({
+      variables: {
+        token: props.params.token as Uuid,
+        code: new URLSearchParams(window.location.search).get("code")!,
+        input: { username, name, bio },
+      },
+      onCompleted(response) {
+        setSubmitting(false);
+        if (response.completeSignup) {
+          // Check if it's a Session (success) or SignupValidationErrors
+          if (response.completeSignup.__typename === "Session") {
+            // Session created successfully, set cookie and redirect
+            setSessionCookie(response.completeSignup.id).then((success) => {
+              if (success) {
+                window.location.href = "/?filter=recommendations";
+              }
+            });
+          } else if (
+            response.completeSignup.__typename === "SignupValidationErrors"
+          ) {
+            // Handle field-specific validation errors
+            const errors = response.completeSignup;
+            setFieldErrors({
+              username: errors.username || "",
+              name: errors.name || "",
+              bio: errors.bio || "",
+            });
+          }
+        }
+      },
+      onError(error) {
+        setSubmitting(false);
+        // Show generic error message for network/server errors
+        alert(
+          error.message || "An error occurred during signup. Please try again.",
+        );
+      },
+    });
+  }
+
+  return (
+    <div lang={i18n.locale} class="lg:p-8">
+      <div class="mx-auto max-w-2xl">
+        <div class="flex flex-col space-y-2 text-center mb-8">
+          <h1 class="text-2xl font-semibold tracking-tight">
+            {t`Sign up`}
+          </h1>
+          <Show when={verifying()}>
+            <p class="text-sm text-muted-foreground">
+              {t`Verifying your invitation...`}
+            </p>
+          </Show>
+          <Show when={invalid()}>
+            <p class="text-sm text-red-600">
+              {t`The sign-up link is invalid. Please make sure you're using the correct link from the email you received.`}
+            </p>
+          </Show>
+          <Show when={signupInfo()}>
+            <p class="text-sm text-muted-foreground">
+              {t`Welcome to Hackers' Pub! Please fill out the form below to complete your sign-up.`}
+            </p>
+          </Show>
+        </div>
+
+        <Show when={signupInfo()}>
+          <form class="space-y-6" on:submit={onSubmit}>
+            <div class="grid gap-4 lg:grid-cols-2">
+              <div class="lg:col-span-2">
+                <TextField validationState="valid" class="gap-1">
+                  <TextFieldLabel>{t`Email address`}</TextFieldLabel>
+                  <TextFieldInput
+                    type="email"
+                    value={signupInfo()?.email || ""}
+                    disabled
+                    class="bg-muted"
+                  />
+                </TextField>
+                <p class="text-sm text-muted-foreground mt-1">
+                  {t`Your email address will be used to sign in to your account.`}
+                </p>
+              </div>
+
+              <div>
+                <TextField
+                  validationState={fieldErrors().username ? "invalid" : "valid"}
+                  class="gap-1"
+                >
+                  <TextFieldLabel>{t`Username`} *</TextFieldLabel>
+                  <TextFieldInput
+                    ref={usernameInput}
+                    type="text"
+                    pattern="^[A-Za-z0-9_]{1,50}$"
+                    required
+                    onBlur={handleUsernameBlur}
+                  />
+                </TextField>
+                {fieldErrors().username
+                  ? (
+                    <p class="text-sm text-red-600 mt-1">
+                      {fieldErrors().username}
+                    </p>
+                  )
+                  : (
+                    <p class="text-sm text-muted-foreground mt-1">
+                      {t`Your username will be used to create your profile URL and your fediverse handle.`}
+                    </p>
+                  )}
+              </div>
+
+              <div>
+                <TextField
+                  validationState={fieldErrors().name ? "invalid" : "valid"}
+                  class="gap-1"
+                >
+                  <TextFieldLabel>{t`Display name`} *</TextFieldLabel>
+                  <TextFieldInput
+                    ref={nameInput}
+                    type="text"
+                    required
+                    onBlur={handleNameBlur}
+                  />
+                </TextField>
+                {fieldErrors().name
+                  ? (
+                    <p class="text-sm text-red-600 mt-1">
+                      {fieldErrors().name}
+                    </p>
+                  )
+                  : (
+                    <p class="text-sm text-muted-foreground mt-1">
+                      {t`Your name will be displayed on your profile and in your posts.`}
+                    </p>
+                  )}
+              </div>
+
+              <div class="lg:col-span-2">
+                <TextField
+                  validationState={fieldErrors().bio ? "invalid" : "valid"}
+                  class="gap-1"
+                >
+                  <TextFieldLabel>{t`Bio`}</TextFieldLabel>
+                  <TextFieldTextArea
+                    ref={bioInput}
+                    rows={4}
+                    placeholder={t`Tell us about yourself...`}
+                    onBlur={handleBioBlur}
+                  />
+                </TextField>
+                {fieldErrors().bio
+                  ? <p class="text-sm text-red-600 mt-1">{fieldErrors().bio}</p>
+                  : (
+                    <p class="text-sm text-muted-foreground mt-1">
+                      {t`Your bio will be displayed on your profile. You can use Markdown to format it. Maximum 512 characters.`}
+                    </p>
+                  )}
+              </div>
+
+              <Show when={signupInfo()?.inviter}>
+                <div class="lg:col-span-2 p-4 bg-muted rounded-lg">
+                  <h3 class="font-medium mb-2">{t`You were invited by`}</h3>
+                  <div class="flex items-center gap-3">
+                    <Show when={signupInfo()?.inviter?.avatarUrl}>
+                      <img
+                        src={signupInfo()?.inviter?.avatarUrl}
+                        alt=""
+                        class="w-8 h-8 rounded-full"
+                      />
+                    </Show>
+                    <div>
+                      <p class="font-medium">{signupInfo()?.inviter?.name}</p>
+                      <p class="text-sm text-muted-foreground">
+                        @{signupInfo()?.inviter?.handle}
+                      </p>
+                    </div>
+                  </div>
+                  <p class="text-sm text-muted-foreground mt-2">
+                    {t`You'll automatically follow each other when you sign up.`}
+                  </p>
+                </div>
+              </Show>
+
+              <div class="lg:col-span-2">
+                <div class="border rounded-lg p-4">
+                  <h3 class="font-medium mb-2">{t`Code of conduct`}</h3>
+                  <p class="text-sm text-muted-foreground mb-3">
+                    {t`I have read and agree to the Code of conduct.`}
+                  </p>
+                  <details class="text-sm">
+                    <summary class="cursor-pointer text-blue-600 hover:text-blue-800">
+                      {t`Read the full Code of conduct`}
+                    </summary>
+                    <div class="mt-2 p-3 bg-muted rounded prose prose-sm max-w-none">
+                      <Show
+                        when={codeOfConductData()?.codeOfConduct}
+                        fallback={
+                          <p class="text-muted-foreground">{t`Loading...`}</p>
+                        }
+                      >
+                        {(doc) => <DocumentView $document={doc()} />}
+                      </Show>
+                    </div>
+                  </details>
+                </div>
+              </div>
+
+              <div class="lg:col-span-2 text-center">
+                <Button
+                  type="submit"
+                  disabled={submitting() || !signupInfo()}
+                  class="w-full cursor-pointer"
+                >
+                  {submitting() ? t`Creating account...` : t`Sign up`}
+                </Button>
+              </div>
+            </div>
+          </form>
+        </Show>
+      </div>
+    </div>
+  );
+}

--- a/web-next/src/routes/sign/up/[token].tsx
+++ b/web-next/src/routes/sign/up/[token].tsx
@@ -1,3 +1,4 @@
+import { EXPIRATION } from "@hackerspub/models/session";
 import {
   validateBio,
   validateDisplayName,
@@ -94,7 +95,7 @@ const setSessionCookie = async (sessionId: Uuid) => {
   setCookie(event.nativeEvent, "session", sessionId, {
     httpOnly: true,
     path: "/",
-    expires: new Date(Date.now() + 365 * 60 * 60 * 24 * 1000), // 365 days
+    expires: new Date(Date.now() + EXPIRATION.total("millisecond")),
     secure: getRequestProtocol(event.nativeEvent) === "https",
   });
   return true;

--- a/web-next/src/routes/sign/up/[token].tsx
+++ b/web-next/src/routes/sign/up/[token].tsx
@@ -6,7 +6,7 @@ import {
 import type { Uuid } from "@hackerspub/models/uuid";
 import { validateUuid } from "@hackerspub/models/uuid";
 import { toaster } from "@kobalte/core";
-import { type RouteSectionProps } from "@solidjs/router";
+import { type RouteSectionProps, useNavigate } from "@solidjs/router";
 import { fetchQuery, graphql } from "relay-runtime";
 import { createEffect, createSignal, Show } from "solid-js";
 import { getRequestEvent } from "solid-js/web";
@@ -106,6 +106,7 @@ type SignupInfo = NonNullable<
 
 export default function SignupPage(props: RouteSectionProps) {
   const { t, i18n } = useLingui();
+  const navigate = useNavigate();
   const [signupInfo, setSignupInfo] = createSignal<SignupInfo | null>(null);
   const [verifying, setVerifying] = createSignal(true);
   const [invalid, setInvalid] = createSignal(false);
@@ -279,7 +280,7 @@ export default function SignupPage(props: RouteSectionProps) {
             // Session created successfully, set cookie and redirect
             setSessionCookie(response.completeSignup.id).then((success) => {
               if (success) {
-                window.location.href = "/?filter=recommendations";
+                navigate("/?filter=recommendations");
               }
             });
           } else if (

--- a/web-next/src/routes/sign/up/[token].tsx
+++ b/web-next/src/routes/sign/up/[token].tsx
@@ -237,6 +237,23 @@ export default function SignupPage(props: RouteSectionProps) {
     const name = nameInput.value.trim();
     const bio = bioInput?.value?.trim() || "";
 
+    // Validate all fields before submission
+    const usernameError = validateUsername(username);
+    const nameError = validateDisplayName(name);
+    const bioError = validateBio(bio);
+
+    // Set field errors
+    setFieldErrors({
+      username: usernameError as SignupUsernameError | null,
+      name: nameError as SignupDisplayNameError | null,
+      bio: bioError as SignupBioError | null,
+    });
+
+    // Don't submit if there are validation errors
+    if (usernameError || nameError || bioError) {
+      return;
+    }
+
     setSubmitting(true);
 
     completeSignup({


### PR DESCRIPTION
Implement SignUp feature in web-next

write codes with claude code.

<img width="767" height="755" alt="image" src="https://github.com/user-attachments/assets/7004716d-3758-43a9-bd63-08eb3f6850f2" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a user sign-up flow with invitation verification, including a dedicated signup page for completing registration.
  * Added support for verifying signup tokens, handling validation errors, and automatically establishing mutual following with inviters.
  * Expanded GraphQL schema to include signup-related queries and mutations.
  * Enhanced localization with new translations for sign-up fields, validation messages, and guidance in English, Japanese, Korean, Simplified and Traditional Chinese.
  * Added user input validation for usernames, display names, and bios with detailed error feedback.
  * Added toast notifications for user feedback during signup.
  * Improved session management with refined session object representation and centralized session type definition.
  * Updated session cookie expiration handling during login to use dynamic expiration values.

* **Bug Fixes**
  * Improved error handling and validation feedback during the sign-up process.

* **Documentation**
  * Updated code of conduct agreement and explanatory texts for the sign-up process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->