### PR TITLE
Fix Docker build for pull requests in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,11 +47,12 @@ jobs:
         else
           echo arch=amd64 >> "$GITHUB_OUTPUT"
         fi
-    - uses: docker/build-push-action@v6
+    - if: github.event_name == 'push'
+      uses: docker/build-push-action@v6
       with:
         pull: "true"
-        push: ${{ github.event_name == 'push' && 'true' || 'false' }}
-        no-cache: ${{ github.event_name == 'push' && 'false' || 'true' }}
+        push: "true"
+        no-cache: "false"
         build-args:
           GIT_COMMIT=${{ github.sha }}
         tags: ghcr.io/${{ github.repository }}:git-${{ github.sha }}-${{ steps.arch.outputs.arch }}
@@ -68,6 +69,27 @@ jobs:
           type=registry,ref=ghcr.io/${{ github.repository }}:build-cache-${{ steps.arch.outputs.arch }}
         cache-to:
           type=registry,ref=ghcr.io/${{ github.repository }}:build-cache-${{ steps.arch.outputs.arch }},mode=max
+        provenance: false
+    - if: github.event_name == 'pull_request'
+      uses: docker/build-push-action@v6
+      with:
+        pull: "true"
+        push: "false"
+        no-cache: "true"
+        build-args:
+          GIT_COMMIT=${{ github.sha }}
+        tags: ghcr.io/${{ github.repository }}:git-${{ github.sha }}-${{ steps.arch.outputs.arch }}
+        labels: |
+          org.opencontainers.image.revision=${{ github.sha }}
+        annotations: |
+          org.opencontainers.image.title=Hackers' Pub
+          org.opencontainers.image.description=ActivityPub-enabled social network for hackers
+          org.opencontainers.image.url=https://hackers.pub/
+          org.opencontainers.image.source=https://github.com/dahlia/hackerspub
+          org.opencontainers.image.revision=${{ github.sha }}
+          org.opencontainers.image.licenses=AGPL-3.0-only
+        cache-from:
+          type=registry,ref=ghcr.io/${{ github.repository }}:build-cache-${{ steps.arch.outputs.arch }}
         provenance: false
 
   manifest:


### PR DESCRIPTION
## Summary
- Fix Docker build failures in GitHub Actions for pull requests
- Separate build steps for push vs pull_request events
- Pull requests now build without pushing to registry and use no-cache
- Push events continue to build with push and cache optimization

## Changes
- Split single Docker build step into two conditional steps
- Pull request builds: `push: false`, `no-cache: true`
- Push builds: `push: true`, `no-cache: false`
- Both steps maintain same build args, tags, and annotations

## Test plan
- [x] Verify CI passes on this PR (pull_request event)
- [ ] Verify CI still works correctly on merge to main (push event)
- [ ] Confirm no Docker registry push occurs during PR builds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow to separately handle Docker image builds for push and pull request events, improving clarity and reliability of automated builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->