### PR TITLE
Fix server response when failed to load session or account

### DIFF
--- a/graphql/builder.ts
+++ b/graphql/builder.ts
@@ -29,22 +29,25 @@ import {
 import { createGraphQLError } from "graphql-yoga";
 import type Keyv from "keyv";
 
-export interface Context {
+export interface ServerContext {
   db: Database;
   kv: Keyv;
   disk: Disk;
   email: Transport;
   fedCtx: RequestContext<ContextData>;
-  session: Session | undefined;
-  account: Account & { actor: Actor } | undefined;
   request: Request;
   connectionInfo?: Deno.ServeHandlerInfo<Deno.Addr>;
+}
+
+export interface UserContext extends ServerContext {
+  session: Session | undefined;
+  account: Account & { actor: Actor } | undefined;
 }
 
 export interface PothosTypes {
   DefaultFieldNullability: false;
   DrizzleRelations: typeof relations;
-  Context: Context;
+  Context: UserContext;
   AuthScopes: {
     signed: boolean;
     moderator: boolean;

--- a/graphql/main.ts
+++ b/graphql/main.ts
@@ -1,7 +1,3 @@
-import type { Account, Actor } from "@hackerspub/models/schema";
-import { getSession } from "@hackerspub/models/session";
-import { type Uuid, validateUuid } from "@hackerspub/models/uuid";
-import { getCookies } from "@std/http/cookie";
 import * as models from "./ai.ts";
 import { db } from "./db.ts";
 import { drive } from "./drive.ts";
@@ -13,37 +9,12 @@ import { createYogaServer } from "./mod.ts";
 const yogaServer = createYogaServer();
 
 Deno.serve({ port: 8080 }, async (req, info) => {
-  let sessionId: Uuid | undefined = undefined;
-  const authorization = req.headers.get("Authorization");
-  if (authorization && authorization.startsWith("Bearer ")) {
-    const uuid = authorization.slice(7).trim();
-    if (validateUuid(uuid)) sessionId = uuid;
-  }
-  if (sessionId == null) {
-    const cookies = getCookies(req.headers);
-    if (validateUuid(cookies.session)) sessionId = cookies.session;
-  }
-  let session = sessionId == null ? undefined : await getSession(kv, sessionId);
-
-  let account: Account & { actor: Actor } | undefined = undefined;
-  if (session != null) {
-    account = await db.query.accountTable.findFirst({
-      where: { id: session.accountId },
-      with: {
-        actor: true,
-      },
-    });
-    if (account == null) session = undefined;
-  }
-
   const disk = drive.use();
   return yogaServer.fetch(req, {
     db,
     kv,
     disk,
     email,
-    session,
-    account,
     fedCtx: federation.createContext(req, { db, kv, disk, models }),
     request: req,
     connectionInfo: info,

--- a/graphql/mod.ts
+++ b/graphql/mod.ts
@@ -10,7 +10,7 @@ import "./poll.ts";
 import "./post.ts";
 import "./reactable.ts";
 import "./signup.ts";
-export type { Context } from "./builder.ts";
+export type { UserContext as Context } from "./builder.ts";
 export { createYogaServer } from "./server.ts";
 
 export const schema: GraphQLSchema = builder.toSchema();

--- a/graphql/server.ts
+++ b/graphql/server.ts
@@ -1,16 +1,56 @@
+import type { Account, Actor } from "@hackerspub/models/schema";
+import { getSession } from "@hackerspub/models/session";
+import { type Uuid, validateUuid } from "@hackerspub/models/uuid";
+import { getCookies } from "@std/http/cookie";
 import { execute } from "graphql";
 import {
   createYoga,
   type Plugin as EnvelopPlugin,
   type YogaServerInstance,
 } from "graphql-yoga";
-import type { Context } from "./builder.ts";
+import type { ServerContext, UserContext } from "./builder.ts";
 import { schema as graphqlSchema } from "./mod.ts";
 
-export function createYogaServer(): YogaServerInstance<Context, Context> {
+export function createYogaServer(): YogaServerInstance<
+  ServerContext,
+  UserContext
+> {
   return createYoga({
     schema: graphqlSchema,
-    context: (ctx) => ctx,
+    context: async (ctx) => {
+      const { request: req, db, kv } = ctx;
+      let sessionId: Uuid | undefined = undefined;
+      const authorization = req.headers.get("Authorization");
+      if (authorization && authorization.startsWith("Bearer ")) {
+        const uuid = authorization.slice(7).trim();
+        if (validateUuid(uuid)) sessionId = uuid;
+      }
+      if (sessionId == null) {
+        const cookies = getCookies(req.headers);
+        if (validateUuid(cookies.session)) sessionId = cookies.session;
+      }
+
+      let session = sessionId == null
+        ? undefined
+        : await getSession(kv, sessionId);
+      let account: Account & { actor: Actor } | undefined;
+
+      if (session != null) {
+        account = await db.query.accountTable.findFirst({
+          where: { id: session.accountId },
+          with: {
+            actor: true,
+          },
+        });
+        if (account == null) session = undefined;
+      }
+
+      return {
+        session,
+        account,
+        ...ctx,
+      };
+    },
     plugins: [{
       onExecute: ({ setExecuteFn, context }) => {
         const isNoPropagate =


### PR DESCRIPTION
Server response when DB connetion is failed while loading session & account

## Before

```
Object.assign(new SyntaxError("Unexpected token 'I', \"Internal S\"... is not valid JSON"), {
    stack: "SyntaxError: Unexpected token 'I', \"Internal S\"... is not valid JSON\n    at parse (\x3Canonymous>)\n    at packageData (ext:deno_fetch/22_body.js:421:14)\n    at consumeBody (ext:deno_fetch/22_body.js:274:12)\n    at eventLoopTick (ext:core/01_core.js:179:7)\n    at async eval (/Users/perlmint/Documents/hackerspub/web-next/src/RelayEnvironment.tsx?tsr-directive-use-server=:26:10)\n    at async handleServerFunction (/Users/perlmint/Documents/hackerspub/node_modules/.deno/@solidjs+start@1.1.7_2/node_modules/@solidjs/start/dist/runtime/server-handler.js:115:18)\n    at async _callHandler (/Users/perlmint/Documents/hackerspub/node_modules/.deno/h3@1.15.3/node_modules/h3/dist/index.mjs:1862:16)\n    at async /Users/perlmint/Documents/hackerspub/node_modules/.deno/h3@1.15.3/node_modules/h3/dist/index.mjs:2003:19\n    at async Object.callAsync (/Users/perlmint/Documents/hackerspub/node_modules/.deno/unctx@2.4.1/node_modules/unctx/dist/index.mjs:72:16)\n    at async ServerImpl.toNodeHandle (/Users/perlmint/Documents/hackerspub/node_modules/.deno/h3@1.15.3/node_modules/h3/dist/index.mjs:2295:7)"
}))
```

## After

```
errors: $R[1] = [$R[2] = {
    message: "Unexpected error.",
    extensions: $R[3] = {
        code: "INTERNAL_SERVER_ERROR"
    }
}]
```




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced user session and account retrieval for more reliable user context in server requests.

* **Refactor**
  * Improved internal context design by separating server and user-specific data.
  * Updated type exports to align with the new context structure.

No visible changes to the user interface or workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->