### PR TITLE
feature: Implement Remote Follow

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,6 +1,6 @@
 MODE=development # development, test, production
 ORIGIN=https://example.com  # base url of server
-PRODUCTION_ACTOR_HANDLE=@yourFedifyId@hackers.pub #if enviroments is "development", replace development_id(ngrok) into production id that you used
+PRODUCTION_ACTOR_HANDLE=@yourFedifyId@hackers.pub #if current environments is "development", replace ngrok_fediverse_id into real_fediverse_id that you used. (ngrok_fediverse_id is not found in production)
 DATABASE_URL=postgresql://localhost/hackerspub
 KV_URL=file:///tmp/kv.db
 SECRET_KEY=  # openssl rand -hex 32

--- a/.env.sample
+++ b/.env.sample
@@ -1,5 +1,6 @@
 MODE=development # development, test, production
 ORIGIN=https://example.com  # base url of server
+PRODUCTION_ACTOR_HANDLE=@yourFedifyId@hackers.pub #if enviroments is "development", replace development_id(ngrok) into production id that you used
 DATABASE_URL=postgresql://localhost/hackerspub
 KV_URL=file:///tmp/kv.db
 SECRET_KEY=  # openssl rand -hex 32

--- a/web/components/Profile.tsx
+++ b/web/components/Profile.tsx
@@ -35,7 +35,7 @@ export function Profile(
   );
   return (
     <Translation>
-      {(t) => (
+      {(t, language) => (
         <>
           {relationship?.incoming === "block"
             ? (
@@ -183,6 +183,7 @@ export function Profile(
                     <RemoteFollowButton
                       actorHandle={actor.handle}
                       actorName={actor.name || actor.username}
+                      language={language}
                     />
                   </div>
                 )

--- a/web/components/Profile.tsx
+++ b/web/components/Profile.tsx
@@ -10,6 +10,7 @@ import { Link } from "../islands/Link.tsx";
 import { Button } from "./Button.tsx";
 import { Msg, Translation } from "./Msg.tsx";
 import { PageTitle } from "./PageTitle.tsx";
+import { RemoteFollowButton } from "../islands/RemoteFollowButton.tsx";
 
 export interface ProfileProps {
   actor: Actor & { successor: Actor | null };
@@ -174,12 +175,10 @@ export function Profile(
             {relationship === null
               ? (
                 <div class="shrink-0">
-                  <Button
-                    class="ml-4 mt-2 h-9"
-                    type="button"
-                  >
-                    <Msg $key="profile.follow" />
-                  </Button>
+                  <RemoteFollowButton
+                    actorHandle={actor.handle}
+                    actorName={actor.name ?? undefined}
+                  />
                 </div>
               )
               : relationship.outgoing === "none"

--- a/web/components/Profile.tsx
+++ b/web/components/Profile.tsx
@@ -7,10 +7,10 @@ import { compactUrl } from "@hackerspub/models/url";
 import { escape } from "@std/html/entities";
 import { ConfirmForm } from "../islands/ConfirmForm.tsx";
 import { Link } from "../islands/Link.tsx";
+import { RemoteFollowButton } from "../islands/RemoteFollowButton.tsx";
 import { Button } from "./Button.tsx";
 import { Msg, Translation } from "./Msg.tsx";
 import { PageTitle } from "./PageTitle.tsx";
-import { RemoteFollowButton } from "../islands/RemoteFollowButton.tsx";
 
 export interface ProfileProps {
   actor: Actor & { successor: Actor | null };
@@ -18,10 +18,12 @@ export interface ProfileProps {
   relationship: Relationship | null;
   links?: AccountLink[];
   profileHref: string;
+  signedAccount?: { id: string; actor: { id: string } } | null;
 }
 
 export function Profile(
-  { actor, actorMentions, profileHref, relationship, links }: ProfileProps,
+  { actor, actorMentions, profileHref, relationship, links, signedAccount }:
+    ProfileProps,
 ) {
   const bioHtml = preprocessContentHtml(
     actor.bioHtml ?? "",
@@ -172,49 +174,51 @@ export function Profile(
                   />
                 )}
             </PageTitle>
-            {relationship === null
-              ? (
-                <div class="shrink-0">
-                  <RemoteFollowButton
-                    actorHandle={actor.handle}
-                    actorName={actor.name ?? undefined}
-                  />
-                </div>
-              )
-              : relationship.outgoing === "none"
-              ? (
-                // 로그인했지만 팔로우하지 않은 상태 -> 팔로우 버튼
-                <form
-                  method="post"
-                  action={`${profileHref}/follow`}
-                  class="shrink-0"
-                >
-                  <Button
-                    disabled={relationship?.incoming === "block"}
-                    class="ml-4 mt-2 h-9"
-                  >
-                    {relationship.incoming === "follow"
-                      ? <Msg $key="profile.followBack" />
-                      : <Msg $key="profile.follow" />}
-                  </Button>
-                </form>
-              )
-              : relationship.incoming !== "block" &&
-                relationship.outgoing !== "block" &&
-                (
-                  // 팔로우했거나 요청 중인 상태 -> 언팔로우/요청취소 버튼
+            {signedAccount?.actor.id !== actor.id && (
+              relationship === null
+                ? (
+                  <div class="shrink-0">
+                    <RemoteFollowButton
+                      actorHandle={actor.handle}
+                      actorName={actor.name || actor.username}
+                    />
+                  </div>
+                )
+                : relationship?.outgoing === "none"
+                ? (
+                  // 로그인했지만 팔로우하지 않은 상태 -> 팔로우 버튼
                   <form
                     method="post"
-                    action={`${profileHref}/unfollow`}
+                    action={`${profileHref}/follow`}
                     class="shrink-0"
                   >
-                    <Button class="ml-4 mt-2 h-9">
-                      {relationship.outgoing === "follow"
-                        ? <Msg $key="profile.unfollow" />
-                        : <Msg $key="profile.cancelRequest" />}
+                    <Button
+                      disabled={relationship?.incoming === "block"}
+                      class="ml-4 mt-2 h-9"
+                    >
+                      {relationship.incoming === "follow"
+                        ? <Msg $key="profile.followBack" />
+                        : <Msg $key="profile.follow" />}
                     </Button>
                   </form>
-                )}
+                )
+                : relationship?.incoming !== "block" &&
+                  relationship?.outgoing !== "block" &&
+                  (
+                    // 팔로우했거나 요청 중인 상태 -> 언팔로우/요청취소 버튼
+                    <form
+                      method="post"
+                      action={`${profileHref}/unfollow`}
+                      class="shrink-0"
+                    >
+                      <Button class="ml-4 mt-2 h-9">
+                        {relationship?.outgoing === "follow"
+                          ? <Msg $key="profile.unfollow" />
+                          : <Msg $key="profile.cancelRequest" />}
+                      </Button>
+                    </form>
+                  )
+            )}
             {relationship != null &&
               (
                 <div class="pl-3 pt-3.5">

--- a/web/components/Profile.tsx
+++ b/web/components/Profile.tsx
@@ -67,6 +67,7 @@ export function Profile(
                         width={18}
                         height={18}
                         class="inline-block align-top mt-0.5 mr-1"
+                        alt="Profile img"
                       />
                       {actor.successor.name == null
                         ? actor.successor.username
@@ -103,6 +104,7 @@ export function Profile(
                   class={`mb-5 mr-4 ${
                     actor.successorId == null ? "" : "grayscale"
                   }`}
+                  alt="Profile img"
                 />
               </a>
             )}

--- a/web/components/Profile.tsx
+++ b/web/components/Profile.tsx
@@ -171,8 +171,20 @@ export function Profile(
                   />
                 )}
             </PageTitle>
-            {relationship?.outgoing === "none"
+            {relationship === null
               ? (
+                <div class="shrink-0">
+                  <Button
+                    class="ml-4 mt-2 h-9"
+                    type="button"
+                  >
+                    <Msg $key="profile.follow" />
+                  </Button>
+                </div>
+              )
+              : relationship.outgoing === "none"
+              ? (
+                // 로그인했지만 팔로우하지 않은 상태 -> 팔로우 버튼
                 <form
                   method="post"
                   action={`${profileHref}/follow`}
@@ -188,9 +200,10 @@ export function Profile(
                   </Button>
                 </form>
               )
-              : relationship != null && relationship.incoming !== "block" &&
+              : relationship.incoming !== "block" &&
                 relationship.outgoing !== "block" &&
                 (
+                  // 팔로우했거나 요청 중인 상태 -> 언팔로우/요청취소 버튼
                   <form
                     method="post"
                     action={`${profileHref}/unfollow`}

--- a/web/islands/RecommendedActors.tsx
+++ b/web/islands/RecommendedActors.tsx
@@ -147,6 +147,7 @@ export function RecommendedActors(
                       <RemoteFollowButton
                         actorHandle={actor.handle}
                         actorName={actor.name || actor.username}
+                        language={language}
                       />
                     )
                     : (

--- a/web/islands/RecommendedActors.tsx
+++ b/web/islands/RecommendedActors.tsx
@@ -9,6 +9,7 @@ import { Msg, Translation, TranslationSetup } from "../components/Msg.tsx";
 import { PageTitle } from "../components/PageTitle.tsx";
 import type { Language } from "../i18n.ts";
 import { Link } from "./Link.tsx";
+import { RemoteFollowButton } from "./RemoteFollowButton.tsx";
 
 export interface RecommendedActorsProps {
   language: Language;
@@ -17,11 +18,19 @@ export interface RecommendedActorsProps {
   window: number;
   title: boolean;
   class?: string;
+  signedAccount?: Account | null;
 }
 
 export function RecommendedActors(
-  { language, actors, actorMentions, window, title, class: klass }:
-    RecommendedActorsProps,
+  {
+    language,
+    actors,
+    actorMentions,
+    window,
+    title,
+    class: klass,
+    signedAccount,
+  }: RecommendedActorsProps,
 ) {
   const [shownActors, setShownActors] = useState(actors.slice(0, window));
   const [hiddenActors, setHiddenActors] = useState(actors.slice(window));
@@ -133,41 +142,52 @@ export function RecommendedActors(
                       }}
                     />
                   </div>
-                  <Button
-                    class="mt-4 w-full grow-0"
-                    disabled={followingActors.has(actor.id)}
-                    onClick={() => {
-                      setHiddenActors((hiddenActors) => hiddenActors.slice(1));
-                      setFollowingActors((actors) => {
-                        const s = new Set(actors);
-                        s.add(actor.id);
-                        return s;
-                      });
-                      fetch(
-                        actor.accountId == null
-                          ? `/${actor.handle}/follow`
-                          : `/@${actor.username}/follow`,
-                        {
-                          method: "POST",
-                        },
-                      ).then(() => {
-                        setShownActors((actors) => [
-                          ...actors.slice(0, index),
-                          ...hiddenActors.slice(0, 1),
-                          ...actors.slice(index + 1),
-                        ]);
-                        setFollowingActors((actors) => {
-                          const s = new Set(actors);
-                          s.delete(actor.id);
-                          return s;
-                        });
-                      });
-                    }}
-                  >
-                    {followingActors.has(actor.id)
-                      ? <Msg $key="recommendedActors.following" />
-                      : <Msg $key="recommendedActors.follow" />}
-                  </Button>
+                  {signedAccount == null
+                    ? (
+                      <RemoteFollowButton
+                        actorHandle={actor.handle}
+                        actorName={actor.name || actor.username}
+                      />
+                    )
+                    : (
+                      <Button
+                        class="mt-4 w-full grow-0"
+                        disabled={followingActors.has(actor.id)}
+                        onClick={() => {
+                          setHiddenActors((hiddenActors) =>
+                            hiddenActors.slice(1)
+                          );
+                          setFollowingActors((actors) => {
+                            const s = new Set(actors);
+                            s.add(actor.id);
+                            return s;
+                          });
+                          fetch(
+                            actor.accountId == null
+                              ? `/${actor.handle}/follow`
+                              : `/@${actor.username}/follow`,
+                            {
+                              method: "POST",
+                            },
+                          ).then(() => {
+                            setShownActors((actors) => [
+                              ...actors.slice(0, index),
+                              ...hiddenActors.slice(0, 1),
+                              ...actors.slice(index + 1),
+                            ]);
+                            setFollowingActors((actors) => {
+                              const s = new Set(actors);
+                              s.delete(actor.id);
+                              return s;
+                            });
+                          });
+                        }}
+                      >
+                        {followingActors.has(actor.id)
+                          ? <Msg $key="recommendedActors.following" />
+                          : <Msg $key="recommendedActors.follow" />}
+                      </Button>
+                    )}
                 </div>
               ))}
             </div>

--- a/web/islands/RemoteFollowButton.tsx
+++ b/web/islands/RemoteFollowButton.tsx
@@ -1,0 +1,42 @@
+import { useSignal } from "@preact/signals";
+import { Button } from "../components/Button.tsx";
+import { Msg } from "../components/Msg.tsx";
+import { RemoteFollowModal } from "./RemoteFollowModal.tsx";
+
+export interface RemoteFollowButtonProps {
+  actorHandle: string;
+  actorName?: string;
+}
+
+export function RemoteFollowButton(
+  { actorHandle, actorName }: RemoteFollowButtonProps,
+) {
+  const isModalOpen = useSignal(false);
+
+  const openModal = () => {
+    isModalOpen.value = true;
+  };
+
+  const closeModal = () => {
+    isModalOpen.value = false;
+  };
+
+  return (
+    <>
+      <Button
+        class="ml-4 mt-2 h-9"
+        type="button"
+        onClick={openModal}
+      >
+        <Msg $key="profile.follow" />
+      </Button>
+
+      <RemoteFollowModal
+        isOpen={isModalOpen.value}
+        onClose={closeModal}
+        actorHandle={actorHandle}
+        actorName={actorName}
+      />
+    </>
+  );
+}

--- a/web/islands/RemoteFollowButton.tsx
+++ b/web/islands/RemoteFollowButton.tsx
@@ -1,15 +1,17 @@
 import { useSignal } from "@preact/signals";
 import { Button } from "../components/Button.tsx";
-import { Msg } from "../components/Msg.tsx";
+import { Msg, TranslationSetup } from "../components/Msg.tsx";
+import type { Language } from "../i18n.ts";
 import { RemoteFollowModal } from "./RemoteFollowModal.tsx";
 
 export interface RemoteFollowButtonProps {
   actorHandle: string;
   actorName?: string;
+  language: Language;
 }
 
 export function RemoteFollowButton(
-  { actorHandle, actorName }: RemoteFollowButtonProps,
+  { actorHandle, actorName, language }: RemoteFollowButtonProps,
 ) {
   const isModalOpen = useSignal(false);
 
@@ -22,13 +24,13 @@ export function RemoteFollowButton(
   };
 
   return (
-    <>
+    <TranslationSetup language={language}>
       <Button
         class="ml-4 mt-2 h-9"
         type="button"
         onClick={openModal}
       >
-        <Msg $key="profile.follow" />
+        <Msg $key="remoteFollow.title" />
       </Button>
 
       <RemoteFollowModal
@@ -36,7 +38,8 @@ export function RemoteFollowButton(
         onClose={closeModal}
         actorHandle={actorHandle}
         actorName={actorName}
+        language={language}
       />
-    </>
+    </TranslationSetup>
   );
 }

--- a/web/islands/RemoteFollowModal.tsx
+++ b/web/islands/RemoteFollowModal.tsx
@@ -1,6 +1,7 @@
 import { useSignal } from "@preact/signals";
 import { Button } from "../components/Button.tsx";
 import { Msg, TranslationSetup } from "../components/Msg.tsx";
+import getFixedT from "../i18n.ts";
 import type { Language } from "../i18n.ts";
 import type { ActorInfo } from "../routes/api/webfinger.ts";
 
@@ -73,6 +74,7 @@ export function RemoteFollowModal(
   const errorMessage = useSignal("");
   const isLoading = useSignal(false);
   const actionInfo = useSignal<ActorInfo | null>(null);
+  const t = getFixedT(language);
 
   const validateFediverseId = (id: string): boolean => {
     // Fediverse ID 형식: @username@domain.com 또는 username@domain.com
@@ -95,23 +97,20 @@ export function RemoteFollowModal(
 
     const inputId = fediverseId.value.trim();
     if (!inputId) {
-      errorMessage.value = "Fediverse ID를 입력해주세요.";
+      errorMessage.value = t("remoteFollow.fediverseIdRequired");
       return;
     }
 
     // Fediverse ID 형식 검증
     if (!validateFediverseId(inputId)) {
-      errorMessage.value =
-        "올바른 Fediverse ID 형식이 아닙니다. (@username@domain.com 형식으로 입력해주세요)";
+      errorMessage.value = t("remoteFollow.fediverseIdInvalid");
       return;
     }
 
     // 해커스펍 사용자인지 확인
     if (isHackersPubUser(inputId)) {
       const shouldRedirectToLogin = confirm(
-        "해커스펍 사용자로 보입니다. 로그인하시겠습니까?\n" +
-          "확인: 로그인 페이지로 이동\n" +
-          "취소: 모달 닫기",
+        t("remoteFollow.hackersPubUserConfirm"),
       );
 
       if (shouldRedirectToLogin) {
@@ -140,11 +139,11 @@ export function RemoteFollowModal(
       const data = await response.json();
 
       if (!response.ok) {
-        throw new Error(data.error || "사용자 조회에 실패했습니다.");
+        throw new Error(data.error || t("remoteFollow.userLookupError"));
       }
 
       if (!data.actor) {
-        throw new Error("사용자 정보를 찾을 수 없습니다.");
+        throw new Error(t("remoteFollow.userNotFound"));
       }
 
       // 사용자 정보를 상태에 저장하여 UI에 표시
@@ -154,7 +153,7 @@ export function RemoteFollowModal(
       console.error("Webfinger lookup error:", error);
       errorMessage.value = error instanceof Error
         ? error.message
-        : "사용자 정보 조회 중 오류가 발생했습니다.";
+        : t("remoteFollow.userLookupError");
       actionInfo.value = null;
     } finally {
       isLoading.value = false;
@@ -196,7 +195,7 @@ export function RemoteFollowModal(
       window.open(remoteFollowUrl, "_blank", "noopener,noreferrer");
       onClose();
     } else {
-      errorMessage.value = "해당 서비스의 팔로우 페이지를 찾을 수 없습니다.";
+      errorMessage.value = t("remoteFollow.followServiceNotFound");
     }
   };
 
@@ -237,11 +236,13 @@ export function RemoteFollowModal(
 
           <div class="mb-4">
             <p class="text-sm text-gray-600 dark:text-gray-300 mb-2">
-              {actorName || actorHandle}님을 팔로우하려면 Fediverse ID를
-              입력해주세요.
+              <Msg
+                $key="remoteFollow.description"
+                actorName={actorName || actorHandle}
+              />
             </p>
             <p class="text-xs text-gray-500 dark:text-gray-400">
-              Fediverse ID를 입력하세요 (예: @username@mastodon.social)
+              <Msg $key="remoteFollow.fediverseIdExample" />
             </p>
           </div>
 
@@ -251,12 +252,12 @@ export function RemoteFollowModal(
                 htmlFor="fediverseId"
                 class="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-2"
               >
-                Fediverse ID
+                <Msg $key="remoteFollow.fediverseIdLabel" />
               </label>
               <input
                 id="fediverseId"
                 type="text"
-                placeholder="@username@mastodon.social"
+                placeholder={t("remoteFollow.fediverseIdPlaceholder")}
                 value={fediverseId.value}
                 onInput={handleInputChange}
                 disabled={isLoading.value}
@@ -272,7 +273,7 @@ export function RemoteFollowModal(
               )}
               {isLoading.value && (
                 <p class="text-blue-500 text-xs mt-1">
-                  사용자 정보를 조회 중입니다...
+                  <Msg $key="remoteFollow.lookingUpUser" />
                 </p>
               )}
             </div>
@@ -283,7 +284,7 @@ export function RemoteFollowModal(
                   {actionInfo.value.icon && (
                     <img
                       src={actionInfo.value.icon}
-                      alt="프로필 이미지"
+                      alt={t("remoteFollow.profileImageAlt")}
                       class="w-10 h-10 rounded-full flex-shrink-0"
                     />
                   )}
@@ -324,7 +325,7 @@ export function RemoteFollowModal(
                 onClick={onClose}
                 class="flex-1 bg-gray-100 dark:bg-stone-700 hover:bg-gray-200 dark:hover:bg-stone-600"
               >
-                취소
+                <Msg $key="remoteFollow.cancel" />
               </Button>
               {actionInfo.value
                 ? (
@@ -333,7 +334,7 @@ export function RemoteFollowModal(
                     onClick={handleFollowClick}
                     class="flex-1"
                   >
-                    팔로우하기
+                    <Msg $key="remoteFollow.title" />
                   </Button>
                 )
                 : (
@@ -342,7 +343,9 @@ export function RemoteFollowModal(
                     disabled={isLoading.value}
                     class="flex-1 disabled:opacity-50"
                   >
-                    {isLoading.value ? "조회 중..." : "사용자 조회"}
+                    {isLoading.value
+                      ? <Msg $key="remoteFollow.lookingUpUser" />
+                      : <Msg $key="remoteFollow.lookupUser" />}
                   </Button>
                 )}
             </div>

--- a/web/islands/RemoteFollowModal.tsx
+++ b/web/islands/RemoteFollowModal.tsx
@@ -1,5 +1,7 @@
 import { useSignal } from "@preact/signals";
 import { Button } from "../components/Button.tsx";
+import { Msg, TranslationSetup } from "../components/Msg.tsx";
+import type { Language } from "../i18n.ts";
 import type { ActorInfo } from "../routes/api/webfinger.ts";
 
 export interface RemoteFollowModalProps {
@@ -7,6 +9,7 @@ export interface RemoteFollowModalProps {
   onClose: () => void;
   actorHandle: string;
   actorName?: string;
+  language: Language;
 }
 
 // webfinger template을 사용하여 원격 팔로우 URL 생성
@@ -64,7 +67,7 @@ function generateRemoteFollowUrl(
 }
 
 export function RemoteFollowModal(
-  { isOpen, onClose, actorHandle, actorName }: RemoteFollowModalProps,
+  { isOpen, onClose, actorHandle, actorName, language }: RemoteFollowModalProps,
 ) {
   const fediverseId = useSignal("");
   const errorMessage = useSignal("");
@@ -200,150 +203,152 @@ export function RemoteFollowModal(
   if (!isOpen) return null;
 
   return (
-    <div
-      class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50"
-      onClick={handleBackdropClick}
-    >
-      <div class="bg-white dark:bg-stone-800 rounded-lg p-6 max-w-md w-full mx-4">
-        <div class="flex justify-between items-center mb-4">
-          <h2 class="text-lg font-semibold">
-            원격 팔로우
-          </h2>
-          <button
-            type="button"
-            onClick={onClose}
-            class="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
-          >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              fill="none"
-              viewBox="0 0 24 24"
-              strokeWidth={2}
-              stroke="currentColor"
-              class="w-5 h-5"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M6 18L18 6M6 6l12 12"
-              />
-            </svg>
-          </button>
-        </div>
-
-        <div class="mb-4">
-          <p class="text-sm text-gray-600 dark:text-gray-300 mb-2">
-            {actorName || actorHandle}님을 팔로우하려면 Fediverse ID를
-            입력해주세요.
-          </p>
-          <p class="text-xs text-gray-500 dark:text-gray-400">
-            Fediverse ID를 입력하세요 (예: @username@mastodon.social)
-          </p>
-        </div>
-
-        <form onSubmit={handleSubmit}>
-          <div class="mb-4">
-            <label
-              htmlFor="fediverseId"
-              class="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-2"
-            >
-              Fediverse ID
-            </label>
-            <input
-              id="fediverseId"
-              type="text"
-              placeholder="@username@mastodon.social"
-              value={fediverseId.value}
-              onInput={handleInputChange}
-              disabled={isLoading.value}
-              class={`w-full px-3 py-2 border rounded-md bg-white dark:bg-stone-700 text-gray-900 dark:text-gray-100 disabled:opacity-50 ${
-                errorMessage.value
-                  ? "border-red-500 dark:border-red-400"
-                  : "border-gray-300 dark:border-gray-600"
-              }`}
-              required
-            />
-            {errorMessage.value && (
-              <p class="text-red-500 text-xs mt-1">{errorMessage.value}</p>
-            )}
-            {isLoading.value && (
-              <p class="text-blue-500 text-xs mt-1">
-                사용자 정보를 조회 중입니다...
-              </p>
-            )}
-          </div>
-
-          {actionInfo.value && (
-            <div class="mb-4 p-3 border rounded-md bg-gray-50 dark:bg-stone-700">
-              <div class="flex items-start gap-3">
-                {actionInfo.value.icon && (
-                  <img
-                    src={actionInfo.value.icon}
-                    alt="프로필 이미지"
-                    class="w-10 h-10 rounded-full flex-shrink-0"
-                  />
-                )}
-                <div class="flex-1">
-                  <h4 class="font-medium text-gray-900 dark:text-gray-100">
-                    {actionInfo.value.name ||
-                      actionInfo.value.preferredUsername ||
-                      actionInfo.value.handle.split("@")[0]}
-                  </h4>
-                  <p class="text-sm text-gray-600 dark:text-gray-400">
-                    {actionInfo.value.handle}
-                  </p>
-                  {actionInfo.value.software &&
-                    actionInfo.value.software !== "unknown" && (
-                    <p class="text-xs text-gray-500 dark:text-gray-500">
-                      {actionInfo.value.software.charAt(0).toUpperCase() +
-                        actionInfo.value.software.slice(1)}
-                    </p>
-                  )}
-                  {actionInfo.value.summary && (
-                    <p
-                      class="text-xs text-gray-600 dark:text-gray-400 mt-1"
-                      style="display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden;"
-                    >
-                      {actionInfo.value.summary.replace(/<[^>]*>/g, "")
-                        .substring(0, 100)}
-                      {actionInfo.value.summary.length > 100 ? "..." : ""}
-                    </p>
-                  )}
-                </div>
-              </div>
-            </div>
-          )}
-
-          <div class="flex gap-3">
-            <Button
+    <TranslationSetup language={language}>
+      <div
+        class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50"
+        onClick={handleBackdropClick}
+      >
+        <div class="bg-white dark:bg-stone-800 rounded-lg p-6 max-w-md w-full mx-4">
+          <div class="flex justify-between items-center mb-4">
+            <h2 class="text-lg font-semibold">
+              <Msg $key="remoteFollow.title" />
+            </h2>
+            <button
               type="button"
               onClick={onClose}
-              class="flex-1 bg-gray-100 dark:bg-stone-700 hover:bg-gray-200 dark:hover:bg-stone-600"
+              class="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
             >
-              취소
-            </Button>
-            {actionInfo.value
-              ? (
-                <Button
-                  type="button"
-                  onClick={handleFollowClick}
-                  class="flex-1"
-                >
-                  팔로우하기
-                </Button>
-              )
-              : (
-                <Button
-                  type="submit"
-                  disabled={isLoading.value}
-                  class="flex-1 disabled:opacity-50"
-                >
-                  {isLoading.value ? "조회 중..." : "사용자 조회"}
-                </Button>
-              )}
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                strokeWidth={2}
+                stroke="currentColor"
+                class="w-5 h-5"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M6 18L18 6M6 6l12 12"
+                />
+              </svg>
+            </button>
           </div>
-        </form>
+
+          <div class="mb-4">
+            <p class="text-sm text-gray-600 dark:text-gray-300 mb-2">
+              {actorName || actorHandle}님을 팔로우하려면 Fediverse ID를
+              입력해주세요.
+            </p>
+            <p class="text-xs text-gray-500 dark:text-gray-400">
+              Fediverse ID를 입력하세요 (예: @username@mastodon.social)
+            </p>
+          </div>
+
+          <form onSubmit={handleSubmit}>
+            <div class="mb-4">
+              <label
+                htmlFor="fediverseId"
+                class="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-2"
+              >
+                Fediverse ID
+              </label>
+              <input
+                id="fediverseId"
+                type="text"
+                placeholder="@username@mastodon.social"
+                value={fediverseId.value}
+                onInput={handleInputChange}
+                disabled={isLoading.value}
+                class={`w-full px-3 py-2 border rounded-md bg-white dark:bg-stone-700 text-gray-900 dark:text-gray-100 disabled:opacity-50 ${
+                  errorMessage.value
+                    ? "border-red-500 dark:border-red-400"
+                    : "border-gray-300 dark:border-gray-600"
+                }`}
+                required
+              />
+              {errorMessage.value && (
+                <p class="text-red-500 text-xs mt-1">{errorMessage.value}</p>
+              )}
+              {isLoading.value && (
+                <p class="text-blue-500 text-xs mt-1">
+                  사용자 정보를 조회 중입니다...
+                </p>
+              )}
+            </div>
+
+            {actionInfo.value && (
+              <div class="mb-4 p-3 border rounded-md bg-gray-50 dark:bg-stone-700">
+                <div class="flex items-start gap-3">
+                  {actionInfo.value.icon && (
+                    <img
+                      src={actionInfo.value.icon}
+                      alt="프로필 이미지"
+                      class="w-10 h-10 rounded-full flex-shrink-0"
+                    />
+                  )}
+                  <div class="flex-1">
+                    <h4 class="font-medium text-gray-900 dark:text-gray-100">
+                      {actionInfo.value.name ||
+                        actionInfo.value.preferredUsername ||
+                        actionInfo.value.handle.split("@")[0]}
+                    </h4>
+                    <p class="text-sm text-gray-600 dark:text-gray-400">
+                      {actionInfo.value.handle}
+                    </p>
+                    {actionInfo.value.software &&
+                      actionInfo.value.software !== "unknown" && (
+                      <p class="text-xs text-gray-500 dark:text-gray-500">
+                        {actionInfo.value.software.charAt(0).toUpperCase() +
+                          actionInfo.value.software.slice(1)}
+                      </p>
+                    )}
+                    {actionInfo.value.summary && (
+                      <p
+                        class="text-xs text-gray-600 dark:text-gray-400 mt-1"
+                        style="display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden;"
+                      >
+                        {actionInfo.value.summary.replace(/<[^>]*>/g, "")
+                          .substring(0, 100)}
+                        {actionInfo.value.summary.length > 100 ? "..." : ""}
+                      </p>
+                    )}
+                  </div>
+                </div>
+              </div>
+            )}
+
+            <div class="flex gap-3">
+              <Button
+                type="button"
+                onClick={onClose}
+                class="flex-1 bg-gray-100 dark:bg-stone-700 hover:bg-gray-200 dark:hover:bg-stone-600"
+              >
+                취소
+              </Button>
+              {actionInfo.value
+                ? (
+                  <Button
+                    type="button"
+                    onClick={handleFollowClick}
+                    class="flex-1"
+                  >
+                    팔로우하기
+                  </Button>
+                )
+                : (
+                  <Button
+                    type="submit"
+                    disabled={isLoading.value}
+                    class="flex-1 disabled:opacity-50"
+                  >
+                    {isLoading.value ? "조회 중..." : "사용자 조회"}
+                  </Button>
+                )}
+            </div>
+          </form>
+        </div>
       </div>
-    </div>
+    </TranslationSetup>
   );
 }

--- a/web/islands/RemoteFollowModal.tsx
+++ b/web/islands/RemoteFollowModal.tsx
@@ -8,11 +8,85 @@ export interface RemoteFollowModalProps {
   actorName?: string;
 }
 
+interface ActorData {
+  id?: string;
+  type: string;
+  preferredUsername?: string;
+  name?: string;
+  summary?: string;
+  url?: string;
+  icon?: string;
+  image?: string;
+  followersCount?: number;
+  followingCount?: number;
+  handle: string;
+  profileUrl: string;
+  domain: string;
+  software: string;
+  template?: string;
+}
+
+// webfinger template을 사용하여 원격 팔로우 URL 생성
+function generateRemoteFollowUrl(
+  actorHandle: string,
+  template?: string,
+  domain?: string,
+  software?: string,
+): string | null {
+  // 1순위: webfinger에서 제공하는 template 사용
+  if (template) {
+    const encodedHandle = encodeURIComponent(actorHandle);
+    const url = template.replace("{uri}", encodedHandle);
+    return url;
+  }
+
+  // 2순위: 도메인과 소프트웨어 정보가 있을 경우 폴백 방식 사용
+  if (!domain) return null;
+
+  const encodedHandle = encodeURIComponent(actorHandle);
+  const encodedAcct = encodeURIComponent(
+    actorHandle.startsWith("@") ? actorHandle.slice(1) : actorHandle,
+  );
+
+  switch (software?.toLowerCase()) {
+    case "mastodon":
+    case "pleroma":
+    case "akkoma":
+    case "pixelfed":
+    case "gotosocial":
+    case "takahe":
+      return `https://${domain}/authorize_interaction?uri=${encodedHandle}`;
+
+    case "misskey":
+    case "foundkey":
+    case "calckey":
+    case "firefish":
+    case "iceshrimp":
+      return `https://${domain}/authorize-follow?acct=${encodedAcct}`;
+
+    case "peertube":
+      return `https://${domain}/remote-interaction?uri=${encodedHandle}`;
+
+    case "lemmy":
+      return `https://${domain}/search?q=${encodedHandle}&type=Users`;
+
+    case "friendica":
+    case "hubzilla":
+      return `https://${domain}/follow?url=${encodedHandle}`;
+
+    default:
+      // 표준 ActivityPub 방식 폴백
+      return `https://${domain}/authorize_interaction?uri=${encodedHandle}`;
+  }
+}
+
 export function RemoteFollowModal(
   { isOpen, onClose, actorHandle, actorName }: RemoteFollowModalProps,
 ) {
   const fediverseId = useSignal("");
   const errorMessage = useSignal("");
+  const isLoading = useSignal(false);
+  const actorData = useSignal<ActorData | null>(null);
 
   const validateFediverseId = (id: string): boolean => {
     // Fediverse ID 형식: @username@domain.com 또는 username@domain.com
@@ -26,7 +100,8 @@ export function RemoteFollowModal(
     const withoutAt = normalizedId.startsWith("@")
       ? normalizedId.slice(1)
       : normalizedId;
-    return withoutAt.endsWith("@hackerspub.com");
+    return withoutAt.endsWith("@hackerspub.com") ||
+      withoutAt.endsWith("@hackers.pub");
   };
 
   const handleSubmit = async (e: Event) => {
@@ -63,20 +138,40 @@ export function RemoteFollowModal(
       return;
     }
 
-    // 일반 Fediverse 사용자: 원격 팔로우 처리
+    // 일반 Fediverse 사용자: 서버 API를 통한 webfinger 조회
     try {
-      const normalizedId = inputId.startsWith("@") ? inputId.slice(1) : inputId;
-      const [_, domain] = normalizedId.split("@");
+      isLoading.value = true;
+      errorMessage.value = "";
 
-      // 원격 팔로우를 위한 URL 생성 (ActivityPub 표준)
-      const followUrl = `https://${domain}/authorize_interaction?uri=${
-        encodeURIComponent(actorHandle)
-      }`;
-      window.open(followUrl, "_blank");
-      onClose();
+      const response = await fetch("/api/webfinger", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ fediverseId: inputId }),
+      });
+
+      const data = await response.json();
+
+      if (!response.ok) {
+        throw new Error(data.error || "사용자 조회에 실패했습니다.");
+      }
+
+      if (!data.actor) {
+        throw new Error("사용자 정보를 찾을 수 없습니다.");
+      }
+
+      // 사용자 정보를 상태에 저장하여 UI에 표시
+      actorData.value = data.actor;
+      console.log("Actor data:", data.actor);
     } catch (error) {
-      console.error("Remote follow error:", error);
-      errorMessage.value = "원격 팔로우 처리 중 오류가 발생했습니다.";
+      console.error("Webfinger lookup error:", error);
+      errorMessage.value = error instanceof Error
+        ? error.message
+        : "사용자 정보 조회 중 오류가 발생했습니다.";
+      actorData.value = null;
+    } finally {
+      isLoading.value = false;
     }
   };
 
@@ -89,9 +184,33 @@ export function RemoteFollowModal(
   const handleInputChange = (e: Event) => {
     const target = e.target as HTMLInputElement;
     fediverseId.value = target.value;
-    // 입력 중일 때 에러 메시지 초기화
+    // 입력 중일 때 에러 메시지 초기화 및 사용자 데이터 초기화
     if (errorMessage.value) {
       errorMessage.value = "";
+    }
+    if (actorData.value) {
+      actorData.value = null;
+    }
+  };
+
+  const handleFollowClick = () => {
+    if (!actorData.value) return;
+
+    const actor = actorData.value;
+    const domain = actor.handle.split("@")[1];
+    const remoteFollowUrl = generateRemoteFollowUrl(
+      actorHandle,
+      actor.template,
+      domain,
+      actor.software,
+    );
+
+    if (remoteFollowUrl) {
+      // 새 탭에서 원격 팔로우 페이지 열기
+      window.open(remoteFollowUrl, "_blank", "noopener,noreferrer");
+      onClose();
+    } else {
+      errorMessage.value = "해당 서비스의 팔로우 페이지를 찾을 수 없습니다.";
     }
   };
 
@@ -153,7 +272,8 @@ export function RemoteFollowModal(
               placeholder="@username@mastodon.social"
               value={fediverseId.value}
               onInput={handleInputChange}
-              class={`w-full px-3 py-2 border rounded-md bg-white dark:bg-stone-700 text-gray-900 dark:text-gray-100 ${
+              disabled={isLoading.value}
+              class={`w-full px-3 py-2 border rounded-md bg-white dark:bg-stone-700 text-gray-900 dark:text-gray-100 disabled:opacity-50 ${
                 errorMessage.value
                   ? "border-red-500 dark:border-red-400"
                   : "border-gray-300 dark:border-gray-600"
@@ -163,7 +283,53 @@ export function RemoteFollowModal(
             {errorMessage.value && (
               <p class="text-red-500 text-xs mt-1">{errorMessage.value}</p>
             )}
+            {isLoading.value && (
+              <p class="text-blue-500 text-xs mt-1">
+                사용자 정보를 조회 중입니다...
+              </p>
+            )}
           </div>
+
+          {actorData.value && (
+            <div class="mb-4 p-3 border rounded-md bg-gray-50 dark:bg-stone-700">
+              <div class="flex items-start gap-3">
+                {actorData.value.icon && (
+                  <img
+                    src={actorData.value.icon}
+                    alt="프로필 이미지"
+                    class="w-10 h-10 rounded-full flex-shrink-0"
+                  />
+                )}
+                <div class="flex-1">
+                  <h4 class="font-medium text-gray-900 dark:text-gray-100">
+                    {actorData.value.name ||
+                      actorData.value.preferredUsername ||
+                      actorData.value.handle.split("@")[0]}
+                  </h4>
+                  <p class="text-sm text-gray-600 dark:text-gray-400">
+                    {actorData.value.handle}
+                  </p>
+                  {actorData.value.software &&
+                    actorData.value.software !== "unknown" && (
+                    <p class="text-xs text-gray-500 dark:text-gray-500">
+                      {actorData.value.software.charAt(0).toUpperCase() +
+                        actorData.value.software.slice(1)}
+                    </p>
+                  )}
+                  {actorData.value.summary && (
+                    <p
+                      class="text-xs text-gray-600 dark:text-gray-400 mt-1"
+                      style="display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden;"
+                    >
+                      {actorData.value.summary.replace(/<[^>]*>/g, "")
+                        .substring(0, 100)}
+                      {actorData.value.summary.length > 100 ? "..." : ""}
+                    </p>
+                  )}
+                </div>
+              </div>
+            </div>
+          )}
 
           <div class="flex gap-3">
             <Button
@@ -173,12 +339,25 @@ export function RemoteFollowModal(
             >
               취소
             </Button>
-            <Button
-              type="submit"
-              class="flex-1"
-            >
-              팔로우
-            </Button>
+            {actorData.value
+              ? (
+                <Button
+                  type="button"
+                  onClick={handleFollowClick}
+                  class="flex-1"
+                >
+                  팔로우하기
+                </Button>
+              )
+              : (
+                <Button
+                  type="submit"
+                  disabled={isLoading.value}
+                  class="flex-1 disabled:opacity-50"
+                >
+                  {isLoading.value ? "조회 중..." : "사용자 조회"}
+                </Button>
+              )}
           </div>
         </form>
       </div>

--- a/web/islands/RemoteFollowModal.tsx
+++ b/web/islands/RemoteFollowModal.tsx
@@ -133,7 +133,7 @@ export function RemoteFollowModal(
         headers: {
           "Content-Type": "application/json",
         },
-        body: JSON.stringify({ fediverseId: inputId, actorHandle }),
+        body: JSON.stringify({ fediverseId: inputId, actorHandle, language }),
       });
 
       const data = await response.json();

--- a/web/islands/RemoteFollowModal.tsx
+++ b/web/islands/RemoteFollowModal.tsx
@@ -1,29 +1,12 @@
 import { useSignal } from "@preact/signals";
 import { Button } from "../components/Button.tsx";
+import type { ActorInfo } from "../routes/api/webfinger.ts";
 
 export interface RemoteFollowModalProps {
   isOpen: boolean;
   onClose: () => void;
   actorHandle: string;
   actorName?: string;
-}
-
-interface ActorData {
-  id?: string;
-  type: string;
-  preferredUsername?: string;
-  name?: string;
-  summary?: string;
-  url?: string;
-  icon?: string;
-  image?: string;
-  followersCount?: number;
-  followingCount?: number;
-  handle: string;
-  profileUrl: string;
-  domain: string;
-  software: string;
-  template?: string;
 }
 
 // webfinger template을 사용하여 원격 팔로우 URL 생성
@@ -86,7 +69,7 @@ export function RemoteFollowModal(
   const fediverseId = useSignal("");
   const errorMessage = useSignal("");
   const isLoading = useSignal(false);
-  const actorData = useSignal<ActorData | null>(null);
+  const actionInfo = useSignal<ActorInfo | null>(null);
 
   const validateFediverseId = (id: string): boolean => {
     // Fediverse ID 형식: @username@domain.com 또는 username@domain.com
@@ -148,7 +131,7 @@ export function RemoteFollowModal(
         headers: {
           "Content-Type": "application/json",
         },
-        body: JSON.stringify({ fediverseId: inputId }),
+        body: JSON.stringify({ fediverseId: inputId, actorHandle }),
       });
 
       const data = await response.json();
@@ -162,14 +145,14 @@ export function RemoteFollowModal(
       }
 
       // 사용자 정보를 상태에 저장하여 UI에 표시
-      actorData.value = data.actor;
+      actionInfo.value = data.actor;
       console.log("Actor data:", data.actor);
     } catch (error) {
       console.error("Webfinger lookup error:", error);
       errorMessage.value = error instanceof Error
         ? error.message
         : "사용자 정보 조회 중 오류가 발생했습니다.";
-      actorData.value = null;
+      actionInfo.value = null;
     } finally {
       isLoading.value = false;
     }
@@ -188,15 +171,15 @@ export function RemoteFollowModal(
     if (errorMessage.value) {
       errorMessage.value = "";
     }
-    if (actorData.value) {
-      actorData.value = null;
+    if (actionInfo.value) {
+      actionInfo.value = null;
     }
   };
 
   const handleFollowClick = () => {
-    if (!actorData.value) return;
+    if (!actionInfo.value) return;
 
-    const actor = actorData.value;
+    const actor = actionInfo.value;
     const domain = actor.handle.split("@")[1];
     const remoteFollowUrl = generateRemoteFollowUrl(
       actorHandle,
@@ -290,40 +273,40 @@ export function RemoteFollowModal(
             )}
           </div>
 
-          {actorData.value && (
+          {actionInfo.value && (
             <div class="mb-4 p-3 border rounded-md bg-gray-50 dark:bg-stone-700">
               <div class="flex items-start gap-3">
-                {actorData.value.icon && (
+                {actionInfo.value.icon && (
                   <img
-                    src={actorData.value.icon}
+                    src={actionInfo.value.icon}
                     alt="프로필 이미지"
                     class="w-10 h-10 rounded-full flex-shrink-0"
                   />
                 )}
                 <div class="flex-1">
                   <h4 class="font-medium text-gray-900 dark:text-gray-100">
-                    {actorData.value.name ||
-                      actorData.value.preferredUsername ||
-                      actorData.value.handle.split("@")[0]}
+                    {actionInfo.value.name ||
+                      actionInfo.value.preferredUsername ||
+                      actionInfo.value.handle.split("@")[0]}
                   </h4>
                   <p class="text-sm text-gray-600 dark:text-gray-400">
-                    {actorData.value.handle}
+                    {actionInfo.value.handle}
                   </p>
-                  {actorData.value.software &&
-                    actorData.value.software !== "unknown" && (
+                  {actionInfo.value.software &&
+                    actionInfo.value.software !== "unknown" && (
                     <p class="text-xs text-gray-500 dark:text-gray-500">
-                      {actorData.value.software.charAt(0).toUpperCase() +
-                        actorData.value.software.slice(1)}
+                      {actionInfo.value.software.charAt(0).toUpperCase() +
+                        actionInfo.value.software.slice(1)}
                     </p>
                   )}
-                  {actorData.value.summary && (
+                  {actionInfo.value.summary && (
                     <p
                       class="text-xs text-gray-600 dark:text-gray-400 mt-1"
                       style="display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden;"
                     >
-                      {actorData.value.summary.replace(/<[^>]*>/g, "")
+                      {actionInfo.value.summary.replace(/<[^>]*>/g, "")
                         .substring(0, 100)}
-                      {actorData.value.summary.length > 100 ? "..." : ""}
+                      {actionInfo.value.summary.length > 100 ? "..." : ""}
                     </p>
                   )}
                 </div>
@@ -339,7 +322,7 @@ export function RemoteFollowModal(
             >
               취소
             </Button>
-            {actorData.value
+            {actionInfo.value
               ? (
                 <Button
                   type="button"

--- a/web/islands/RemoteFollowModal.tsx
+++ b/web/islands/RemoteFollowModal.tsx
@@ -1,0 +1,187 @@
+import { useSignal } from "@preact/signals";
+import { Button } from "../components/Button.tsx";
+
+export interface RemoteFollowModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  actorHandle: string;
+  actorName?: string;
+}
+
+export function RemoteFollowModal(
+  { isOpen, onClose, actorHandle, actorName }: RemoteFollowModalProps,
+) {
+  const fediverseId = useSignal("");
+  const errorMessage = useSignal("");
+
+  const validateFediverseId = (id: string): boolean => {
+    // Fediverse ID 형식: @username@domain.com 또는 username@domain.com
+    const fediverseIdRegex =
+      /^@?([a-zA-Z0-9_.-]+)@([a-zA-Z0-9.-]+\.[a-zA-Z]{2,})$/;
+    return fediverseIdRegex.test(id.trim());
+  };
+
+  const isHackersPubUser = (id: string): boolean => {
+    const normalizedId = id.trim().toLowerCase();
+    const withoutAt = normalizedId.startsWith("@")
+      ? normalizedId.slice(1)
+      : normalizedId;
+    return withoutAt.endsWith("@hackerspub.com");
+  };
+
+  const handleSubmit = async (e: Event) => {
+    e.preventDefault();
+
+    const inputId = fediverseId.value.trim();
+    if (!inputId) {
+      errorMessage.value = "Fediverse ID를 입력해주세요.";
+      return;
+    }
+
+    // Fediverse ID 형식 검증
+    if (!validateFediverseId(inputId)) {
+      errorMessage.value =
+        "올바른 Fediverse ID 형식이 아닙니다. (@username@domain.com 형식으로 입력해주세요)";
+      return;
+    }
+
+    // 해커스펍 사용자인지 확인
+    if (isHackersPubUser(inputId)) {
+      const shouldRedirectToLogin = confirm(
+        "해커스펍 사용자로 보입니다. 로그인하시겠습니까?\n" +
+          "확인: 로그인 페이지로 이동\n" +
+          "취소: 모달 닫기",
+      );
+
+      if (shouldRedirectToLogin) {
+        // 현재 페이지를 returnUrl로 설정하여 로그인 페이지로 이동
+        const returnUrl = encodeURIComponent(window.location.href);
+        window.location.href = `/sign?returnUrl=${returnUrl}`;
+      } else {
+        onClose();
+      }
+      return;
+    }
+
+    // 일반 Fediverse 사용자: 원격 팔로우 처리
+    try {
+      const normalizedId = inputId.startsWith("@") ? inputId.slice(1) : inputId;
+      const [_, domain] = normalizedId.split("@");
+
+      // 원격 팔로우를 위한 URL 생성 (ActivityPub 표준)
+      const followUrl = `https://${domain}/authorize_interaction?uri=${
+        encodeURIComponent(actorHandle)
+      }`;
+      window.open(followUrl, "_blank");
+      onClose();
+    } catch (error) {
+      console.error("Remote follow error:", error);
+      errorMessage.value = "원격 팔로우 처리 중 오류가 발생했습니다.";
+    }
+  };
+
+  const handleBackdropClick = (e: Event) => {
+    if (e.target === e.currentTarget) {
+      onClose();
+    }
+  };
+
+  const handleInputChange = (e: Event) => {
+    const target = e.target as HTMLInputElement;
+    fediverseId.value = target.value;
+    // 입력 중일 때 에러 메시지 초기화
+    if (errorMessage.value) {
+      errorMessage.value = "";
+    }
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50"
+      onClick={handleBackdropClick}
+    >
+      <div class="bg-white dark:bg-stone-800 rounded-lg p-6 max-w-md w-full mx-4">
+        <div class="flex justify-between items-center mb-4">
+          <h2 class="text-lg font-semibold">
+            원격 팔로우
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            class="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth={2}
+              stroke="currentColor"
+              class="w-5 h-5"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </button>
+        </div>
+
+        <div class="mb-4">
+          <p class="text-sm text-gray-600 dark:text-gray-300 mb-2">
+            {actorName || actorHandle}님을 팔로우하려면 Fediverse ID를
+            입력해주세요.
+          </p>
+          <p class="text-xs text-gray-500 dark:text-gray-400">
+            Fediverse ID를 입력하세요 (예: @username@mastodon.social)
+          </p>
+        </div>
+
+        <form onSubmit={handleSubmit}>
+          <div class="mb-4">
+            <label
+              htmlFor="fediverseId"
+              class="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-2"
+            >
+              Fediverse ID
+            </label>
+            <input
+              id="fediverseId"
+              type="text"
+              placeholder="@username@mastodon.social"
+              value={fediverseId.value}
+              onInput={handleInputChange}
+              class={`w-full px-3 py-2 border rounded-md bg-white dark:bg-stone-700 text-gray-900 dark:text-gray-100 ${
+                errorMessage.value
+                  ? "border-red-500 dark:border-red-400"
+                  : "border-gray-300 dark:border-gray-600"
+              }`}
+              required
+            />
+            {errorMessage.value && (
+              <p class="text-red-500 text-xs mt-1">{errorMessage.value}</p>
+            )}
+          </div>
+
+          <div class="flex gap-3">
+            <Button
+              type="button"
+              onClick={onClose}
+              class="flex-1 bg-gray-100 dark:bg-stone-700 hover:bg-gray-200 dark:hover:bg-stone-600"
+            >
+              취소
+            </Button>
+            <Button
+              type="submit"
+              class="flex-1"
+            >
+              팔로우
+            </Button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/web/locales/en.json
+++ b/web/locales/en.json
@@ -418,5 +418,25 @@
     "exhausted": "This invitation link has been exhausted. You need to use another invitation link to join Hackers' Pub.",
     "duplicateEmail": "This email address is already registered with Hackers' Pub. Please use a different email address.",
     "sent": "An email to join Hackers' Pub has been sent to {{email}}. Please check your inbox (it might be in your spam folder)."
+  },
+  "remoteFollow": {
+    "title": "Remote Follow",
+    "description": "To follow {{actorName}}, enter your Fediverse ID.",
+    "fediverseIdLabel": "Fediverse ID",
+    "fediverseIdPlaceholder": "@username@mastodon.social",
+    "fediverseIdExample": "Enter your Fediverse ID (e.g., @username@mastodon.social)",
+    "fediverseIdRequired": "Please enter your Fediverse ID.",
+    "fediverseIdInvalid": "Invalid Fediverse ID format. Please enter in @username@domain.com format.",
+    "hackersPubUserConfirm": "This appears to be a Hackers' Pub user. Would you like to sign in?\nOK: Go to sign in page\nCancel: Close modal",
+    "userLookupError": "Failed to look up user.",
+    "userNotFound": "User information not found.",
+    "userLookupGenericError": "An error occurred while looking up user information.",
+    "profileImageAlt": "Profile image",
+    "lookingUpUser": "Looking up user information...",
+    "followServiceNotFound": "Could not find the follow page for this service.",
+    "cancel": "Cancel",
+    "follow": "Follow",
+    "lookupUser": "Look up user",
+    "lookingUp": "Looking up..."
   }
 }

--- a/web/locales/en.json
+++ b/web/locales/en.json
@@ -437,6 +437,16 @@
     "cancel": "Cancel",
     "follow": "Follow",
     "lookupUser": "Look up user",
-    "lookingUp": "Looking up..."
+    "lookingUp": "Looking up...",
+    "api": {
+      "fediverseIdRequired": "Fediverse ID is required.",
+      "fediverseIdInvalidFormat": "Invalid Fediverse ID format.",
+      "userNotFoundWithStatus": "User not found: {{status}}",
+      "webfingerLookupError": "An error occurred during Webfinger lookup.",
+      "activityPubProfileNotFound": "ActivityPub profile not found.",
+      "objectNotActor": "The retrieved object is not an Actor.",
+      "profileInfoFetchFailed": "Failed to fetch profile information.",
+      "serverError": "Server error occurred."
+    }
   }
 }

--- a/web/locales/ja.json
+++ b/web/locales/ja.json
@@ -421,9 +421,23 @@
     "hackersPubUserConfirm": "これはHackers' Pubユーザーのようです。ログインしますか？\nOK：ログインページへ移動\nキャンセル：モーダルを閉じる",
     "userLookupError": "ユーザーの検索に失敗しました。",
     "userNotFound": "ユーザー情報が見つかりません。",
+    "userLookupGenericError": "ユーザー情報検索中にエラーが発生しました。",
+    "profileImageAlt": "プロフィール画像",
+    "lookingUpUser": "ユーザー情報を取得中...",
+    "followServiceNotFound": "該当サービスのフォローページが見つかりません。",
     "cancel": "キャンセル",
     "follow": "フォローする",
     "lookupUser": "ユーザーを検索",
-    "followExternal": "外部でフォロー"
+    "lookingUp": "検索中...",
+    "api": {
+      "fediverseIdRequired": "フェディバースIDが必要です。",
+      "fediverseIdInvalidFormat": "正しいフェディバースID形式ではありません。",
+      "userNotFoundWithStatus": "ユーザーが見つかりません：{{status}}",
+      "webfingerLookupError": "Webfinger検索中にエラーが発生しました。",
+      "activityPubProfileNotFound": "ActivityPubプロフィールが見つかりません。",
+      "objectNotActor": "取得されたオブジェクトはActorではありません。",
+      "profileInfoFetchFailed": "プロフィール情報を取得できませんでした。",
+      "serverError": "サーバーエラーが発生しました。"
+    }
   }
 }

--- a/web/locales/ja.json
+++ b/web/locales/ja.json
@@ -409,5 +409,21 @@
     "exhausted": "この招待リンクは既に使い切られています。Hackers' Pubに参加するには、別の招待リンクを使用する必要があります。",
     "duplicateEmail": "このメールアドレスは既にHackers' Pubに登録されています。別のメールアドレスをご使用ください。",
     "sent": "Hackers' Pubへの参加メールが{{email}}に送信されました。受信箱をご確認ください。（迷惑メールフォルダにある可能性があります）"
+  },
+  "remoteFollow": {
+    "title": "リモートフォロー",
+    "description": "{{actorName}}さんをフォローするには、フェディバースIDを入力してください。",
+    "fediverseIdLabel": "フェディバースID",
+    "fediverseIdPlaceholder": "@username@mastodon.social",
+    "fediverseIdExample": "フェディバースIDを入力してください（例：@username@mastodon.social）",
+    "fediverseIdRequired": "フェディバースIDを入力してください。",
+    "fediverseIdInvalid": "無効なフェディバースID形式です。@username@domain.com形式で入力してください。",
+    "hackersPubUserConfirm": "これはHackers' Pubユーザーのようです。ログインしますか？\nOK：ログインページへ移動\nキャンセル：モーダルを閉じる",
+    "userLookupError": "ユーザーの検索に失敗しました。",
+    "userNotFound": "ユーザー情報が見つかりません。",
+    "cancel": "キャンセル",
+    "follow": "フォローする",
+    "lookupUser": "ユーザーを検索",
+    "followExternal": "外部でフォロー"
   }
 }

--- a/web/locales/ko.json
+++ b/web/locales/ko.json
@@ -407,5 +407,25 @@
     "exhausted": "이 초대 링크는 이미 소진되었습니다. Hackers' Pub에 가입하려면 다른 초대 링크를 사용해야 합니다.",
     "duplicateEmail": "이 이메일 주소는 이미 Hackers' Pub에 가입되어 있습니다. 다른 이메일 주소를 사용해 주세요.",
     "sent": "Hackers' Pub에 가입하기 위한 이메일이 {{email}}로 발송되었습니다. 받은 편지함을 확인해 주세요. (스팸함에 있을 수도 있습니다.)"
+  },
+  "remoteFollow": {
+    "title": "원격 팔로",
+    "description": "{{actorName}}님을 팔로우하려면 Fediverse ID를 입력해주세요.",
+    "fediverseIdLabel": "Fediverse ID",
+    "fediverseIdPlaceholder": "@username@mastodon.social",
+    "fediverseIdExample": "Fediverse ID를 입력하세요 (예: @username@mastodon.social)",
+    "fediverseIdRequired": "Fediverse ID를 입력해주세요.",
+    "fediverseIdInvalid": "올바른 Fediverse ID 형식이 아닙니다. (@username@domain.com 형식으로 입력해주세요)",
+    "hackersPubUserConfirm": "해커스펍 사용자로 보입니다. 로그인하시겠습니까?\n확인: 로그인 페이지로 이동\n취소: 모달 닫기",
+    "userLookupError": "사용자 조회에 실패했습니다.",
+    "userNotFound": "사용자 정보를 찾을 수 없습니다.",
+    "userLookupGenericError": "사용자 정보 조회 중 오류가 발생했습니다.",
+    "profileImageAlt": "프로필 이미지",
+    "lookingUpUser": "사용자 정보를 조회 중입니다...",
+    "followServiceNotFound": "해당 서비스의 팔로우 페이지를 찾을 수 없습니다.",
+    "cancel": "취소",
+    "follow": "팔로우하기",
+    "lookupUser": "사용자 조회",
+    "lookingUp": "조회 중..."
   }
 }

--- a/web/locales/ko.json
+++ b/web/locales/ko.json
@@ -426,6 +426,16 @@
     "cancel": "취소",
     "follow": "팔로우하기",
     "lookupUser": "사용자 조회",
-    "lookingUp": "조회 중..."
+    "lookingUp": "조회 중...",
+    "api": {
+      "fediverseIdRequired": "Fediverse ID가 필요합니다.",
+      "fediverseIdInvalidFormat": "올바른 Fediverse ID 형식이 아닙니다.",
+      "userNotFoundWithStatus": "사용자를 찾을 수 없습니다: {{status}}",
+      "webfingerLookupError": "Webfinger 조회 중 오류가 발생했습니다.",
+      "activityPubProfileNotFound": "ActivityPub 프로필을 찾을 수 없습니다.",
+      "objectNotActor": "조회된 객체가 Actor가 아닙니다.",
+      "profileInfoFetchFailed": "프로필 정보를 가져올 수 없습니다.",
+      "serverError": "서버 오류가 발생했습니다."
+    }
   }
 }

--- a/web/locales/zh-CN.json
+++ b/web/locales/zh-CN.json
@@ -422,9 +422,23 @@
     "hackersPubUserConfirm": "这似乎是 Hackers' Pub 用户。你想要登录吗？\n确定：前往登录页面\n取消：关闭弹窗",
     "userLookupError": "查找用户失败。",
     "userNotFound": "未找到用户信息。",
+    "userLookupGenericError": "用户信息查找过程中发生错误。",
+    "profileImageAlt": "个人资料图片",
+    "lookingUpUser": "正在查找用户信息...",
+    "followServiceNotFound": "未找到该服务的关注页面。",
     "cancel": "取消",
     "follow": "关注",
     "lookupUser": "查找用户",
-    "followExternal": "外部关注"
+    "lookingUp": "查找中...",
+    "api": {
+      "fediverseIdRequired": "联邦宇宙 ID 是必需的。",
+      "fediverseIdInvalidFormat": "联邦宇宙 ID 格式不正确。",
+      "userNotFoundWithStatus": "未找到用户：{{status}}",
+      "webfingerLookupError": "Webfinger 查找过程中发生错误。",
+      "activityPubProfileNotFound": "未找到 ActivityPub 个人资料。",
+      "objectNotActor": "查找到的对象不是 Actor。",
+      "profileInfoFetchFailed": "无法获取个人资料信息。",
+      "serverError": "服务器发生错误。"
+    }
   }
 }

--- a/web/locales/zh-CN.json
+++ b/web/locales/zh-CN.json
@@ -410,5 +410,21 @@
     "exhausted": "此邀请链接已用完。您需要使用其他邀请链接来加入 Hackers' Pub。",
     "duplicateEmail": "此电子邮件地址已在 Hackers' Pub 注册。请使用其他电子邮件地址。",
     "sent": "加入 Hackers' Pub 的邮件已发送到 {{email}}。请检查您的收件箱。（可能在垃圾邮件文件夹中）"
+  },
+  "remoteFollow": {
+    "title": "远程关注",
+    "description": "要关注 {{actorName}}，请输入你的联邦宇宙 ID。",
+    "fediverseIdLabel": "联邦宇宙 ID",
+    "fediverseIdPlaceholder": "@username@mastodon.social",
+    "fediverseIdExample": "输入你的联邦宇宙 ID（例如：@username@mastodon.social）",
+    "fediverseIdRequired": "请输入你的联邦宇宙 ID。",
+    "fediverseIdInvalid": "联邦宇宙 ID 格式无效。请以 @username@domain.com 格式输入。",
+    "hackersPubUserConfirm": "这似乎是 Hackers' Pub 用户。你想要登录吗？\n确定：前往登录页面\n取消：关闭弹窗",
+    "userLookupError": "查找用户失败。",
+    "userNotFound": "未找到用户信息。",
+    "cancel": "取消",
+    "follow": "关注",
+    "lookupUser": "查找用户",
+    "followExternal": "外部关注"
   }
 }

--- a/web/locales/zh-TW.json
+++ b/web/locales/zh-TW.json
@@ -411,5 +411,21 @@
     "exhausted": "此邀請連結已用完。您需要使用其他邀請連結來加入 Hackers' Pub。",
     "duplicateEmail": "此電子郵件地址已在 Hackers' Pub 註冊。請使用其他電子郵件地址。",
     "sent": "加入 Hackers' Pub 的郵件已發送到 {{email}}。請檢查您的收件匣。（可能在垃圾郵件資料夾中）"
+  },
+  "remoteFollow": {
+    "title": "遠端關注",
+    "description": "要關注 {{actorName}}，請輸入你的聯邦宇宙 ID。",
+    "fediverseIdLabel": "聯邦宇宙 ID",
+    "fediverseIdPlaceholder": "@username@mastodon.social",
+    "fediverseIdExample": "輸入你的聯邦宇宙 ID（例如：@username@mastodon.social）",
+    "fediverseIdRequired": "請輸入你的聯邦宇宙 ID。",
+    "fediverseIdInvalid": "聯邦宇宙 ID 格式無效。請以 @username@domain.com 格式輸入。",
+    "hackersPubUserConfirm": "這似乎是 Hackers' Pub 使用者。你想要登入嗎？\n確定：前往登入頁面\n取消：關閉彈窗",
+    "userLookupError": "查找使用者失敗。",
+    "userNotFound": "未找到使用者資訊。",
+    "cancel": "取消",
+    "follow": "關注",
+    "lookupUser": "查找使用者",
+    "followExternal": "外部關注"
   }
 }

--- a/web/locales/zh-TW.json
+++ b/web/locales/zh-TW.json
@@ -423,9 +423,23 @@
     "hackersPubUserConfirm": "這似乎是 Hackers' Pub 使用者。你想要登入嗎？\n確定：前往登入頁面\n取消：關閉彈窗",
     "userLookupError": "查找使用者失敗。",
     "userNotFound": "未找到使用者資訊。",
+    "userLookupGenericError": "使用者資訊查找過程中發生錯誤。",
+    "profileImageAlt": "個人資料圖片",
+    "lookingUpUser": "正在查找使用者資訊...",
+    "followServiceNotFound": "未找到該服務的關注頁面。",
     "cancel": "取消",
     "follow": "關注",
     "lookupUser": "查找使用者",
-    "followExternal": "外部關注"
+    "lookingUp": "查找中...",
+    "api": {
+      "fediverseIdRequired": "聯邦宇宙 ID 是必需的。",
+      "fediverseIdInvalidFormat": "聯邦宇宙 ID 格式不正確。",
+      "userNotFoundWithStatus": "未找到使用者：{{status}}",
+      "webfingerLookupError": "Webfinger 查找過程中發生錯誤。",
+      "activityPubProfileNotFound": "未找到 ActivityPub 個人資料。",
+      "objectNotActor": "查找到的物件不是 Actor。",
+      "profileInfoFetchFailed": "無法取得個人資料資訊。",
+      "serverError": "伺服器發生錯誤。"
+    }
   }
 }

--- a/web/routes/@[username]/index.tsx
+++ b/web/routes/@[username]/index.tsx
@@ -547,6 +547,7 @@ export default define.page<typeof handler, ProfilePageProps>(
           relationship={data.relationship}
           links={data.links}
           profileHref={data.profileHref}
+          signedAccount={state.account}
         />
         <ProfileNav
           active="total"

--- a/web/routes/api/webfinger.ts
+++ b/web/routes/api/webfinger.ts
@@ -1,0 +1,214 @@
+import { getNodeInfo, isActor } from "@fedify/fedify";
+import { getLogger } from "@logtape/logtape";
+import { define } from "../../utils.ts";
+
+const logger = getLogger(["hackerspub", "api", "webfinger"]);
+
+export const handler = define.handlers(async (ctx) => {
+  if (ctx.req.method !== "POST") {
+    return new Response("Method not allowed", { status: 405 });
+  }
+
+  try {
+    const { fediverseId } = await ctx.req.json();
+    const { fedCtx } = ctx.state;
+
+    if (!fediverseId || typeof fediverseId !== "string") {
+      return new Response(
+        JSON.stringify({ error: "Fediverse ID가 필요합니다." }),
+        {
+          status: 400,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
+    }
+
+    const fediverseIdRegex =
+      /^@?([a-zA-Z0-9_.-]+)@([a-zA-Z0-9.-]+\.[a-zA-Z]{2,})$/;
+    const match = fediverseId.trim().match(fediverseIdRegex);
+
+    if (!match) {
+      return new Response(
+        JSON.stringify({ error: "올바른 Fediverse ID 형식이 아닙니다." }),
+        {
+          status: 400,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
+    }
+
+    const [, username, domain] = match;
+    const normalizedId = `${username}@${domain}`;
+
+    // 개발 환경에서 도메인 변환 처리
+    const getProductionHandle = (handle: string) => {
+      // 개발 환경 감지 (서버 사이드에서는 환경변수나 다른 방법 사용)
+      const isDevelopment = Deno.env.get("DENO_ENV") === "development" ||
+        Deno.env.get("NODE_ENV") === "development";
+
+      if (!isDevelopment) return handle;
+
+      return handle
+        .replace(/@[a-f0-9]+\.ngrok-free\.app$/, "@hackers.pub");
+    };
+
+    const productionHandle = getProductionHandle(`@${normalizedId}`);
+    const finalNormalizedId = productionHandle.startsWith("@")
+      ? productionHandle.slice(1)
+      : productionHandle;
+
+    logger.info("Looking up actor: {fediverseId} -> {finalId}", {
+      fediverseId: normalizedId,
+      finalId: finalNormalizedId,
+    });
+
+    // webfinger를 통한 사용자 조회 (변환된 ID 사용)
+    const finalDomain = finalNormalizedId.split("@")[1];
+    const webfingerUrl =
+      `https://${finalDomain}/.well-known/webfinger?resource=acct:${finalNormalizedId}`;
+
+    const webfingerResponse = await fetch(webfingerUrl, {
+      headers: {
+        "Accept": "application/jrd+json, application/json",
+        "User-Agent": "HackersPub/1.0 (https://hackerspub.com/)",
+      },
+    });
+
+    if (!webfingerResponse.ok) {
+      logger.warn("Webfinger lookup failed: {status} {url}", {
+        status: webfingerResponse.status,
+        url: webfingerUrl,
+      });
+      return new Response(
+        JSON.stringify({
+          error: `사용자를 찾을 수 없습니다: ${webfingerResponse.status}`,
+        }),
+        {
+          status: 404,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
+    }
+
+    const webfingerData = await webfingerResponse.json();
+
+    const activityPubLink = webfingerData.links?.find((
+      link: { type?: string; rel?: string; href?: string },
+    ) =>
+      link.type === "application/activity+json" ||
+      (link.rel === "self" && link.type?.includes("activity"))
+    );
+
+    const subscribeLink = webfingerData.links?.find((
+      link: { rel?: string; template?: string },
+    ) => link.rel === "http://ostatus.org/schema/1.0/subscribe");
+
+    if (!activityPubLink) {
+      logger.warn("No ActivityPub profile found for {fediverseId}", {
+        fediverseId: finalNormalizedId,
+      });
+      return new Response(
+        JSON.stringify({ error: "ActivityPub 프로필을 찾을 수 없습니다." }),
+        {
+          status: 404,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
+    }
+
+    try {
+      const actorObject = await fedCtx.lookupObject(activityPubLink.href);
+
+      if (!isActor(actorObject)) {
+        throw new Error("조회된 객체가 Actor가 아닙니다.");
+      }
+
+      let software = "unknown";
+      try {
+        const nodeInfo = await getNodeInfo(`https://${finalDomain}`);
+        if (nodeInfo?.software?.name) {
+          software = nodeInfo.software.name.toLowerCase();
+        }
+      } catch (error) {
+        logger.warn("Failed to get nodeinfo for {domain}: {error}", {
+          domain: finalDomain,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+
+      let iconUrl = null;
+      let imageUrl = null;
+
+      const icon = await actorObject.getIcon();
+      if (icon) {
+        iconUrl = icon.url?.href;
+      }
+
+      const image = await actorObject.getImage();
+      if (image) {
+        imageUrl = image.url?.href;
+      }
+
+      // fallback access
+      if (!iconUrl && actorObject.iconId) {
+        iconUrl = actorObject.iconId.href;
+      }
+      if (!imageUrl && actorObject.imageId) {
+        imageUrl = actorObject.imageId.href;
+      }
+
+      const actorInfo = {
+        id: actorObject.id?.href,
+        type: actorObject.constructor.name,
+        preferredUsername: actorObject.preferredUsername,
+        name: actorObject.name?.toString(),
+        summary: actorObject.summary?.toString(),
+        url: actorObject.url?.href,
+        icon: iconUrl,
+        image: imageUrl,
+        handle: finalNormalizedId,
+        profileUrl: activityPubLink.href,
+        domain: finalDomain,
+        software: software,
+        template: subscribeLink?.template, // 원격 팔로우용 template 추가
+      };
+
+      logger.info("Successfully looked up actor: {handle}", {
+        handle: finalNormalizedId,
+      });
+
+      return new Response(
+        JSON.stringify({ actor: actorInfo }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
+    } catch (error) {
+      logger.error("Failed to lookup ActivityPub object: {error}", {
+        error: error instanceof Error ? error.message : String(error),
+        profileUrl: activityPubLink.href,
+      });
+
+      return new Response(
+        JSON.stringify({ error: "프로필 정보를 가져올 수 없습니다." }),
+        {
+          status: 500,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
+    }
+  } catch (error) {
+    logger.error("Webfinger API error: {error}", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+
+    return new Response(
+      JSON.stringify({ error: "서버 오류가 발생했습니다." }),
+      {
+        status: 500,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+  }
+});

--- a/web/routes/api/webfinger.ts
+++ b/web/routes/api/webfinger.ts
@@ -1,10 +1,13 @@
 import { type Actor, getNodeInfo, isActor } from "@fedify/fedify";
 import { getLogger } from "@logtape/logtape";
 import { define } from "../../utils.ts";
+import getFixedT from "../../i18n.ts";
+import type { Language } from "../../i18n.ts";
 
 interface WebfingerRequest {
   fediverseId: string;
   actorHandle?: string;
+  language?: Language;
 }
 
 interface WebfingerLink {
@@ -58,18 +61,22 @@ const logger = getLogger(["hackerspub", "api", "webfinger"]);
 
 function validateFediverseId(
   fediverseId: unknown,
+  t: ReturnType<typeof getFixedT>,
 ): { isValid: false; error: string } | {
   isValid: true;
   username: string;
   domain: string;
 } {
   if (!fediverseId || typeof fediverseId !== "string") {
-    return { isValid: false, error: "Fediverse ID가 필요합니다." };
+    return { isValid: false, error: t("remoteFollow.api.fediverseIdRequired") };
   }
 
   const match = fediverseId.trim().match(FEDIVERSE_ID_REGEX);
   if (!match) {
-    return { isValid: false, error: "올바른 Fediverse ID 형식이 아닙니다." };
+    return {
+      isValid: false,
+      error: t("remoteFollow.api.fediverseIdInvalidFormat"),
+    };
   }
 
   const [, username, domain] = match;
@@ -88,6 +95,7 @@ function getProductionHandle(handle: string): string {
 async function lookupWebfinger(
   domain: string,
   normalizedId: string,
+  t: ReturnType<typeof getFixedT>,
 ): Promise<
   {
     success: boolean;
@@ -114,7 +122,9 @@ async function lookupWebfinger(
       });
       return {
         success: false,
-        error: `사용자를 찾을 수 없습니다: ${response.status}`,
+        error: t("remoteFollow.api.userNotFoundWithStatus", {
+          status: response.status,
+        }),
         status: response.status,
       };
     }
@@ -126,7 +136,10 @@ async function lookupWebfinger(
       error: error instanceof Error ? error.message : String(error),
       url: webfingerUrl,
     });
-    return { success: false, error: "Webfinger 조회 중 오류가 발생했습니다." };
+    return {
+      success: false,
+      error: t("remoteFollow.api.webfingerLookupError"),
+    };
   }
 }
 
@@ -199,16 +212,13 @@ async function buildActorInfo(
 }
 
 export const handler = define.handlers(async (ctx) => {
-  if (ctx.req.method !== "POST") {
-    return createJsonResponse({ error: "Method not allowed" }, 405);
-  }
+  const requestBody = await ctx.req.json() as WebfingerRequest;
+  const { fedCtx } = ctx.state;
+  const t = getFixedT(requestBody.language);
 
   try {
-    const requestBody = await ctx.req.json() as WebfingerRequest;
-    const { fedCtx } = ctx.state;
-
     // Validate Fediverse ID
-    const validation = validateFediverseId(requestBody.fediverseId);
+    const validation = validateFediverseId(requestBody.fediverseId, t);
     if (!validation.isValid) {
       return createJsonResponse({ error: validation.error }, 400);
     }
@@ -220,10 +230,10 @@ export const handler = define.handlers(async (ctx) => {
       fediverseId: normalizedId,
     });
 
-    // Perform webfinger lookup
     const webfingerResult = await lookupWebfinger(
       domain,
       normalizedId,
+      t,
     );
 
     if (!webfingerResult.success) {
@@ -252,7 +262,7 @@ export const handler = define.handlers(async (ctx) => {
         fediverseId: normalizedId,
       });
       return createJsonResponse(
-        { error: "ActivityPub 프로필을 찾을 수 없습니다." },
+        { error: t("remoteFollow.api.activityPubProfileNotFound") },
         404,
       );
     }
@@ -262,7 +272,7 @@ export const handler = define.handlers(async (ctx) => {
       const actorObject = await fedCtx.lookupObject(activityPubLink.href);
 
       if (!isActor(actorObject)) {
-        throw new Error("조회된 객체가 Actor가 아닙니다.");
+        throw new Error(t("remoteFollow.api.objectNotActor"));
       }
 
       // Build actor information
@@ -287,7 +297,7 @@ export const handler = define.handlers(async (ctx) => {
       });
 
       return createJsonResponse(
-        { error: "프로필 정보를 가져올 수 없습니다." },
+        { error: t("remoteFollow.api.profileInfoFetchFailed") },
         500,
       );
     }
@@ -297,7 +307,7 @@ export const handler = define.handlers(async (ctx) => {
     });
 
     return createJsonResponse(
-      { error: "서버 오류가 발생했습니다." },
+      { error: t("remoteFollow.api.serverError") },
       500,
     );
   }

--- a/web/routes/api/webfinger.ts
+++ b/web/routes/api/webfinger.ts
@@ -1,57 +1,209 @@
-import { getNodeInfo, isActor } from "@fedify/fedify";
+import { type Actor, getNodeInfo, isActor } from "@fedify/fedify";
 import { getLogger } from "@logtape/logtape";
 import { define } from "../../utils.ts";
 
+interface WebfingerRequest {
+  fediverseId: string;
+}
+
+interface WebfingerLink {
+  rel?: string;
+  type?: string;
+  href?: string;
+  template?: string;
+}
+
+interface WebfingerResponse {
+  subject: string;
+  links: WebfingerLink[];
+}
+
+interface ActorInfo {
+  id: string | undefined;
+  type: string;
+  preferredUsername: string | undefined;
+  name: string | undefined;
+  summary: string | undefined;
+  url: string | undefined;
+  icon: string | null;
+  image: string | null;
+  handle: string;
+  profileUrl: string;
+  domain: string;
+  software: string;
+  template: string | undefined;
+}
+
+// Constants
+const FEDIVERSE_ID_REGEX =
+  /^@?([a-zA-Z0-9_.-]+)@([a-zA-Z0-9.-]+\.[a-zA-Z]{2,})$/;
+const USER_AGENT = "HackersPub/1.0 (https://hackerspub.com/)";
+const ACTIVITY_PUB_TYPE = "application/activity+json";
+const OSTATUS_SUBSCRIBE_REL = "http://ostatus.org/schema/1.0/subscribe";
+const WEBFINGER_ACCEPT_HEADER = "application/jrd+json, application/json";
+
+// Helper functions
+function createJsonResponse(data: unknown, status: number): Response {
+  return new Response(
+    JSON.stringify(data),
+    {
+      status,
+      headers: { "Content-Type": "application/json" },
+    },
+  );
+}
+
 const logger = getLogger(["hackerspub", "api", "webfinger"]);
+
+function validateFediverseId(
+  fediverseId: unknown,
+): { isValid: boolean; username?: string; domain?: string; error?: string } {
+  if (!fediverseId || typeof fediverseId !== "string") {
+    return { isValid: false, error: "Fediverse ID가 필요합니다." };
+  }
+
+  const match = fediverseId.trim().match(FEDIVERSE_ID_REGEX);
+  if (!match) {
+    return { isValid: false, error: "올바른 Fediverse ID 형식이 아닙니다." };
+  }
+
+  const [, username, domain] = match;
+  return { isValid: true, username, domain };
+}
+
+function getProductionHandle(handle: string): string {
+  const isDevelopment = Deno.env.get("DENO_ENV") === "development" ||
+    Deno.env.get("NODE_ENV") === "development";
+
+  if (!isDevelopment) return handle;
+
+  return handle.replace(/@[a-f0-9]+\.ngrok-free\.app$/, "@hackers.pub");
+}
+
+async function lookupWebfinger(
+  domain: string,
+  normalizedId: string,
+): Promise<
+  {
+    success: boolean;
+    data?: WebfingerResponse;
+    error?: string;
+    status?: number;
+  }
+> {
+  const webfingerUrl =
+    `https://${domain}/.well-known/webfinger?resource=acct:${normalizedId}`;
+
+  try {
+    const response = await fetch(webfingerUrl, {
+      headers: {
+        "Accept": WEBFINGER_ACCEPT_HEADER,
+        "User-Agent": USER_AGENT,
+      },
+    });
+
+    if (!response.ok) {
+      logger.warn("Webfinger lookup failed: {status} {url}", {
+        status: response.status,
+        url: webfingerUrl,
+      });
+      return {
+        success: false,
+        error: `사용자를 찾을 수 없습니다: ${response.status}`,
+        status: response.status,
+      };
+    }
+
+    const data = await response.json() as WebfingerResponse;
+    return { success: true, data };
+  } catch (error) {
+    logger.error("Webfinger fetch error: {error}", {
+      error: error instanceof Error ? error.message : String(error),
+      url: webfingerUrl,
+    });
+    return { success: false, error: "Webfinger 조회 중 오류가 발생했습니다." };
+  }
+}
+
+async function buildActorInfo(
+  actorObject: Actor,
+  finalNormalizedId: string,
+  finalDomain: string,
+  profileUrl: string,
+  subscribeTemplate?: string,
+): Promise<ActorInfo> {
+  let software = "unknown";
+  try {
+    const nodeInfo = await getNodeInfo(`https://${finalDomain}`);
+    if (nodeInfo?.software?.name) {
+      software = nodeInfo.software.name.toLowerCase();
+    }
+  } catch (error) {
+    logger.warn("Failed to get nodeinfo for {domain}: {error}", {
+      domain: finalDomain,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+
+  let iconUrl = null;
+  let imageUrl = null;
+
+  const icon = await actorObject.getIcon();
+  if (icon) {
+    iconUrl = icon.url?.href;
+  }
+
+  const image = await actorObject.getImage();
+  if (image) {
+    imageUrl = image.url?.href;
+  }
+
+  // fallback access
+  if (!iconUrl && actorObject.iconId) {
+    iconUrl = actorObject.iconId.href;
+  }
+  if (!imageUrl && actorObject.imageId) {
+    imageUrl = actorObject.imageId.href;
+  }
+
+  return {
+    id: actorObject.id?.href,
+    type: actorObject.constructor.name,
+    preferredUsername: actorObject.preferredUsername?.toString(),
+    name: actorObject.name?.toString(),
+    summary: actorObject.summary?.toString(),
+    url: actorObject.url instanceof URL
+      ? actorObject.url.href
+      : actorObject.url?.toString(),
+    icon: iconUrl instanceof URL ? iconUrl.href : (iconUrl ?? null),
+    image: imageUrl instanceof URL ? imageUrl.href : (imageUrl ?? null),
+    handle: finalNormalizedId,
+    profileUrl: profileUrl,
+    domain: finalDomain,
+    software: software,
+    template: subscribeTemplate,
+  };
+}
 
 export const handler = define.handlers(async (ctx) => {
   if (ctx.req.method !== "POST") {
-    return new Response("Method not allowed", { status: 405 });
+    return createJsonResponse({ error: "Method not allowed" }, 405);
   }
 
   try {
-    const { fediverseId } = await ctx.req.json();
+    const requestBody = await ctx.req.json() as WebfingerRequest;
     const { fedCtx } = ctx.state;
 
-    if (!fediverseId || typeof fediverseId !== "string") {
-      return new Response(
-        JSON.stringify({ error: "Fediverse ID가 필요합니다." }),
-        {
-          status: 400,
-          headers: { "Content-Type": "application/json" },
-        },
-      );
+    // Validate Fediverse ID
+    const validation = validateFediverseId(requestBody.fediverseId);
+    if (!validation.isValid) {
+      return createJsonResponse({ error: validation.error }, 400);
     }
 
-    const fediverseIdRegex =
-      /^@?([a-zA-Z0-9_.-]+)@([a-zA-Z0-9.-]+\.[a-zA-Z]{2,})$/;
-    const match = fediverseId.trim().match(fediverseIdRegex);
-
-    if (!match) {
-      return new Response(
-        JSON.stringify({ error: "올바른 Fediverse ID 형식이 아닙니다." }),
-        {
-          status: 400,
-          headers: { "Content-Type": "application/json" },
-        },
-      );
-    }
-
-    const [, username, domain] = match;
+    const { username, domain } = validation;
     const normalizedId = `${username}@${domain}`;
 
-    // 개발 환경에서 도메인 변환 처리
-    const getProductionHandle = (handle: string) => {
-      // 개발 환경 감지 (서버 사이드에서는 환경변수나 다른 방법 사용)
-      const isDevelopment = Deno.env.get("DENO_ENV") === "development" ||
-        Deno.env.get("NODE_ENV") === "development";
-
-      if (!isDevelopment) return handle;
-
-      return handle
-        .replace(/@[a-f0-9]+\.ngrok-free\.app$/, "@hackers.pub");
-    };
-
+    // Handle development environment domain conversion
     const productionHandle = getProductionHandle(`@${normalizedId}`);
     const finalNormalizedId = productionHandle.startsWith("@")
       ? productionHandle.slice(1)
@@ -62,140 +214,75 @@ export const handler = define.handlers(async (ctx) => {
       finalId: finalNormalizedId,
     });
 
-    // webfinger를 통한 사용자 조회 (변환된 ID 사용)
+    // Perform webfinger lookup
     const finalDomain = finalNormalizedId.split("@")[1];
-    const webfingerUrl =
-      `https://${finalDomain}/.well-known/webfinger?resource=acct:${finalNormalizedId}`;
+    const webfingerResult = await lookupWebfinger(
+      finalDomain,
+      finalNormalizedId,
+    );
 
-    const webfingerResponse = await fetch(webfingerUrl, {
-      headers: {
-        "Accept": "application/jrd+json, application/json",
-        "User-Agent": "HackersPub/1.0 (https://hackerspub.com/)",
-      },
-    });
-
-    if (!webfingerResponse.ok) {
-      logger.warn("Webfinger lookup failed: {status} {url}", {
-        status: webfingerResponse.status,
-        url: webfingerUrl,
-      });
-      return new Response(
-        JSON.stringify({
-          error: `사용자를 찾을 수 없습니다: ${webfingerResponse.status}`,
-        }),
-        {
-          status: 404,
-          headers: { "Content-Type": "application/json" },
-        },
+    if (!webfingerResult.success) {
+      return createJsonResponse(
+        { error: webfingerResult.error },
+        webfingerResult.status || 404,
       );
     }
 
-    const webfingerData = await webfingerResponse.json();
+    const webfingerData = webfingerResult.data!;
 
+    // Find ActivityPub and subscribe links
     const activityPubLink = webfingerData.links?.find((
-      link: { type?: string; rel?: string; href?: string },
+      link: WebfingerLink,
     ) =>
-      link.type === "application/activity+json" ||
+      link.type === ACTIVITY_PUB_TYPE ||
       (link.rel === "self" && link.type?.includes("activity"))
     );
 
     const subscribeLink = webfingerData.links?.find((
-      link: { rel?: string; template?: string },
-    ) => link.rel === "http://ostatus.org/schema/1.0/subscribe");
+      link: WebfingerLink,
+    ) => link.rel === OSTATUS_SUBSCRIBE_REL);
 
-    if (!activityPubLink) {
+    if (!activityPubLink || !activityPubLink.href) {
       logger.warn("No ActivityPub profile found for {fediverseId}", {
         fediverseId: finalNormalizedId,
       });
-      return new Response(
-        JSON.stringify({ error: "ActivityPub 프로필을 찾을 수 없습니다." }),
-        {
-          status: 404,
-          headers: { "Content-Type": "application/json" },
-        },
+      return createJsonResponse(
+        { error: "ActivityPub 프로필을 찾을 수 없습니다." },
+        404,
       );
     }
 
     try {
+      // Lookup ActivityPub object
       const actorObject = await fedCtx.lookupObject(activityPubLink.href);
 
       if (!isActor(actorObject)) {
         throw new Error("조회된 객체가 Actor가 아닙니다.");
       }
 
-      let software = "unknown";
-      try {
-        const nodeInfo = await getNodeInfo(`https://${finalDomain}`);
-        if (nodeInfo?.software?.name) {
-          software = nodeInfo.software.name.toLowerCase();
-        }
-      } catch (error) {
-        logger.warn("Failed to get nodeinfo for {domain}: {error}", {
-          domain: finalDomain,
-          error: error instanceof Error ? error.message : String(error),
-        });
-      }
-
-      let iconUrl = null;
-      let imageUrl = null;
-
-      const icon = await actorObject.getIcon();
-      if (icon) {
-        iconUrl = icon.url?.href;
-      }
-
-      const image = await actorObject.getImage();
-      if (image) {
-        imageUrl = image.url?.href;
-      }
-
-      // fallback access
-      if (!iconUrl && actorObject.iconId) {
-        iconUrl = actorObject.iconId.href;
-      }
-      if (!imageUrl && actorObject.imageId) {
-        imageUrl = actorObject.imageId.href;
-      }
-
-      const actorInfo = {
-        id: actorObject.id?.href,
-        type: actorObject.constructor.name,
-        preferredUsername: actorObject.preferredUsername,
-        name: actorObject.name?.toString(),
-        summary: actorObject.summary?.toString(),
-        url: actorObject.url?.href,
-        icon: iconUrl,
-        image: imageUrl,
-        handle: finalNormalizedId,
-        profileUrl: activityPubLink.href,
-        domain: finalDomain,
-        software: software,
-        template: subscribeLink?.template, // 원격 팔로우용 template 추가
-      };
+      // Build actor information
+      const actorInfo = await buildActorInfo(
+        actorObject,
+        finalNormalizedId,
+        finalDomain,
+        activityPubLink.href,
+        subscribeLink?.template,
+      );
 
       logger.info("Successfully looked up actor: {handle}", {
         handle: finalNormalizedId,
       });
 
-      return new Response(
-        JSON.stringify({ actor: actorInfo }),
-        {
-          status: 200,
-          headers: { "Content-Type": "application/json" },
-        },
-      );
+      return createJsonResponse({ actor: actorInfo }, 200);
     } catch (error) {
       logger.error("Failed to lookup ActivityPub object: {error}", {
         error: error instanceof Error ? error.message : String(error),
         profileUrl: activityPubLink.href,
       });
 
-      return new Response(
-        JSON.stringify({ error: "프로필 정보를 가져올 수 없습니다." }),
-        {
-          status: 500,
-          headers: { "Content-Type": "application/json" },
-        },
+      return createJsonResponse(
+        { error: "프로필 정보를 가져올 수 없습니다." },
+        500,
       );
     }
   } catch (error) {
@@ -203,12 +290,9 @@ export const handler = define.handlers(async (ctx) => {
       error: error instanceof Error ? error.message : String(error),
     });
 
-    return new Response(
-      JSON.stringify({ error: "서버 오류가 발생했습니다." }),
-      {
-        status: 500,
-        headers: { "Content-Type": "application/json" },
-      },
+    return createJsonResponse(
+      { error: "서버 오류가 발생했습니다." },
+      500,
     );
   }
 });

--- a/web/routes/api/webfinger.ts
+++ b/web/routes/api/webfinger.ts
@@ -4,6 +4,7 @@ import { define } from "../../utils.ts";
 
 interface WebfingerRequest {
   fediverseId: string;
+  actorHandle?: string;
 }
 
 interface WebfingerLink {
@@ -18,7 +19,7 @@ interface WebfingerResponse {
   links: WebfingerLink[];
 }
 
-interface ActorInfo {
+export interface ActorInfo {
   id: string | undefined;
   type: string;
   preferredUsername: string | undefined;
@@ -57,7 +58,11 @@ const logger = getLogger(["hackerspub", "api", "webfinger"]);
 
 function validateFediverseId(
   fediverseId: unknown,
-): { isValid: boolean; username?: string; domain?: string; error?: string } {
+): { isValid: false; error: string } | {
+  isValid: true;
+  username: string;
+  domain: string;
+} {
   if (!fediverseId || typeof fediverseId !== "string") {
     return { isValid: false, error: "Fediverse ID가 필요합니다." };
   }
@@ -72,12 +77,12 @@ function validateFediverseId(
 }
 
 function getProductionHandle(handle: string): string {
-  const isDevelopment = Deno.env.get("DENO_ENV") === "development" ||
-    Deno.env.get("NODE_ENV") === "development";
+  const isDevelopment = Deno.env.get("MODE") === "development";
+  const productionHandle = Deno.env.get("PRODUCTION_ACTOR_HANDLE");
 
-  if (!isDevelopment) return handle;
+  if (!isDevelopment || !productionHandle) return handle;
 
-  return handle.replace(/@[a-f0-9]+\.ngrok-free\.app$/, "@hackers.pub");
+  return productionHandle;
 }
 
 async function lookupWebfinger(
@@ -131,6 +136,7 @@ async function buildActorInfo(
   finalDomain: string,
   profileUrl: string,
   subscribeTemplate?: string,
+  actorHandle?: string,
 ): Promise<ActorInfo> {
   let software = "unknown";
   try {
@@ -166,6 +172,11 @@ async function buildActorInfo(
     imageUrl = actorObject.imageId.href;
   }
 
+  // Handle development environment domain conversion for my actor handle
+  const finalActorHandle = actorHandle
+    ? getProductionHandle(actorHandle)
+    : undefined;
+
   return {
     id: actorObject.id?.href,
     type: actorObject.constructor.name,
@@ -181,7 +192,9 @@ async function buildActorInfo(
     profileUrl: profileUrl,
     domain: finalDomain,
     software: software,
-    template: subscribeTemplate,
+    template: subscribeTemplate && finalActorHandle
+      ? subscribeTemplate.replace("{uri}", encodeURIComponent(finalActorHandle))
+      : subscribeTemplate,
   };
 }
 
@@ -203,22 +216,14 @@ export const handler = define.handlers(async (ctx) => {
     const { username, domain } = validation;
     const normalizedId = `${username}@${domain}`;
 
-    // Handle development environment domain conversion
-    const productionHandle = getProductionHandle(`@${normalizedId}`);
-    const finalNormalizedId = productionHandle.startsWith("@")
-      ? productionHandle.slice(1)
-      : productionHandle;
-
-    logger.info("Looking up actor: {fediverseId} -> {finalId}", {
+    logger.info("Looking up actor: {fediverseId}", {
       fediverseId: normalizedId,
-      finalId: finalNormalizedId,
     });
 
     // Perform webfinger lookup
-    const finalDomain = finalNormalizedId.split("@")[1];
     const webfingerResult = await lookupWebfinger(
-      finalDomain,
-      finalNormalizedId,
+      domain,
+      normalizedId,
     );
 
     if (!webfingerResult.success) {
@@ -244,7 +249,7 @@ export const handler = define.handlers(async (ctx) => {
 
     if (!activityPubLink || !activityPubLink.href) {
       logger.warn("No ActivityPub profile found for {fediverseId}", {
-        fediverseId: finalNormalizedId,
+        fediverseId: normalizedId,
       });
       return createJsonResponse(
         { error: "ActivityPub 프로필을 찾을 수 없습니다." },
@@ -263,14 +268,15 @@ export const handler = define.handlers(async (ctx) => {
       // Build actor information
       const actorInfo = await buildActorInfo(
         actorObject,
-        finalNormalizedId,
-        finalDomain,
+        normalizedId,
+        domain,
         activityPubLink.href,
         subscribeLink?.template,
+        requestBody.actorHandle,
       );
 
       logger.info("Successfully looked up actor: {handle}", {
-        handle: finalNormalizedId,
+        handle: normalizedId,
       });
 
       return createJsonResponse({ actor: actorInfo }, 200);

--- a/web/routes/index.tsx
+++ b/web/routes/index.tsx
@@ -281,6 +281,7 @@ export default define.page<typeof handler, HomeProps>(
             window={6}
             title={data.filter !== "recommendations"}
             class={data.filter === "recommendations" ? "mt-4" : ""}
+            signedAccount={state.account}
           />
         )}
       </>


### PR DESCRIPTION
# 📋 Overview
This PR introduces the **Remote Follow** feature, allowing Fediverse users to remotely follow the Hackers' Pub account.  
The feature is integrated into both the **Profile** and **RecommendedActors** components.

<img width="849" height="593" alt="image" src="https://github.com/user-attachments/assets/d2a9f7a7-86a5-4eac-abca-ceab2539e5f6" />


# 🛠️ Implementation Details
## Adding
- Added RemoteFollowModal component for Fediverse interactions
- Added RemoteFollowButton component
- Implemented WebFinger lookup for remote follows
- Display RemoteFollowButton for non-logged-in users

## Integration
- Integrated `signedAccount` prop into Profile
- Displayed RemoteFollowButton for non-logged-in users
- Added development/production handle mapping
- Integrated RemoteFollowButton into RecommendedActors list

## Enhancements
- Added `alt` attributes for images in Profile component (accessibility)
- Improved `.env.sample` with PRODUCTION_ACTOR_HANDLE documentation
- Added localization support (Korean, English, Japanese, Simplified Chinese, Traditional Chinese)

# 📁 Modified Files
## New files:
- web/islands/RemoteFollowModal.tsx
- web/islands/RemoteFollowButton.tsx
- web/routes/api/webfinger.ts

## Updated files:
- web/components/Profile.tsx
- web/islands/RecommendedActors.tsx
- web/routes/@[username]/index.tsx
- web/routes/index.tsx
- Localization files: ko.json, en.json, ja.json, zh-CN.json, zh-TW.json
- .env.sample


# 📝 Notes
- Remote Follow behavior still needs verification across different Fediverse platforms (e.g., Mastodon, Misskey, Pleroma, etc.).  
- Chinese (Simplified/Traditional) and Japanese translations were generated automatically using LLM.  
  → Please review whether the translated messages are appropriate and natural.  