### PR TITLE
fix(#132): sync Dockerfile.dev with latest Dockerfile

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,9 +1,9 @@
 FROM docker.io/denoland/deno:2.4.4
 
-RUN apt-get update && apt-get install -y build-essential ffmpeg jq git && \
+RUN apt-get update && apt-get install -y build-essential curl ffmpeg jq git && \
   apt-get clean && rm -rf /var/lib/apt/lists/*
 
-RUN curl -fsSL https://deb.nodesource.com/setup_23.x -o nodesource_setup.sh && \
+RUN curl -fsSL https://deb.nodesource.com/setup_24.x -o nodesource_setup.sh && \
   bash nodesource_setup.sh && \
   apt-get install -y nodejs && \
   rm nodesource_setup.sh && \


### PR DESCRIPTION
This PR resolves #132 by updating `Dockerfile.dev` with latest `Dockerfile`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Updated the development container to use Node.js 24.x.
  * Added curl to the development container image.
  * Refined package installation steps within the development environment.
  * Docker-based development workflows will use the updated environment.
  * No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->