### PR TITLE
feature: Note / Share's default visibility in preference

### DIFF
--- a/drizzle/0084_account-note-share-visibility.sql
+++ b/drizzle/0084_account-note-share-visibility.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "account" ADD COLUMN "note_visibility" "post_visibility" DEFAULT 'public' NOT NULL;--> statement-breakpoint
+ALTER TABLE "account" ADD COLUMN "share_visibility" "post_visibility" DEFAULT 'public' NOT NULL;

--- a/drizzle/meta/0084_snapshot.json
+++ b/drizzle/meta/0084_snapshot.json
@@ -1,0 +1,3482 @@
+{
+  "id": "f2a6fafb-d29c-40e4-82c1-b67f26f41ba0",
+  "prevId": "532fca63-0927-4871-b47d-43ea360b9df1",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account_email": {
+      "name": "account_email",
+      "schema": "",
+      "columns": {
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public": {
+          "name": "public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "verified": {
+          "name": "verified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_account_email_lower_email": {
+          "name": "idx_account_email_lower_email",
+          "columns": [
+            {
+              "expression": "lower(\"email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_email_account_id_account_id_fk": {
+          "name": "account_email_account_id_account_id_fk",
+          "tableFrom": "account_email",
+          "tableTo": "account",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account_key": {
+      "name": "account_key",
+      "schema": "",
+      "columns": {
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "account_key_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public": {
+          "name": "public",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private": {
+          "name": "private",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_key_account_id_account_id_fk": {
+          "name": "account_key_account_id_account_id_fk",
+          "tableFrom": "account_key",
+          "tableTo": "account",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "account_key_account_id_type_pk": {
+          "name": "account_key_account_id_type_pk",
+          "columns": [
+            "account_id",
+            "type"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "account_key_public_check": {
+          "name": "account_key_public_check",
+          "value": "\"account_key\".\"public\" IS JSON OBJECT"
+        },
+        "account_key_private_check": {
+          "name": "account_key_private_check",
+          "value": "\"account_key\".\"private\" IS JSON OBJECT"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.account_link": {
+      "name": "account_link",
+      "schema": "",
+      "columns": {
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "index": {
+          "name": "index",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "account_link_icon",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'web'"
+        },
+        "verified": {
+          "name": "verified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_link_account_id_account_id_fk": {
+          "name": "account_link_account_id_account_id_fk",
+          "tableFrom": "account_link",
+          "tableTo": "account",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "account_link_account_id_index_pk": {
+          "name": "account_link_account_id_index_pk",
+          "columns": [
+            "account_id",
+            "index"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "account_link_name_check": {
+          "name": "account_link_name_check",
+          "value": "\n        char_length(\"account_link\".\"name\") <= 50 AND\n        \"account_link\".\"name\" !~ '^[[:space:]]' AND\n        \"account_link\".\"name\" !~ '[[:space:]]$'\n      "
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "old_username": {
+          "name": "old_username",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username_changed": {
+          "name": "username_changed",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_key": {
+          "name": "avatar_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "og_image_key": {
+          "name": "og_image_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locales": {
+          "name": "locales",
+          "type": "varchar[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "moderator": {
+          "name": "moderator",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "notification_read": {
+          "name": "notification_read",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "left_invitations": {
+          "name": "left_invitations",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hide_from_invitation_tree": {
+          "name": "hide_from_invitation_tree",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "hide_foreign_languages": {
+          "name": "hide_foreign_languages",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "prefer_ai_summary": {
+          "name": "prefer_ai_summary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "note_visibility": {
+          "name": "note_visibility",
+          "type": "post_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "share_visibility": {
+          "name": "share_visibility",
+          "type": "post_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_inviter_id_account_id_fk": {
+          "name": "account_inviter_id_account_id_fk",
+          "tableFrom": "account",
+          "tableTo": "account",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "account_username_unique": {
+          "name": "account_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        },
+        "account_avatar_key_unique": {
+          "name": "account_avatar_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "avatar_key"
+          ]
+        },
+        "account_og_image_key_unique": {
+          "name": "account_og_image_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "og_image_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "account_username_check": {
+          "name": "account_username_check",
+          "value": "\"account\".\"username\" ~ '^[a-z0-9_]{1,50}$'"
+        },
+        "account_name_check": {
+          "name": "account_name_check",
+          "value": "\n        char_length(\"account\".\"name\") <= 50 AND\n        \"account\".\"name\" !~ '^[[:space:]]' AND\n        \"account\".\"name\" !~ '[[:space:]]$'\n      "
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.actor": {
+      "name": "actor",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "iri": {
+          "name": "iri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instance_host": {
+          "name": "instance_host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "handle_host": {
+          "name": "handle_host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "generated": {
+            "as": "'@' || \"actor\".\"username\" || '@' || \"actor\".\"handle_host\"",
+            "type": "stored"
+          }
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio_html": {
+          "name": "bio_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "automatically_approves_followers": {
+          "name": "automatically_approves_followers",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "header_url": {
+          "name": "header_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inbox_url": {
+          "name": "inbox_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shared_inbox_url": {
+          "name": "shared_inbox_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "followers_url": {
+          "name": "followers_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "featured_url": {
+          "name": "featured_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "field_htmls": {
+          "name": "field_htmls",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::json"
+        },
+        "emojis": {
+          "name": "emojis",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "sensitive": {
+          "name": "sensitive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "successor_id": {
+          "name": "successor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aliases": {
+          "name": "aliases",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(ARRAY[]::text[])"
+        },
+        "followees_count": {
+          "name": "followees_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "followers_count": {
+          "name": "followers_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "posts_count": {
+          "name": "posts_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "published": {
+          "name": "published",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "actor_instance_host_instance_host_fk": {
+          "name": "actor_instance_host_instance_host_fk",
+          "tableFrom": "actor",
+          "tableTo": "instance",
+          "columnsFrom": [
+            "instance_host"
+          ],
+          "columnsTo": [
+            "host"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "actor_account_id_account_id_fk": {
+          "name": "actor_account_id_account_id_fk",
+          "tableFrom": "actor",
+          "tableTo": "account",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "actor_successor_id_actor_id_fk": {
+          "name": "actor_successor_id_actor_id_fk",
+          "tableFrom": "actor",
+          "tableTo": "actor",
+          "columnsFrom": [
+            "successor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "actor_iri_unique": {
+          "name": "actor_iri_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "iri"
+          ]
+        },
+        "actor_account_id_unique": {
+          "name": "actor_account_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "account_id"
+          ]
+        },
+        "actor_username_instance_host_unique": {
+          "name": "actor_username_instance_host_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username",
+            "instance_host"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "actor_username_check": {
+          "name": "actor_username_check",
+          "value": "\"actor\".\"username\" NOT LIKE '%@%'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.article_content": {
+      "name": "article_content",
+      "schema": "",
+      "columns": {
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_started": {
+          "name": "summary_started",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "og_image_key": {
+          "name": "og_image_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_language": {
+          "name": "original_language",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "translator_id": {
+          "name": "translator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "translation_requester_id": {
+          "name": "translation_requester_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "being_translated": {
+          "name": "being_translated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "published": {
+          "name": "published",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "article_content_source_id_article_source_id_fk": {
+          "name": "article_content_source_id_article_source_id_fk",
+          "tableFrom": "article_content",
+          "tableTo": "article_source",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "article_content_translator_id_account_id_fk": {
+          "name": "article_content_translator_id_account_id_fk",
+          "tableFrom": "article_content",
+          "tableTo": "account",
+          "columnsFrom": [
+            "translator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "article_content_translation_requester_id_account_id_fk": {
+          "name": "article_content_translation_requester_id_account_id_fk",
+          "tableFrom": "article_content",
+          "tableTo": "account",
+          "columnsFrom": [
+            "translation_requester_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "article_content_source_id_original_language_article_content_source_id_language_fk": {
+          "name": "article_content_source_id_original_language_article_content_source_id_language_fk",
+          "tableFrom": "article_content",
+          "tableTo": "article_content",
+          "columnsFrom": [
+            "source_id",
+            "original_language"
+          ],
+          "columnsTo": [
+            "source_id",
+            "language"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "article_content_source_id_language_pk": {
+          "name": "article_content_source_id_language_pk",
+          "columns": [
+            "source_id",
+            "language"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "article_content_og_image_key_unique": {
+          "name": "article_content_og_image_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "og_image_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "article_content_original_language_check": {
+          "name": "article_content_original_language_check",
+          "value": "(\n        \"article_content\".\"translator_id\" IS NULL AND\n        \"article_content\".\"translation_requester_id\" IS NULL\n      ) = (\"article_content\".\"original_language\" IS NULL)"
+        },
+        "article_content_translator_translation_requester_id_check": {
+          "name": "article_content_translator_translation_requester_id_check",
+          "value": "\"article_content\".\"translator_id\" IS NULL OR \"article_content\".\"translation_requester_id\" IS NULL"
+        },
+        "article_content_being_translated_check": {
+          "name": "article_content_being_translated_check",
+          "value": "NOT \"article_content\".\"being_translated\" OR (\"article_content\".\"original_language\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.article_draft": {
+      "name": "article_draft",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "article_source_id": {
+          "name": "article_source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(ARRAY[]::text[])"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "article_draft_account_id_account_id_fk": {
+          "name": "article_draft_account_id_account_id_fk",
+          "tableFrom": "article_draft",
+          "tableTo": "account",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "article_draft_article_source_id_article_source_id_fk": {
+          "name": "article_draft_article_source_id_article_source_id_fk",
+          "tableFrom": "article_draft",
+          "tableTo": "article_source",
+          "columnsFrom": [
+            "article_source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.article_source": {
+      "name": "article_source",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published_year": {
+          "name": "published_year",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "EXTRACT(year FROM CURRENT_TIMESTAMP)"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(ARRAY[]::text[])"
+        },
+        "allow_llm_translation": {
+          "name": "allow_llm_translation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "published": {
+          "name": "published",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "article_source_account_id_account_id_fk": {
+          "name": "article_source_account_id_account_id_fk",
+          "tableFrom": "article_source",
+          "tableTo": "account",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "article_source_account_id_published_year_slug_unique": {
+          "name": "article_source_account_id_published_year_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "account_id",
+            "published_year",
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "article_source_published_year_check": {
+          "name": "article_source_published_year_check",
+          "value": "\"article_source\".\"published_year\" = EXTRACT(year FROM \"article_source\".\"published\")"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.blocking": {
+      "name": "blocking",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "iri": {
+          "name": "iri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blocker_id": {
+          "name": "blocker_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blockee_id": {
+          "name": "blockee_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "blocking_blocker_id_actor_id_fk": {
+          "name": "blocking_blocker_id_actor_id_fk",
+          "tableFrom": "blocking",
+          "tableTo": "actor",
+          "columnsFrom": [
+            "blocker_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "blocking_blockee_id_actor_id_fk": {
+          "name": "blocking_blockee_id_actor_id_fk",
+          "tableFrom": "blocking",
+          "tableTo": "actor",
+          "columnsFrom": [
+            "blockee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "blocking_iri_unique": {
+          "name": "blocking_iri_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "iri"
+          ]
+        },
+        "blocking_blocker_id_blockee_id_unique": {
+          "name": "blocking_blocker_id_blockee_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "blocker_id",
+            "blockee_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "blocking_blocker_blockee_check": {
+          "name": "blocking_blocker_blockee_check",
+          "value": "\"blocking\".\"blocker_id\" != \"blocking\".\"blockee_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.custom_emoji": {
+      "name": "custom_emoji",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "iri": {
+          "name": "iri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_type": {
+          "name": "image_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "custom_emoji_iri_unique": {
+          "name": "custom_emoji_iri_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "iri"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "custom_emoji_name_check": {
+          "name": "custom_emoji_name_check",
+          "value": "\"custom_emoji\".\"name\" ~ '^:[^:[:space:]]+:$'"
+        },
+        "custom_emoji_image_type_check": {
+          "name": "custom_emoji_image_type_check",
+          "value": "\n        CASE\n          WHEN \"custom_emoji\".\"image_type\" IS NULL THEN true\n          ELSE \"custom_emoji\".\"image_type\" ~ '^image/'\n        END\n      "
+        },
+        "custom_emoji_image_url_check": {
+          "name": "custom_emoji_image_url_check",
+          "value": "\"custom_emoji\".\"image_url\" ~ '^https?://'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.following": {
+      "name": "following",
+      "schema": "",
+      "columns": {
+        "iri": {
+          "name": "iri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "follower_id": {
+          "name": "follower_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "followee_id": {
+          "name": "followee_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted": {
+          "name": "accepted",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "following_follower_id_index": {
+          "name": "following_follower_id_index",
+          "columns": [
+            {
+              "expression": "follower_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "following_follower_id_actor_id_fk": {
+          "name": "following_follower_id_actor_id_fk",
+          "tableFrom": "following",
+          "tableTo": "actor",
+          "columnsFrom": [
+            "follower_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "following_followee_id_actor_id_fk": {
+          "name": "following_followee_id_actor_id_fk",
+          "tableFrom": "following",
+          "tableTo": "actor",
+          "columnsFrom": [
+            "followee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "following_follower_id_followee_id_unique": {
+          "name": "following_follower_id_followee_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "follower_id",
+            "followee_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instance": {
+      "name": "instance",
+      "schema": "",
+      "columns": {
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "software": {
+          "name": "software",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_version": {
+          "name": "software_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "instance_host_check": {
+          "name": "instance_host_check",
+          "value": "\"instance\".\"host\" NOT LIKE '%@%'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.invitation_link": {
+      "name": "invitation_link",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invitations_left": {
+          "name": "invitations_left",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invitation_link_inviter_id_account_id_fk": {
+          "name": "invitation_link_inviter_id_account_id_fk",
+          "tableFrom": "invitation_link",
+          "tableTo": "account",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mention": {
+      "name": "mention",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "mention_actor_id_index": {
+          "name": "mention_actor_id_index",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mention_post_id_post_id_fk": {
+          "name": "mention_post_id_post_id_fk",
+          "tableFrom": "mention",
+          "tableTo": "post",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mention_actor_id_actor_id_fk": {
+          "name": "mention_actor_id_actor_id_fk",
+          "tableFrom": "mention",
+          "tableTo": "actor",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "mention_post_id_actor_id_pk": {
+          "name": "mention_post_id_actor_id_pk",
+          "columns": [
+            "post_id",
+            "actor_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.note_medium": {
+      "name": "note_medium",
+      "schema": "",
+      "columns": {
+        "note_source_id": {
+          "name": "note_source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "index": {
+          "name": "index",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alt": {
+          "name": "alt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "note_medium_note_source_id_note_source_id_fk": {
+          "name": "note_medium_note_source_id_note_source_id_fk",
+          "tableFrom": "note_medium",
+          "tableTo": "note_source",
+          "columnsFrom": [
+            "note_source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "note_medium_note_source_id_index_pk": {
+          "name": "note_medium_note_source_id_index_pk",
+          "columns": [
+            "note_source_id",
+            "index"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "note_medium_key_unique": {
+          "name": "note_medium_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.note_source": {
+      "name": "note_source",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "post_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "published": {
+          "name": "published",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "note_source_account_id_account_id_fk": {
+          "name": "note_source_account_id_account_id_fk",
+          "tableFrom": "note_source",
+          "tableTo": "account",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification": {
+      "name": "notification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "notification_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_ids": {
+          "name": "actor_ids",
+          "type": "uuid[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(ARRAY[]::uuid[])"
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_emoji_id": {
+          "name": "custom_emoji_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_notification_account_id_created": {
+          "name": "idx_notification_account_id_created",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notification_account_id_actor_ids_index": {
+          "name": "notification_account_id_actor_ids_index",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "actor_ids",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"notification\".\"type\" = 'follow'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notification_account_id_post_id_index": {
+          "name": "notification_account_id_post_id_index",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"notification\".\"type\" NOT IN ('follow', 'react')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notification_account_id_post_id_emoji_index": {
+          "name": "notification_account_id_post_id_emoji_index",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "emoji",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"notification\".\"type\" = 'react' AND \"notification\".\"custom_emoji_id\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notification_account_id_post_id_custom_emoji_id_index": {
+          "name": "notification_account_id_post_id_custom_emoji_id_index",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "custom_emoji_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"notification\".\"type\" = 'react' AND \"notification\".\"emoji\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_account_id_account_id_fk": {
+          "name": "notification_account_id_account_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "account",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_post_id_post_id_fk": {
+          "name": "notification_post_id_post_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "post",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_custom_emoji_id_custom_emoji_id_fk": {
+          "name": "notification_custom_emoji_id_custom_emoji_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "custom_emoji",
+          "columnsFrom": [
+            "custom_emoji_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "notification_post_id_check": {
+          "name": "notification_post_id_check",
+          "value": "\n        CASE \"notification\".\"type\"\n          WHEN 'follow' THEN \"notification\".\"post_id\" IS NULL\n          ELSE \"notification\".\"post_id\" IS NOT NULL\n        END\n      "
+        },
+        "notification_emoji_check": {
+          "name": "notification_emoji_check",
+          "value": "\n        CASE \"notification\".\"type\"\n          WHEN 'react'\n          THEN \"notification\".\"emoji\" IS NOT NULL AND \"notification\".\"custom_emoji_id\" IS NULL\n            OR \"notification\".\"emoji\" IS NULL AND \"notification\".\"custom_emoji_id\" IS NOT NULL\n          ELSE \"notification\".\"emoji\" IS NULL AND \"notification\".\"custom_emoji_id\" IS NULL\n        END\n      "
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.passkey": {
+      "name": "passkey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webauthn_user_id": {
+          "name": "webauthn_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "passkey_device_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backed_up": {
+          "name": "backed_up",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transports": {
+          "name": "transports",
+          "type": "passkey_transport[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used": {
+          "name": "last_used",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "passkey_account_id_index": {
+          "name": "passkey_account_id_index",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "passkey_webauthn_user_id_index": {
+          "name": "passkey_webauthn_user_id_index",
+          "columns": [
+            {
+              "expression": "webauthn_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "passkey_account_id_account_id_fk": {
+          "name": "passkey_account_id_account_id_fk",
+          "tableFrom": "passkey",
+          "tableTo": "account",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "passkey_account_id_webauthn_user_id_unique": {
+          "name": "passkey_account_id_webauthn_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "account_id",
+            "webauthn_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "passkey_name_check": {
+          "name": "passkey_name_check",
+          "value": "\"passkey\".\"name\" !~ '^[[:space:]]*$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.pin": {
+      "name": "pin",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "pin_actor_id_index": {
+          "name": "pin_actor_id_index",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pin_actor_id_actor_id_fk": {
+          "name": "pin_actor_id_actor_id_fk",
+          "tableFrom": "pin",
+          "tableTo": "actor",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pin_post_id_actor_id_post_id_actor_id_fk": {
+          "name": "pin_post_id_actor_id_post_id_actor_id_fk",
+          "tableFrom": "pin",
+          "tableTo": "post",
+          "columnsFrom": [
+            "post_id",
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id",
+            "actor_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "pin_post_id_actor_id_pk": {
+          "name": "pin_post_id_actor_id_pk",
+          "columns": [
+            "post_id",
+            "actor_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.poll_option": {
+      "name": "poll_option",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "index": {
+          "name": "index",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "votes_count": {
+          "name": "votes_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "poll_option_post_id_poll_post_id_fk": {
+          "name": "poll_option_post_id_poll_post_id_fk",
+          "tableFrom": "poll_option",
+          "tableTo": "poll",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "post_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "poll_option_post_id_index_pk": {
+          "name": "poll_option_post_id_index_pk",
+          "columns": [
+            "post_id",
+            "index"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "poll_option_post_id_title_unique": {
+          "name": "poll_option_post_id_title_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "post_id",
+            "title"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "poll_option_index_check": {
+          "name": "poll_option_index_check",
+          "value": "\"poll_option\".\"index\" >= 0"
+        },
+        "poll_option_votes_count_check": {
+          "name": "poll_option_votes_count_check",
+          "value": "\"poll_option\".\"votes_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.poll": {
+      "name": "poll",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "multiple": {
+          "name": "multiple",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voters_count": {
+          "name": "voters_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "ends": {
+          "name": "ends",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "poll_post_id_post_id_fk": {
+          "name": "poll_post_id_post_id_fk",
+          "tableFrom": "poll",
+          "tableTo": "post",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "poll_voters_count_check": {
+          "name": "poll_voters_count_check",
+          "value": "\"poll\".\"voters_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.poll_vote": {
+      "name": "poll_vote",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "option_index": {
+          "name": "option_index",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "poll_vote_post_id_poll_post_id_fk": {
+          "name": "poll_vote_post_id_poll_post_id_fk",
+          "tableFrom": "poll_vote",
+          "tableTo": "poll",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "post_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "poll_vote_actor_id_actor_id_fk": {
+          "name": "poll_vote_actor_id_actor_id_fk",
+          "tableFrom": "poll_vote",
+          "tableTo": "actor",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "poll_vote_post_id_option_index_poll_option_post_id_index_fk": {
+          "name": "poll_vote_post_id_option_index_poll_option_post_id_index_fk",
+          "tableFrom": "poll_vote",
+          "tableTo": "poll_option",
+          "columnsFrom": [
+            "post_id",
+            "option_index"
+          ],
+          "columnsTo": [
+            "post_id",
+            "index"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "poll_vote_post_id_option_index_actor_id_pk": {
+          "name": "poll_vote_post_id_option_index_actor_id_pk",
+          "columns": [
+            "post_id",
+            "option_index",
+            "actor_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_link": {
+      "name": "post_link",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "site_name": {
+          "name": "site_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_alt": {
+          "name": "image_alt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_type": {
+          "name": "image_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_width": {
+          "name": "image_width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_height": {
+          "name": "image_height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "scraped": {
+          "name": "scraped",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "post_link_creator_id_index": {
+          "name": "post_link_creator_id_index",
+          "columns": [
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_link_creator_id_actor_id_fk": {
+          "name": "post_link_creator_id_actor_id_fk",
+          "tableFrom": "post_link",
+          "tableTo": "actor",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "post_link_url_unique": {
+          "name": "post_link_url_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "url"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "post_link_url_check": {
+          "name": "post_link_url_check",
+          "value": "\"post_link\".\"url\" ~ '^https?://'"
+        },
+        "post_link_image_url_check": {
+          "name": "post_link_image_url_check",
+          "value": "\"post_link\".\"image_url\" ~ '^https?://'"
+        },
+        "post_link_image_alt_check": {
+          "name": "post_link_image_alt_check",
+          "value": "\"post_link\".\"image_alt\" IS NULL OR \"post_link\".\"image_url\" IS NOT NULL"
+        },
+        "post_link_image_type_check": {
+          "name": "post_link_image_type_check",
+          "value": "\n        CASE\n          WHEN \"post_link\".\"image_type\" IS NULL THEN true\n          ELSE \"post_link\".\"image_type\" ~ '^image/' AND\n               \"post_link\".\"image_url\" IS NOT NULL\n        END\n      "
+        },
+        "post_link_image_width_height_check": {
+          "name": "post_link_image_width_height_check",
+          "value": "\n        CASE\n          WHEN \"post_link\".\"image_width\" IS NOT NULL\n          THEN \"post_link\".\"image_url\" IS NOT NULL AND\n                 \"post_link\".\"image_height\" IS NOT NULL AND\n                 \"post_link\".\"image_width\" > 0 AND\n                 \"post_link\".\"image_height\" > 0\n          WHEN \"post_link\".\"image_height\" IS NOT NULL\n          THEN \"post_link\".\"image_url\" IS NOT NULL AND\n               \"post_link\".\"image_width\" IS NOT NULL AND\n               \"post_link\".\"image_width\" > 0 AND\n               \"post_link\".\"image_height\" > 0\n          ELSE true\n        END\n      "
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.post_medium": {
+      "name": "post_medium",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "index": {
+          "name": "index",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "post_medium_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alt": {
+          "name": "alt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_key": {
+          "name": "thumbnail_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sensitive": {
+          "name": "sensitive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "post_medium_post_id_post_id_fk": {
+          "name": "post_medium_post_id_post_id_fk",
+          "tableFrom": "post_medium",
+          "tableTo": "post",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "post_medium_post_id_index_pk": {
+          "name": "post_medium_post_id_index_pk",
+          "columns": [
+            "post_id",
+            "index"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "post_medium_thumbnail_key_unique": {
+          "name": "post_medium_thumbnail_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "thumbnail_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "post_medium_index_check": {
+          "name": "post_medium_index_check",
+          "value": "\"post_medium\".\"index\" >= 0"
+        },
+        "post_medium_url_check": {
+          "name": "post_medium_url_check",
+          "value": "\"post_medium\".\"url\" ~ '^https?://'"
+        },
+        "post_medium_width_height_check": {
+          "name": "post_medium_width_height_check",
+          "value": "\n        CASE\n          WHEN \"post_medium\".\"width\" IS NULL THEN \"post_medium\".\"height\" IS NULL\n          ELSE \"post_medium\".\"height\" IS NOT NULL AND\n               \"post_medium\".\"width\" > 0 AND \"post_medium\".\"height\" > 0\n        END\n      "
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.post": {
+      "name": "post",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "iri": {
+          "name": "iri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "post_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "post_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unlisted'"
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "article_source_id": {
+          "name": "article_source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note_source_id": {
+          "name": "note_source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shared_post_id": {
+          "name": "shared_post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_target_id": {
+          "name": "reply_target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quoted_post_id": {
+          "name": "quoted_post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_html": {
+          "name": "content_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "emojis": {
+          "name": "emojis",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "sensitive": {
+          "name": "sensitive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "replies_count": {
+          "name": "replies_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "shares_count": {
+          "name": "shares_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "quotes_count": {
+          "name": "quotes_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reactions_counts": {
+          "name": "reactions_counts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "reactions_count": {
+          "name": "reactions_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "generated": {
+            "as": "json_sum_object_values(\"post\".\"reactions_counts\")",
+            "type": "stored"
+          }
+        },
+        "link_id": {
+          "name": "link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "published": {
+          "name": "published",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_post_visibility_published": {
+          "name": "idx_post_visibility_published",
+          "columns": [
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"published\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_post_actor_id_published": {
+          "name": "idx_post_actor_id_published",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"published\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "post_reply_target_id_index": {
+          "name": "post_reply_target_id_index",
+          "columns": [
+            {
+              "expression": "reply_target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_actor_id_actor_id_fk": {
+          "name": "post_actor_id_actor_id_fk",
+          "tableFrom": "post",
+          "tableTo": "actor",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_article_source_id_article_source_id_fk": {
+          "name": "post_article_source_id_article_source_id_fk",
+          "tableFrom": "post",
+          "tableTo": "article_source",
+          "columnsFrom": [
+            "article_source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_note_source_id_note_source_id_fk": {
+          "name": "post_note_source_id_note_source_id_fk",
+          "tableFrom": "post",
+          "tableTo": "note_source",
+          "columnsFrom": [
+            "note_source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_shared_post_id_post_id_fk": {
+          "name": "post_shared_post_id_post_id_fk",
+          "tableFrom": "post",
+          "tableTo": "post",
+          "columnsFrom": [
+            "shared_post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_reply_target_id_post_id_fk": {
+          "name": "post_reply_target_id_post_id_fk",
+          "tableFrom": "post",
+          "tableTo": "post",
+          "columnsFrom": [
+            "reply_target_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "post_quoted_post_id_post_id_fk": {
+          "name": "post_quoted_post_id_post_id_fk",
+          "tableFrom": "post",
+          "tableTo": "post",
+          "columnsFrom": [
+            "quoted_post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "post_link_id_post_link_id_fk": {
+          "name": "post_link_id_post_link_id_fk",
+          "tableFrom": "post",
+          "tableTo": "post_link",
+          "columnsFrom": [
+            "link_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "post_iri_unique": {
+          "name": "post_iri_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "iri"
+          ]
+        },
+        "post_article_source_id_unique": {
+          "name": "post_article_source_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "article_source_id"
+          ]
+        },
+        "post_note_source_id_unique": {
+          "name": "post_note_source_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "note_source_id"
+          ]
+        },
+        "post_id_actor_id_unique": {
+          "name": "post_id_actor_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "actor_id"
+          ]
+        },
+        "post_actor_id_shared_post_id_unique": {
+          "name": "post_actor_id_shared_post_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "actor_id",
+            "shared_post_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "post_article_source_id_check": {
+          "name": "post_article_source_id_check",
+          "value": "\"post\".\"type\" = 'Article' OR \"post\".\"article_source_id\" IS NULL"
+        },
+        "post_note_source_id_check": {
+          "name": "post_note_source_id_check",
+          "value": "\"post\".\"type\" = 'Note' OR \"post\".\"note_source_id\" IS NULL"
+        },
+        "post_shared_post_id_reply_target_id_check": {
+          "name": "post_shared_post_id_reply_target_id_check",
+          "value": "\"post\".\"shared_post_id\" IS NULL OR \"post\".\"reply_target_id\" IS NULL"
+        },
+        "post_reactions_acounts_check": {
+          "name": "post_reactions_acounts_check",
+          "value": "\"post\".\"reactions_counts\" IS JSON OBJECT"
+        },
+        "post_link_id_check": {
+          "name": "post_link_id_check",
+          "value": "(\"post\".\"link_id\" IS NULL) = (\"post\".\"link_url\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.reaction": {
+      "name": "reaction",
+      "schema": "",
+      "columns": {
+        "iri": {
+          "name": "iri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_emoji_id": {
+          "name": "custom_emoji_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "reaction_post_id_actor_id_emoji_index": {
+          "name": "reaction_post_id_actor_id_emoji_index",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "emoji",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"reaction\".\"custom_emoji_id\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reaction_post_id_actor_id_custom_emoji_id_index": {
+          "name": "reaction_post_id_actor_id_custom_emoji_id_index",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "custom_emoji_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"reaction\".\"emoji\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reaction_post_id_index": {
+          "name": "reaction_post_id_index",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reaction_post_id_post_id_fk": {
+          "name": "reaction_post_id_post_id_fk",
+          "tableFrom": "reaction",
+          "tableTo": "post",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reaction_actor_id_actor_id_fk": {
+          "name": "reaction_actor_id_actor_id_fk",
+          "tableFrom": "reaction",
+          "tableTo": "actor",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reaction_custom_emoji_id_custom_emoji_id_fk": {
+          "name": "reaction_custom_emoji_id_custom_emoji_id_fk",
+          "tableFrom": "reaction",
+          "tableTo": "custom_emoji",
+          "columnsFrom": [
+            "custom_emoji_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "reaction_emoji_check": {
+          "name": "reaction_emoji_check",
+          "value": "\n        \"reaction\".\"emoji\" IS NOT NULL\n          AND length(\"reaction\".\"emoji\") > 0\n          AND \"reaction\".\"emoji\" !~ '^[[:space:]:]+|[[:space:]:]+$'\n          AND \"reaction\".\"custom_emoji_id\" IS NULL\n        OR\n          \"reaction\".\"emoji\" IS NULL AND \"reaction\".\"custom_emoji_id\" IS NOT NULL\n      "
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.timeline_item": {
+      "name": "timeline_item",
+      "schema": "",
+      "columns": {
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_author_id": {
+          "name": "original_author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sharer_id": {
+          "name": "last_sharer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sharers_count": {
+          "name": "sharers_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "added": {
+          "name": "added",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "appended": {
+          "name": "appended",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_timeline_item_account_id_added": {
+          "name": "idx_timeline_item_account_id_added",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"added\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "timeline_item_account_id_account_id_fk": {
+          "name": "timeline_item_account_id_account_id_fk",
+          "tableFrom": "timeline_item",
+          "tableTo": "account",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "timeline_item_post_id_post_id_fk": {
+          "name": "timeline_item_post_id_post_id_fk",
+          "tableFrom": "timeline_item",
+          "tableTo": "post",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "timeline_item_original_author_id_actor_id_fk": {
+          "name": "timeline_item_original_author_id_actor_id_fk",
+          "tableFrom": "timeline_item",
+          "tableTo": "actor",
+          "columnsFrom": [
+            "original_author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "timeline_item_last_sharer_id_actor_id_fk": {
+          "name": "timeline_item_last_sharer_id_actor_id_fk",
+          "tableFrom": "timeline_item",
+          "tableTo": "actor",
+          "columnsFrom": [
+            "last_sharer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "timeline_item_account_id_post_id_pk": {
+          "name": "timeline_item_account_id_post_id_pk",
+          "columns": [
+            "account_id",
+            "post_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.account_key_type": {
+      "name": "account_key_type",
+      "schema": "public",
+      "values": [
+        "Ed25519",
+        "RSASSA-PKCS1-v1_5"
+      ]
+    },
+    "public.account_link_icon": {
+      "name": "account_link_icon",
+      "schema": "public",
+      "values": [
+        "activitypub",
+        "akkoma",
+        "bluesky",
+        "codeberg",
+        "dev",
+        "discord",
+        "facebook",
+        "github",
+        "gitlab",
+        "hackernews",
+        "hollo",
+        "instagram",
+        "keybase",
+        "lemmy",
+        "linkedin",
+        "lobsters",
+        "mastodon",
+        "matrix",
+        "misskey",
+        "pixelfed",
+        "pleroma",
+        "qiita",
+        "reddit",
+        "sourcehut",
+        "threads",
+        "velog",
+        "web",
+        "wikipedia",
+        "x",
+        "zenn"
+      ]
+    },
+    "public.actor_type": {
+      "name": "actor_type",
+      "schema": "public",
+      "values": [
+        "Application",
+        "Group",
+        "Organization",
+        "Person",
+        "Service"
+      ]
+    },
+    "public.notification_type": {
+      "name": "notification_type",
+      "schema": "public",
+      "values": [
+        "follow",
+        "mention",
+        "reply",
+        "share",
+        "quote",
+        "react"
+      ]
+    },
+    "public.passkey_device_type": {
+      "name": "passkey_device_type",
+      "schema": "public",
+      "values": [
+        "singleDevice",
+        "multiDevice"
+      ]
+    },
+    "public.passkey_transport": {
+      "name": "passkey_transport",
+      "schema": "public",
+      "values": [
+        "ble",
+        "cable",
+        "hybrid",
+        "internal",
+        "nfc",
+        "smart-card",
+        "usb"
+      ]
+    },
+    "public.post_medium_type": {
+      "name": "post_medium_type",
+      "schema": "public",
+      "values": [
+        "image/gif",
+        "image/jpeg",
+        "image/png",
+        "image/svg+xml",
+        "image/webp",
+        "video/mp4",
+        "video/webm",
+        "video/quicktime"
+      ]
+    },
+    "public.post_type": {
+      "name": "post_type",
+      "schema": "public",
+      "values": [
+        "Article",
+        "Note",
+        "Question"
+      ]
+    },
+    "public.post_visibility": {
+      "name": "post_visibility",
+      "schema": "public",
+      "values": [
+        "public",
+        "unlisted",
+        "followers",
+        "direct",
+        "none"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -589,6 +589,13 @@
       "when": 1749288874962,
       "tag": "0083_index-lower-email",
       "breakpoints": true
+    },
+    {
+      "idx": 84,
+      "version": "7",
+      "when": 1755851982593,
+      "tag": "0084_account-note-share-visibility",
+      "breakpoints": true
     }
   ]
 }

--- a/models/post.ts
+++ b/models/post.ts
@@ -712,6 +712,7 @@ export async function sharePost(
     links: AccountLink[];
   },
   post: Post & { actor: Actor },
+  visibility?: PostVisibility,
 ): Promise<Post> {
   const { db } = fedCtx.data;
   const actor = await syncActorFromAccount(fedCtx, account);
@@ -720,7 +721,7 @@ export async function sharePost(
     id,
     iri: fedCtx.getObjectUri(vocab.Announce, { id }).href,
     type: post.type,
-    visibility: "public",
+    visibility: visibility || account.shareVisibility,
     actorId: actor.id,
     sharedPostId: post.id,
     name: post.name,

--- a/models/schema.ts
+++ b/models/schema.ts
@@ -26,6 +26,18 @@ import type { Uuid } from "./uuid.ts";
 
 const currentTimestamp = sql`CURRENT_TIMESTAMP`;
 
+export const POST_VISIBILITIES = [
+  "public",
+  "unlisted",
+  "followers",
+  "direct",
+  "none",
+] as const;
+
+export const postVisibilityEnum = pgEnum("post_visibility", POST_VISIBILITIES);
+
+export type PostVisibility = (typeof postVisibilityEnum.enumValues)[number];
+
 export const accountTable = pgTable(
   "account",
   {
@@ -54,6 +66,12 @@ export const accountTable = pgTable(
     preferAiSummary: boolean("prefer_ai_summary")
       .notNull()
       .default(true),
+    noteVisibility: postVisibilityEnum("note_visibility")
+      .notNull()
+      .default("public"),
+    shareVisibility: postVisibilityEnum("share_visibility")
+      .notNull()
+      .default("public"),
     updated: timestamp({ withTimezone: true })
       .notNull()
       .default(currentTimestamp),
@@ -524,18 +542,6 @@ export const articleContentTable = pgTable(
 
 export type ArticleContent = typeof articleContentTable.$inferSelect;
 export type NewArticleContent = typeof articleContentTable.$inferInsert;
-
-export const POST_VISIBILITIES = [
-  "public",
-  "unlisted",
-  "followers",
-  "direct",
-  "none",
-] as const;
-
-export const postVisibilityEnum = pgEnum("post_visibility", POST_VISIBILITIES);
-
-export type PostVisibility = (typeof postVisibilityEnum.enumValues)[number];
 
 export const noteSourceTable = pgTable("note_source", {
   id: uuid().$type<Uuid>().primaryKey(),

--- a/web/islands/DefaultVisibilityPreference.tsx
+++ b/web/islands/DefaultVisibilityPreference.tsx
@@ -1,0 +1,77 @@
+import getFixedT from "../i18n.ts";
+import type { PostVisibility } from "@hackerspub/models/schema";
+import { Label } from "../components/Label.tsx";
+import type { Language } from "../i18n.ts";
+
+export interface DefaultVisibilityPreferenceProps {
+  noteVisibility: PostVisibility;
+  shareVisibility: PostVisibility;
+  language: Language;
+}
+
+export function DefaultVisibilityPreference({
+  noteVisibility,
+  shareVisibility,
+  language,
+}: DefaultVisibilityPreferenceProps) {
+  const t = getFixedT(language);
+
+  return (
+    <>
+      <div class="mt-4 grid md:grid-cols-2 gap-5">
+        <div>
+          <Label label={t("settings.preferences.noteVisibility")}>
+            <select
+              name="noteVisibility"
+              class="border-[1px] bg-stone-200 border-stone-500 dark:bg-stone-700 dark:border-stone-600 dark:text-white cursor-pointer p-2"
+              aria-label={t("composer.visibility")}
+              value={noteVisibility}
+            >
+              <option value="public">
+                {t("postVisibility.public")}
+              </option>
+              <option value="unlisted">
+                {t("postVisibility.unlisted")}
+              </option>
+              <option value="followers">
+                {t("postVisibility.followers")}
+              </option>
+              <option value="direct">
+                {t("postVisibility.direct")}
+              </option>
+            </select>
+          </Label>
+          <p class="opacity-50">
+            {t("settings.preferences.postVisibilityDescription")}
+          </p>
+        </div>
+        <div>
+          <Label label={t("settings.preferences.shareVisibility")}>
+            <select
+              name="shareVisibility"
+              class="border-[1px] bg-stone-200 border-stone-500 dark:bg-stone-700 dark:border-stone-600 dark:text-white cursor-pointer p-2"
+              aria-label={t("composer.visibility")}
+              value={shareVisibility}
+            >
+              <option value="public">
+                {t("postVisibility.public")}
+              </option>
+              <option value="unlisted">
+                {t("postVisibility.unlisted")}
+              </option>
+              <option value="followers">
+                {t("postVisibility.followers")}
+              </option>
+              <option value="direct">
+                {t("postVisibility.direct")}
+              </option>
+            </select>
+          </Label>
+          <p class="opacity-50">
+            {t("settings.preferences.shareVisibilityDescription")}
+          </p>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/web/locales/en.json
+++ b/web/locales/en.json
@@ -139,6 +139,10 @@
       "title": "Preferences",
       "preferAiSummary": "Prefer AI-generated summary",
       "preferAiSummaryDescription": "If enabled, the AI will generate a summary of the article for you. Otherwise, the first few lines of the article will be used as the summary.",
+      "noteVisibility": "Note privacy",
+      "noteVisibilityDescription": "The default privacy setting for your notes.",
+      "shareVisibility": "Share privacy",
+      "shareVisibilityDescription": "The default privacy setting for your shares.",
       "save": "$t(settings.profile.save)"
     },
     "language": {

--- a/web/locales/ja.json
+++ b/web/locales/ja.json
@@ -137,6 +137,10 @@
       "title": "設定",
       "preferAiSummary": "AI生成の要約を優先",
       "preferAiSummaryDescription": "有効にすると、AIが記事の要約を生成します。無効の場合、記事の最初の数行が要約として使用されます。",
+      "noteVisibility": "投稿の公開範囲",
+      "noteVisibilityDescription": "投稿の基本公開範囲を設定します。",
+      "shareVisibility": "共有の公開範囲",
+      "shareVisibilityDescription": "共有の基本公開範囲を設定します。",
       "save": "$t(settings.profile.save)"
     },
     "language": {

--- a/web/locales/ko.json
+++ b/web/locales/ko.json
@@ -137,6 +137,10 @@
       "title": "환경 설정",
       "preferAiSummary": "AI가 생성한 요약 선호",
       "preferAiSummaryDescription": "활성화하면 AI가 게시글의 요약을 생성합니다. 그렇지 않으면 게시글의 첫 몇 줄이 요약으로 사용됩니다.",
+      "noteVisibility": "단문 공개 범위",
+      "noteVisibilityDescription": "단문의 기본 공개 범위를 설정합니다.",
+      "shareVisibility": "공유 공개 범위",
+      "shareVisibilityDescription": "공유 시의 기본 공개 범위를 설정합니다.",
       "save": "$t(settings.profile.save)"
     },
     "language": {

--- a/web/routes/@[username]/[idOrYear]/[slug]/index.tsx
+++ b/web/routes/@[username]/[idOrYear]/[slug]/index.tsx
@@ -520,6 +520,7 @@ export function ArticlePage(
           )
           : (
             <Composer
+              defaultVisibility={state.account!.postVisibility}
               class="mt-4"
               commentTargets={commentTargets}
               language={state.language}

--- a/web/routes/@[username]/[idOrYear]/[slug]/quotes.tsx
+++ b/web/routes/@[username]/[idOrYear]/[slug]/quotes.tsx
@@ -166,6 +166,7 @@ export default define.page<typeof handler, ArticleQuotesProps>(
           )
           : (
             <Composer
+              defaultVisibility={state.account!.postVisibility}
               language={state.language}
               postUrl=""
               noQuoteOnPaste

--- a/web/routes/@[username]/[idOrYear]/quotes.tsx
+++ b/web/routes/@[username]/[idOrYear]/quotes.tsx
@@ -244,6 +244,7 @@ export default define.page<typeof handler, NoteQuotesProps>(
           )
           : (
             <Composer
+              defaultVisibility={state.account!.postVisibility}
               language={state.language}
               postUrl=""
               noQuoteOnPaste

--- a/web/routes/@[username]/settings/preferences.tsx
+++ b/web/routes/@[username]/settings/preferences.tsx
@@ -3,9 +3,12 @@ import { accountTable } from "@hackerspub/models/schema";
 import { eq } from "drizzle-orm";
 import { Button } from "../../../components/Button.tsx";
 import { Msg } from "../../../components/Msg.tsx";
+import { Label } from "../../../components/Label.tsx";
 import { SettingsNav } from "../../../components/SettingsNav.tsx";
 import { db } from "../../../db.ts";
 import { define } from "../../../utils.ts";
+import type { PostVisibility } from "@hackerspub/models/schema";
+import { DefaultVisibilityPreference } from "../../../islands/DefaultVisibilityPreference.tsx";
 
 export const handler = define.handlers({
   GET(ctx) {
@@ -24,8 +27,11 @@ export const handler = define.handlers({
     }
     const form = await ctx.req.formData();
     const preferAiSummary = form.get("preferAiSummary") === "true";
+    const noteVisibility = form.get("noteVisibility") as PostVisibility;
+    const shareVisibility = form.get("shareVisibility") as PostVisibility;
+
     const accounts = await db.update(accountTable)
-      .set({ preferAiSummary })
+      .set({ preferAiSummary, postVisibility, shareVisibility })
       .where(eq(accountTable.id, ctx.state.account.id))
       .returning();
     return page<PreferencesPageProps>(accounts[0]);
@@ -35,33 +41,42 @@ export const handler = define.handlers({
 interface PreferencesPageProps {
   preferAiSummary: boolean;
   leftInvitations: number;
+  postVisibility: PostVisibility;
+  shareVisibility: PostVisibility;
 }
 
 export default define.page<typeof handler, PreferencesPageProps>((
-  { data, params },
-) => (
-  <div>
-    <SettingsNav
-      active="preferences"
-      settingsHref={`/@${params.username}/settings`}
-      leftInvitations={data.leftInvitations}
-    />
-    <form method="post" class="mt-4">
-      <label>
-        <input
-          type="checkbox"
-          name="preferAiSummary"
-          checked={data.preferAiSummary}
-          value="true"
-        />{" "}
-        <Msg $key="settings.preferences.preferAiSummary" />
-      </label>
-      <p class="opacity-50">
-        <Msg $key="settings.preferences.preferAiSummaryDescription" />
-      </p>
-      <Button type="submit" class="mt-4">
-        <Msg $key="settings.preferences.save" />
-      </Button>
-    </form>
-  </div>
-));
+  { state: { language, t }, data, params },
+) => {
+  return (
+    <div>
+      <SettingsNav
+        active="preferences"
+        settingsHref={`/@${params.username}/settings`}
+        leftInvitations={data.leftInvitations}
+      />
+      <form method="post" class="mt-4">
+        <Label label={t("settings.preferences.preferAiSummary")}>
+          <input
+            type="checkbox"
+            name="preferAiSummary"
+            checked={data.preferAiSummary}
+            value="true"
+          />{" "}
+          <Msg $key="settings.preferences.preferAiSummary" />
+          <p class="opacity-50">
+            <Msg $key="settings.preferences.preferAiSummaryDescription" />
+          </p>
+        </Label>
+        <DefaultVisibilityPreference
+          language={language}
+          noteVisibility={data.noteVisibility}
+          shareVisibility={data.shareVisibility}
+        />
+        <Button type="submit" class="mt-4">
+          <Msg $key="settings.preferences.save" />
+        </Button>
+      </form>
+    </div>
+  );
+});

--- a/web/routes/index.tsx
+++ b/web/routes/index.tsx
@@ -11,6 +11,7 @@ import type {
   Post,
   PostLink,
   PostMedium,
+  PostVisibility,
   Reaction,
 } from "@hackerspub/models/schema";
 import {
@@ -243,6 +244,7 @@ export default define.page<typeof handler, HomeProps>(
           <Composer
             language={state.language}
             postUrl={`/@${state.account!.username}`}
+            defaultVisibility={state.account!.postVisibility}
             onPost="reload"
           />
         )}


### PR DESCRIPTION
This PR partially resolves #134.

Currently, it's not possible to change a post's visibility from the `Editor`. To address a part of the related issue, this PR introduces a new setting to allow users to specify the default visibility for notes and shares, excluding posts.

<img width="977" height="413" alt="image" src="https://github.com/user-attachments/assets/79e80f66-6925-4b72-9535-90a30c458c46" />


