### PR TITLE
Resolve warnings related with deno.json

### DIFF
--- a/web-next/deno.jsonc
+++ b/web-next/deno.jsonc
@@ -10,9 +10,6 @@
     "build": "vinxi build",
     "extract": "pnpm dlx @lingui/cli extract"
   },
-  "unstable": [
-    "sloppy-imports"
-  ],
   "lint": {
     "rules": {
       "exclude": [
@@ -24,11 +21,6 @@
     }
   },
   "compilerOptions": {
-    "paths": {
-      "~/*": [
-        "./src/*"
-      ]
-    },
     "jsx": "react-jsx",
     "jsxImportSource": "solid-js",
     "types": [


### PR DESCRIPTION
This pull request resolves warnings like following messages:

```
Warning "unstable" field can only be specified in the workspace root deno.json file.
    at file:///path/to/hackerspub/web-next/deno.jsonc
```

```
Unsupported compiler options in "file:///path/to/hackerspub/web-next/deno.jsonc".
  The following options were ignored:
    paths
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Cleaned up runtime configuration by removing unstable settings to align with stable defaults.
  * Simplified module resolution by removing a custom path alias, reducing confusion during development.
  * No user-facing changes expected.

* Refactor
  * Streamlined build configuration to improve consistency and reduce environment-specific edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->