### PR TITLE
Include customized message to invitation mail which is triggered by invitation link

### DIFF
--- a/web/routes/@[username]/invite/[id]/index.tsx
+++ b/web/routes/@[username]/invite/[id]/index.tsx
@@ -98,13 +98,11 @@ export const handler = define.handlers({
         `${invitationLink.inviter.name} (@${invitationLink.inviter.username}@${
           new URL(ctx.state.canonicalOrigin).host
         })`;
-      await sendEmail({
-        to: email,
-        subject: t("settings.invite.invitationEmailSubject", {
-          inviter,
-          inviterName: invitationLink.inviter.name,
-        }),
-        text: t("settings.invite.invitationEmailText", {
+
+      const invitationMessage = invitationLink.message;
+
+      const invitationEmailBody = (invitationMessage || "").trim() === ""
+        ? t("settings.invite.invitationEmailText", {
           inviter,
           inviterName: invitationLink.inviter.name,
           verifyUrl: verifyUrl.href,
@@ -112,7 +110,25 @@ export const handler = define.handlers({
             // @ts-ignore: DurationFormatOptions, not DateTimeFormatOptions
             style: "long",
           }),
+        })
+        : t("settings.invite.invitationEmailTextWithMessage", {
+          inviter,
+          inviterName: invitationLink.inviter.name,
+          message: invitationMessage,
+          verifyUrl: verifyUrl.href,
+          expiration: EXPIRATION.toLocaleString(ctx.state.language, {
+            // @ts-ignore: DurationFormatOptions, not DateTimeFormatOptions
+            style: "long",
+          }),
+        });
+
+      await sendEmail({
+        to: email,
+        subject: t("settings.invite.invitationEmailSubject", {
+          inviter,
+          inviterName: invitationLink.inviter.name,
         }),
+        text: invitationEmailBody,
       });
       return page<InvitationLinkPageProps>({
         inviter: invitationLink.inviter,


### PR DESCRIPTION
## Context

Previously, invitation emails sent via direct email entry included any custom message the inviter wrote. However, invitation emails generated through invitation links did not include this custom message, even if one was provided. This created an inconsistent experience between the two invitation methods.

## Changes

* Added logic to check whether the invitation link has a custom message.
* If a message is present, the email body now uses the settings.invite.invitationEmailTextWithMessage template.
* If no message is present, the email falls back to the default settings.invite.invitationEmailText template.
* Ensured that both flows (direct email invitations and link-based invitations) consistently handle inviter name, link, and expiration time.

## Impact

This change ensures:
* Consistency between direct email invitations and link-based invitations.
* A better user experience, since invitees now receive any personalized message the inviter intended to include, regardless of how the invitation was sent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Invitation emails now include a custom message from the invitation link when provided, improving personalization.
  - When no message is supplied, a clear default template is used.
  - Emails always include the verification link and expiration details.
  - Email subject remains unchanged; only the body content is updated for clarity and relevance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->