### PR TITLE
web-next: Make timestamps clickable links in NoteCard

### DIFF
--- a/web-next/src/components/NoteCard.tsx
+++ b/web-next/src/components/NoteCard.tsx
@@ -92,6 +92,7 @@ function NoteCardInternal(props: NoteCardInternalProps) {
         language
         visibility
         published
+        url
       }
     `,
     () => props.$note,
@@ -130,8 +131,9 @@ function NoteCardInternal(props: NoteCardInternalProps) {
                 </span>
               </div>
               <div class="flex flex-row text-muted-foreground gap-1">
-                <Timestamp value={note().published} capitalizeFirstLetter />
-                {" "}
+                <a href={note().url || undefined}>
+                  <Timestamp value={note().published} capitalizeFirstLetter />
+                </a>{" "}
                 &middot; <VisibilityTag visibility={note().visibility} />
               </div>
             </div>


### PR DESCRIPTION
In the Fresh project version, the NoteCard’s timestamp was provided as a link pointing to the path of the corresponding Note. This pull request implements that feature in web-next.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Note cards now provide a direct link to the full note: the published timestamp is clickable when a URL is available.
* **UX Improvements**
  * Improved navigation by enabling users to open the note directly from the card via the timestamp link.
  * Behavior is unchanged when a note lacks a URL; the timestamp displays without a link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->