### PR TITLE
chore: Allow 'start' attribute for 'ol' element

### DIFF
--- a/models/html.ts
+++ b/models/html.ts
@@ -88,7 +88,7 @@ const htmlXss = new FilterXSS({
     li: ["class", "id", "lang", "translate"],
     mark: ["lang", "translate"],
     nav: ["lang", "translate"],
-    ol: ["class", "lang", "translate"],
+    ol: ["class", "lang", "translate", "start"],
     p: ["class", "dir", "lang", "translate"],
     picture: ["lang", "translate"],
     pre: ["lang", "translate", "class", "style"],


### PR DESCRIPTION
This PR allows the XSS filter to permit the `start` attribute for `ol` elements.

While exploring CommonMark, I discovered the following[^1] feature and tried it on Hackers' Pub, but it didn't work as expected.

```markdown
1. First
2. Second
3) Third
```

The above example should be converted to:

```
<ol>
  <li>First</li>
  <li>Second</li>
</ol>
<ol start="3">
  <li>Third</li>
</ol>
```

After checking the logs, I found that CommonMark works correctly, but the `start` attribute gets removed during the XSS filtering process. This happens because it's not defined in the `allowList` parameter of `FilterXSS`. This PR modifies the `allowList` to ensure the `start` attribute is preserved.

When I reviewed the MDN documentation[^2], I couldn't predict how this might be exploited for XSS attacks, so I'm curious if you've found any related attack vectors. I created this PR thinking it would be good to support it according to the CommonMark spec, but since it's not a critical PR, it's fine if it's not added.

[^1]: https://spec.commonmark.org/0.31.2/#example-302
[^2]: https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/ol#start

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Ordered lists now support the start attribute in sanitized HTML, enabling custom numbering sequences (e.g., begin at a specific number). Previously this attribute was removed; it is now preserved when creating, importing, or rendering content. This improves formatting fidelity for documents that rely on non-default list numbering across both editing and viewing experiences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->