### PR TITLE
Fix missing reactionGroup.reactors where clause

### DIFF
--- a/graphql/reactable.ts
+++ b/graphql/reactable.ts
@@ -1,9 +1,9 @@
-import { drizzleConnectionHelpers } from "@pothos/plugin-drizzle";
 import type { RelationsFilter } from "@hackerspub/models/db";
 import { type Uuid, validateUuid } from "@hackerspub/models/uuid";
+import { drizzleConnectionHelpers } from "@pothos/plugin-drizzle";
+import { assertNever } from "@std/assert/unstable-never";
 import { Actor } from "./actor.ts";
 import { builder, Node } from "./builder.ts";
-import { assertNever } from "@std/assert/unstable-never";
 
 export interface Reactable {
   id: Uuid;
@@ -76,6 +76,7 @@ export const ReactionGroup = builder.interfaceRef<ReactionGroup>(
           where: {
             ...query.where,
             ...group.where,
+            postId: group.subject.id,
           },
         });
         return {


### PR DESCRIPTION
postId filter was missing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reaction lists now show only users who reacted to the specific post, preventing cross-post reactions from appearing.
  * Improves accuracy and consistency of reactors displayed within reaction groups.
  * Ensures reaction counts and user lists correctly align with the post being viewed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->