### PR TITLE
graphql: expose post.lastSharer

### DIFF
--- a/graphql/post.ts
+++ b/graphql/post.ts
@@ -126,6 +126,7 @@ builder.drizzleInterfaceFields(Post, (t) => ({
   quotedPost: t.relation("quotedPost", { type: Post, nullable: true }),
   replies: t.relatedConnection("replies", { type: Post }),
   shares: t.relatedConnection("shares", { type: Post }),
+  lastSharer: t.relation("actor", { nullable: true }),
   quotes: t.relatedConnection("quotes", { type: Post }),
   mentions: t.connection({
     type: Actor,

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -261,6 +261,7 @@ type Article implements Node & Post & Reactable {
   id: ID!
   iri: URL!
   language: String
+  lastSharer: Actor
   link: PostLink
   media: [PostMedium!]!
   mentions(after: String, before: String, first: Int, last: Int): PostMentionsConnection!
@@ -560,6 +561,7 @@ type Note implements Node & Post & Reactable {
   id: ID!
   iri: URL!
   language: String
+  lastSharer: Actor
   link: PostLink
   media: [PostMedium!]!
   mentions(after: String, before: String, first: Int, last: Int): PostMentionsConnection!
@@ -691,6 +693,7 @@ interface Post implements Node & Reactable {
   id: ID!
   iri: URL!
   language: String
+  lastSharer: Actor
   link: PostLink
   media: [PostMedium!]!
   mentions(after: String, before: String, first: Int, last: Int): PostMentionsConnection!
@@ -889,6 +892,7 @@ type Question implements Node & Post & Reactable {
   id: ID!
   iri: URL!
   language: String
+  lastSharer: Actor
   link: PostLink
   media: [PostMedium!]!
   mentions(after: String, before: String, first: Int, last: Int): PostMentionsConnection!


### PR DESCRIPTION
The `lastSharer` field is required to identify whether a post from `personalTimeline` was shared.

https://github.com/hackers-pub/hackerspub/blob/bffd99d2debcc871158a1bd7efcca04da73215e2/web/components/PostExcerpt.tsx#L75-L85

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new optional “lastSharer” field to posts, enabling clients to retrieve the most recent sharer of a post.
  * Available across Post and its types (Article, Note, Question) for consistent querying.
  * Non-breaking addition: existing queries and behaviors remain unchanged unless the new field is requested.
  * Enhances visibility into sharing activity for content, supporting richer feeds, attributions, and analytics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->