### PR TITLE
graphql: Filter out shared posts from actor articles

### DIFF
--- a/graphql/actor.ts
+++ b/graphql/actor.ts
@@ -204,6 +204,11 @@ export const Actor = builder.drizzleNode("actorTable", {
         where: {
           AND: [
             { type: "Article" },
+            {
+              articleSourceId: {
+                isNotNull: true,
+              },
+            },
             getPostVisibilityFilter(ctx.account?.actor ?? null),
           ],
         },


### PR DESCRIPTION
When querying `actorByHandle(...) { articles { ... } }` in GraphQL, I think they want to know articles written by the actor. But the previous implementation seems to include shared articles (`type=Article && shared_post_id IS NOT NULL && article_source_id IS NULL` in the `post` table). So this pull request lets the `Actor.articles` field exclude the shared articles by checking `article_source_id IS NOT NULL`.

For instance, when running the following GraphQL query, it occurs an error because it tries to access `post.articleSource` even if the `articleSource` is NULL.

```graphql
query GetArticles {
  actorByHandle(handle: "moreal@hackers.pub") {
    id
    articles {
      edges {
        cursor
        node {
          account {
            name
          }
        }
      }
    }
  }
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Actor pages now display a cleaner, more reliable list of related articles by excluding entries that lack source information. This improves relevance, reduces noise, and helps prevent empty or placeholder items from appearing in article feeds. Users should notice more consistent content and fewer incomplete articles when browsing actor-related content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->