### PR TITLE
graphql: Enable reactionsGroup field resolution for Article type

### DIFF
--- a/graphql/post.ts
+++ b/graphql/post.ts
@@ -149,15 +149,9 @@ export const Note = builder.drizzleNode("postTable", {
 
 export const Article = builder.drizzleNode("postTable", {
   variant: "Article",
-  // @ts-ignore: TODO
   interfaces: [Post, Reactable],
   id: {
     column: (post) => post.id,
-  },
-  select: {
-    with: {
-      articleSource: true,
-    },
   },
   fields: (t) => ({
     publishedYear: t.int({


### PR DESCRIPTION
This PR fixes an issue where a `message: "Cannot convert undefined or null to object", path: [ "actorByHandle", "articles", "edges", 0, "node", "reactionGroups" ]` error occurs when trying to fetch the `Reactable.reactionGroups` field under the `Article` type. The `@ts-ignore` comment was unintended but seemed to be resolved, so it was removed.


Reproduction
---------------

```graphql
{
  actorByHandle(handle: "moreal", allowLocalHandle: true) {
    articles {
      edges {
        node {
          reactionGroups {
            ... on EmojiReactionGroup {
              reactors {
                totalCount
                edges {
                  node {
                    __typename
                  }
                }
              }
            }
          }
        }
      }
    }
  }
}
```