### PR TITLE
Fix typo in Japanese translation (外~人 => 他~人)

### DIFF
--- a/web-next/src/locales/ja-JP/messages.po
+++ b/web-next/src/locales/ja-JP/messages.po
@@ -37,38 +37,38 @@ msgstr "{0, plural, other {これまでに合計#人を招待しました。}}"
 #. placeholder {1}: "COUNT"
 #: src/components/notification/FollowNotificationCard.tsx:29
 msgid "{0} and {1} others followed you"
-msgstr "{0}さん外{1}人があなたをフォローしました"
+msgstr "{0}さん他{1}人があなたをフォローしました"
 
 #. placeholder {0}: "ACTOR"
 #. placeholder {1}: "COUNT"
 #: src/components/notification/MentionNotificationCard.tsx:36
 msgid "{0} and {1} others mentioned you"
-msgstr "{0}さん外{1}人があなたにメンションしました"
+msgstr "{0}さん他{1}人があなたにメンションしました"
 
 #. placeholder {0}: "ACTOR"
 #. placeholder {1}: "COUNT"
 #: src/components/notification/QuoteNotificationCard.tsx:34
 msgid "{0} and {1} others quoted your post"
-msgstr "{0}さん外{1}人があなたのコンテンツを引用しました"
+msgstr "{0}さん他{1}人があなたのコンテンツを引用しました"
 
 #. placeholder {0}: "ACTOR"
 #. placeholder {1}: "COUNT"
 #. placeholder {2}: "EMOJI"
 #: src/components/notification/ReactNotificationCard.tsx:59
 msgid "{0} and {1} others reacted to your post with {2}"
-msgstr "{0}さん外{1}人があなたのコンテンツに{2}でリアクションしました"
+msgstr "{0}さん他{1}人があなたのコンテンツに{2}でリアクションしました"
 
 #. placeholder {0}: "ACTOR"
 #. placeholder {1}: "COUNT"
 #: src/components/notification/ReplyNotificationCard.tsx:34
 msgid "{0} and {1} others replied to your post"
-msgstr "{0}さん外{1}人があなたのコンテンツに返信しました"
+msgstr "{0}さん他{1}人があなたのコンテンツに返信しました"
 
 #. placeholder {0}: "ACTOR"
 #. placeholder {1}: "COUNT"
 #: src/components/notification/ShareNotificationCard.tsx:34
 msgid "{0} and {1} others shared your post"
-msgstr "{0}さん外{1}人があなたのコンテンツを共有しました"
+msgstr "{0}さん他{1}人があなたのコンテンツを共有しました"
 
 #. placeholder {0}: "ACTOR"
 #: src/components/notification/FollowNotificationCard.tsx:28

--- a/web/locales/ja.json
+++ b/web/locales/ja.json
@@ -37,7 +37,7 @@
     "mentionedYou": "{{actor}}さんがあなたにメンションしました",
     "repliedToYourPost": "{{actor}}さんがあなたのコンテンツに返信しました",
     "sharedYourPost_zero": "{{actor}}さんがあなたのコンテンツを共有しました",
-    "sharedYourPost_other": "{{actor}}さん外{{count}}人があなたのコンテンツを共有しました",
+    "sharedYourPost_other": "{{actor}}さん他{{count}}人があなたのコンテンツを共有しました",
     "quotedYourPost": "{{actor}}さんがあなたのコンテンツを引用しました",
     "reactedToYourPost_zero": "{{actor}}さんがあなたのコンテンツに{{emoji}}でリアクションしました",
     "reactedToYourPost_other": "{{actor}}さんと他{{count}}人があなたのコンテンツに{{emoji}}でリアクションしました"


### PR DESCRIPTION
Fixed typo in Japanese translation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Refined Japanese translations for notification messages to enhance natural phrasing and readability
  * Updated follow, mention, quote, reaction, reply, and share notifications with improved Japanese language conventions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->