### PR TITLE
Bump Deno to 2.6.4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: denoland/setup-deno@v2
       with:
-        deno-version: 2.6.3
+        deno-version: 2.6.4
         cache: true
     - uses: pnpm/action-setup@v4
       with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/denoland/deno:2.6.3
+FROM docker.io/denoland/deno:2.6.4
 
 RUN apt-get update && apt-get install -y build-essential curl ffmpeg jq && \
   apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM docker.io/denoland/deno:2.6.3
+FROM docker.io/denoland/deno:2.6.4
 
 RUN apt-get update && apt-get install -y build-essential curl ffmpeg jq git && \
   apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,3 @@
 [tools]
-deno = "2.6.3"
+deno = "2.6.4"
 "npm:pnpm" = "10.12.4"


### PR DESCRIPTION
This pull request bumps Deno version to [2.6.4][deno-2.6.4]. This upgrade fixes a minor but inconvenient issue where patch packages (e.g., `@deno/vite-plugin`) are updated when `deno install` is run from this repository[^1].


[deno-2.6.4]: https://github.com/denoland/deno/releases/tag/v2.6.4
[^1]: https://github.com/denoland/deno/pull/31711

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development toolchain version across CI/CD and local build environments for consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->