### PR TITLE
Add NO_WATCHMAN support for environments without watchman

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,5 +1,7 @@
 FROM docker.io/denoland/deno:2.6.4
 
+ENV NO_WATCHMAN=1
+
 RUN apt-get update && apt-get install -y build-essential curl ffmpeg jq git && \
   apt-get clean && rm -rf /var/lib/apt/lists/*
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,25 @@ services:
       - /app/.cache
       - /app/.deno
 
+  web-next:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    environment:
+      NO_WATCHMAN: "1"
+      VITE_API_URL: http://app:8000/graphql
+      HOST: "0.0.0.0"
+    ports:
+      - "3000:3000"
+    depends_on:
+      - app
+    command: sh -c "deno task -f web-next codegen && deno task -f web-next dev"
+    volumes:
+      - .:/app
+      - /app/deps
+      - /app/.cache
+      - /app/.deno
+
   db:
     image: postgres:17
     environment:

--- a/web-next/app.config.ts
+++ b/web-next/app.config.ts
@@ -1,3 +1,5 @@
+import process from "node:process";
+
 import deno from "@deno/vite-plugin";
 import { lingui } from "@lingui/vite-plugin";
 import { defineConfig } from "@solidjs/start/config";
@@ -59,7 +61,7 @@ export default defineConfig({
       deno(),
       tailwindcss(),
       lingui(),
-      relay(),
+      relay({ codegen: process.env.NO_WATCHMAN == "1" ? false : true }),
       cjsInterop({ dependencies: ["relay-runtime"] }),
       Icons({ compiler: "solid" }),
     ],


### PR DESCRIPTION
## Summary

Add `NO_WATCHMAN` environment variable to support running relay-compiler in environments where watchman is unavailable or unreliable (Docker containers on ARM64 Linux, systems with watchman timeout issues).

When `NO_WATCHMAN=1` is set, relay codegen runs once at startup and the vite plugin's automatic watch mode is disabled. Also adds a dedicated `web-next` Docker Compose service for development.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a development web service with build, port mapping (3000), and volume configuration.
  * Introduced NO_WATCHMAN environment variable across the dev setup.
  * Development tooling now reads NO_WATCHMAN to adjust local codegen/watch behavior.
  * Dev service includes development-specific environment variables (e.g., API URL and host) and local cache volumes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->