### PR TITLE
Add searchActorsByHandle GraphQL query

### DIFF
--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -914,6 +914,7 @@ type Query {
   nodes(ids: [ID!]!): [Node]!
   personalTimeline(after: String, before: String, first: Int, last: Int, local: Boolean = false, postType: PostType, withoutShares: Boolean = false): QueryPersonalTimelineConnection!
   publicTimeline(after: String, before: String, first: Int, languages: [Locale!] = [], last: Int, local: Boolean = false, postType: PostType, withoutShares: Boolean = false): QueryPublicTimelineConnection!
+  searchActorsByHandle(limit: Int = 25, prefix: String!): [Actor!]!
   searchGuide(
     """The locale for the search guide."""
     locale: Locale!


### PR DESCRIPTION
## Summary
- Adds a new GraphQL query `searchActorsByHandle` for searching actors by handle prefix
- Supports mention autocomplete functionality in the frontend

## Changes
- `graphql/actor.ts`: Backend resolver implementation
- `graphql/schema.graphql`: Schema definition for the new query


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Actor handle search now available. Users can search for actors by handle prefix with results ranked by relevance. Customizable result limits supported up to 50.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->