### PR TITLE
Add `deletePost` GraphQL mutation

### DIFF
--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -400,7 +400,7 @@ type DeletePostPayload {
   deletedPostId: ID!
 }
 
-union DeletePostResult = DeletePostPayload | InvalidInputError | NotAuthenticatedError
+union DeletePostResult = DeletePostPayload | InvalidInputError | NotAuthenticatedError | SharedPostDeletionNotAllowedError
 
 """A document in a specific language."""
 type Document {
@@ -1149,6 +1149,10 @@ type SharePostPayload {
 }
 
 union SharePostResult = InvalidInputError | NotAuthenticatedError | SharePostPayload
+
+type SharedPostDeletionNotAllowedError {
+  inputPath: String!
+}
 
 enum SignupBioError {
   BIO_TOO_LONG


### PR DESCRIPTION
This pull request just introduces `deletePost` mutation which deletes post (Note, Article and Question).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced deletePost mutation allowing authenticated users to remove their posts.
  * Added ownership validation to ensure only post authors can delete their content.
  * Implemented error handling to prevent deletion of shared posts with specific error messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->