### PR TITLE
Fix empty actorIds check in notification deletion

### DIFF
--- a/models/notification.ts
+++ b/models/notification.ts
@@ -247,6 +247,9 @@ export async function deleteNotification(
         ),
       )
       .returning();
+    const isActorIdsEmpty = isNull(
+      sql`array_length(${notificationTable.actorIds}, 1)`,
+    );
     const deleted = await db.delete(notificationTable)
       .where(
         and(
@@ -260,7 +263,7 @@ export async function deleteNotification(
             : typeof emoji === "string"
             ? eq(notificationTable.emoji, emoji)
             : eq(notificationTable.customEmojiId, emoji.id),
-          eq(sql`array_length(${notificationTable.actorIds}, 1)`, 0),
+          isActorIdsEmpty,
         ),
       )
       .returning();


### PR DESCRIPTION
In PostgreSQL, `array_length(array, 1)` returns `NULL` instead of 0 when `array` is empty (i.e., `{}`).

> https://www.postgresql.org/docs/current/functions-array.html#ARRAY-FUNCTIONS-TABLE
> array_length ( anyarray, integer ) → integer
>   Returns the length of the requested array dimension. (Produces NULL instead of 0 for empty or missing array dimensions.)
>   array_length(array[1,2,3], 1) → 3
>   array_length(array[]::int[], 1) → NULL
>   array_length(array['text'], 2) → NULL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal notification deletion logic for improved code efficiency.

---

**Note:** This release contains no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->