### PR TITLE
Implement `/<username>/following` page

### DIFF
--- a/web-next/src/components/ActorFollowingList.tsx
+++ b/web-next/src/components/ActorFollowingList.tsx
@@ -1,0 +1,98 @@
+import { graphql } from "relay-runtime";
+import { createSignal, For, Match, Show, Switch } from "solid-js";
+import { createPaginationFragment } from "solid-relay";
+import { useLingui } from "~/lib/i18n/macro.d.ts";
+import { ActorFollowingList_following$key } from "./__generated__/ActorFollowingList_following.graphql.ts";
+import { SmallProfileCard } from "./SmallProfileCard.tsx";
+
+export interface ActorFollowingListProps {
+  $following: ActorFollowingList_following$key;
+}
+
+export function ActorFollowingList(props: ActorFollowingListProps) {
+  const { t } = useLingui();
+  const following = createPaginationFragment(
+    graphql`
+      fragment ActorFollowingList_following on Actor
+        @refetchable(queryName: "ActorFollowingListQuery")
+        @argumentDefinitions(
+          cursor: { type: "String" }
+          count: { type: "Int", defaultValue: 20 }
+        )
+      {
+        __id
+        followees(after: $cursor, first: $count)
+          @connection(key: "ActorFollowingList_followees")
+        {
+          edges {
+            __id
+            node {
+              ...SmallProfileCard_actor
+            }
+          }
+          pageInfo {
+            hasNextPage
+          }
+        }
+      }
+    `,
+    () => props.$following,
+  );
+  const [loadingState, setLoadingState] = createSignal<
+    "loaded" | "loading" | "errored"
+  >("loaded");
+
+  function onLoadMore() {
+    setLoadingState("loading");
+    following.loadNext(20, {
+      onComplete(error) {
+        setLoadingState(error == null ? "loaded" : "errored");
+      },
+    });
+  }
+
+  return (
+    <div class="border rounded-xl *:first:rounded-t-xl *:last:rounded-b-xl max-w-prose mx-auto my-4">
+      <Show when={following()}>
+        {(data) => (
+          <>
+            <ul class="divide-y divide-solid">
+              <For each={data().followees.edges}>
+                {(edge) => (
+                  <li>
+                    <SmallProfileCard $actor={edge.node} />
+                  </li>
+                )}
+              </For>
+            </ul>
+            <Show when={following.hasNext}>
+              <div
+                on:click={loadingState() === "loading" ? undefined : onLoadMore}
+                class="block px-4 py-8 text-center text-muted-foreground cursor-pointer hover:text-primary hover:bg-secondary"
+              >
+                <Switch>
+                  <Match
+                    when={following.pending || loadingState() === "loading"}
+                  >
+                    {t`Loading more following…`}
+                  </Match>
+                  <Match when={loadingState() === "errored"}>
+                    {t`Failed to load more following; click to retry`}
+                  </Match>
+                  <Match when={loadingState() === "loaded"}>
+                    {t`Load more following`}
+                  </Match>
+                </Switch>
+              </div>
+            </Show>
+            <Show when={data().followees.edges.length < 1}>
+              <div class="px-4 py-8 text-center text-muted-foreground">
+                {t`No following found`}
+              </div>
+            </Show>
+          </>
+        )}
+      </Show>
+    </div>
+  );
+}

--- a/web-next/src/components/ProfileCard.tsx
+++ b/web-next/src/components/ProfileCard.tsx
@@ -198,7 +198,11 @@ export function ProfileCard(props: ProfileCardProps) {
           </Show>
           <div class="p-4 pt-0 border-b">
             <div class="mx-auto max-w-prose text-muted-foreground">
-              <a>
+              <a
+                href={actor().local
+                  ? `/@${actor().username}/following`
+                  : undefined}
+              >
                 {i18n._(
                   msg`${
                     plural(actor().followeesCount.totalCount, {

--- a/web-next/src/locales/en-US/messages.po
+++ b/web-next/src/locales/en-US/messages.po
@@ -14,12 +14,12 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. placeholder {0}: actor().followersCount.totalCount
-#: src/components/ProfileCard.tsx:218
+#: src/components/ProfileCard.tsx:222
 msgid "{0, plural, one {# follower} other {# followers}}"
 msgstr "{0, plural, one {# follower} other {# followers}}"
 
 #. placeholder {0}: actor().followeesCount.totalCount
-#: src/components/ProfileCard.tsx:203
+#: src/components/ProfileCard.tsx:207
 msgid "{0, plural, one {# following} other {# following}}"
 msgstr "{0, plural, one {# following} other {# following}}"
 
@@ -138,6 +138,12 @@ msgstr "{0}'s articles"
 #: src/routes/(root)/[handle]/(profile)/followers.tsx:69
 msgid "{0}'s followers"
 msgstr "{0}'s followers"
+
+#. placeholder {0}: account().name
+#: src/routes/(root)/[handle]/(profile)/following.tsx:66
+#: src/routes/(root)/[handle]/(profile)/following.tsx:69
+msgid "{0}'s following"
+msgstr "{0}'s following"
 
 #. placeholder {0}: actor().rawName ?? actor().username
 #: src/routes/(root)/[handle]/(profile)/notes.tsx:67
@@ -464,6 +470,10 @@ msgstr "Failed to load more drafts; click to retry"
 msgid "Failed to load more followers; click to retry"
 msgstr "Failed to load more followers; click to retry"
 
+#: src/components/ActorFollowingList.tsx:80
+msgid "Failed to load more following; click to retry"
+msgstr "Failed to load more following; click to retry"
+
 #: src/routes/(root)/[handle]/settings/invite.tsx:488
 msgid "Failed to load more invitees; click to retry"
 msgstr "Failed to load more invitees; click to retry"
@@ -563,7 +573,7 @@ msgstr "Follow Back"
 msgid "Followers only"
 msgstr "Followers only"
 
-#: src/components/ProfileCard.tsx:228
+#: src/components/ProfileCard.tsx:232
 msgid "Following you"
 msgstr "Following you"
 
@@ -730,6 +740,10 @@ msgstr "Load more articles"
 msgid "Load more followers"
 msgstr "Load more followers"
 
+#: src/components/ActorFollowingList.tsx:83
+msgid "Load more following"
+msgstr "Load more following"
+
 #: src/routes/(root)/[handle]/settings/invite.tsx:491
 msgid "Load more invitees"
 msgstr "Load more invitees"
@@ -765,6 +779,10 @@ msgstr "Loading more articles…"
 #: src/components/ActorFollowerList.tsx:77
 msgid "Loading more followers…"
 msgstr "Loading more followers…"
+
+#: src/components/ActorFollowingList.tsx:77
+msgid "Loading more following…"
+msgstr "Loading more following…"
 
 #: src/routes/(root)/[handle]/settings/invite.tsx:485
 msgid "Loading more invitees…"
@@ -864,6 +882,10 @@ msgstr "No drafts yet. Create your first article!"
 #: src/components/ActorFollowerList.tsx:90
 msgid "No followers found"
 msgstr "No followers found"
+
+#: src/components/ActorFollowingList.tsx:90
+msgid "No following found"
+msgstr "No following found"
 
 #: src/routes/(root)/[handle]/settings/invite.tsx:334
 msgid "No invitations left"

--- a/web-next/src/locales/ja-JP/messages.po
+++ b/web-next/src/locales/ja-JP/messages.po
@@ -14,12 +14,12 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. placeholder {0}: actor().followersCount.totalCount
-#: src/components/ProfileCard.tsx:218
+#: src/components/ProfileCard.tsx:222
 msgid "{0, plural, one {# follower} other {# followers}}"
 msgstr "{0, plural, other {#フォロワー}}"
 
 #. placeholder {0}: actor().followeesCount.totalCount
-#: src/components/ProfileCard.tsx:203
+#: src/components/ProfileCard.tsx:207
 msgid "{0, plural, one {# following} other {# following}}"
 msgstr "{0, plural, other {#フォロー}}"
 
@@ -138,6 +138,12 @@ msgstr "{0}さんの記事"
 #: src/routes/(root)/[handle]/(profile)/followers.tsx:69
 msgid "{0}'s followers"
 msgstr "{0}さんのフォロワー"
+
+#. placeholder {0}: account().name
+#: src/routes/(root)/[handle]/(profile)/following.tsx:66
+#: src/routes/(root)/[handle]/(profile)/following.tsx:69
+msgid "{0}'s following"
+msgstr "{0}さんのフォロー中"
 
 #. placeholder {0}: actor().rawName ?? actor().username
 #: src/routes/(root)/[handle]/(profile)/notes.tsx:67
@@ -460,6 +466,10 @@ msgstr "下書きの読み込みに失敗しました。クリックして再試
 msgid "Failed to load more followers; click to retry"
 msgstr "フォロワーの読み込みに失敗しました。クリックして再試行してください"
 
+#: src/components/ActorFollowingList.tsx:80
+msgid "Failed to load more following; click to retry"
+msgstr "フォロー中の読み込みに失敗しました。クリックして再試行してください"
+
 #: src/routes/(root)/[handle]/settings/invite.tsx:488
 msgid "Failed to load more invitees; click to retry"
 msgstr "招待された人々の読み込みに失敗しました。クリックして再試行"
@@ -559,7 +569,7 @@ msgstr "フォローバック"
 msgid "Followers only"
 msgstr "フォロワーのみ"
 
-#: src/components/ProfileCard.tsx:228
+#: src/components/ProfileCard.tsx:232
 msgid "Following you"
 msgstr "あなたをフォロー中"
 
@@ -726,6 +736,10 @@ msgstr "記事をもっと読み込む"
 msgid "Load more followers"
 msgstr "フォロワーをもっと読み込む"
 
+#: src/components/ActorFollowingList.tsx:83
+msgid "Load more following"
+msgstr "フォロー中をもっと読み込む"
+
 #: src/routes/(root)/[handle]/settings/invite.tsx:491
 msgid "Load more invitees"
 msgstr "もっと招待された人々を読み込む"
@@ -761,6 +775,10 @@ msgstr "記事を読み込み中…"
 #: src/components/ActorFollowerList.tsx:77
 msgid "Loading more followers…"
 msgstr "フォロワーを読み込み中…"
+
+#: src/components/ActorFollowingList.tsx:77
+msgid "Loading more following…"
+msgstr "フォロー中を読み込み中…"
 
 #: src/routes/(root)/[handle]/settings/invite.tsx:485
 msgid "Loading more invitees…"
@@ -860,6 +878,10 @@ msgstr "まだ下書きがありません。最初の記事を作成しましょ
 #: src/components/ActorFollowerList.tsx:90
 msgid "No followers found"
 msgstr "フォロワーはいません"
+
+#: src/components/ActorFollowingList.tsx:90
+msgid "No following found"
+msgstr "フォロー中のユーザーはいません"
 
 #: src/routes/(root)/[handle]/settings/invite.tsx:334
 msgid "No invitations left"

--- a/web-next/src/locales/ko-KR/messages.po
+++ b/web-next/src/locales/ko-KR/messages.po
@@ -14,12 +14,12 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. placeholder {0}: actor().followersCount.totalCount
-#: src/components/ProfileCard.tsx:218
+#: src/components/ProfileCard.tsx:222
 msgid "{0, plural, one {# follower} other {# followers}}"
 msgstr "{0, plural, other {# 팔로워}}"
 
 #. placeholder {0}: actor().followeesCount.totalCount
-#: src/components/ProfileCard.tsx:203
+#: src/components/ProfileCard.tsx:207
 msgid "{0, plural, one {# following} other {# following}}"
 msgstr "{0, plural, other {# 팔로잉}}"
 
@@ -138,6 +138,12 @@ msgstr "{0} 님의 게시글"
 #: src/routes/(root)/[handle]/(profile)/followers.tsx:69
 msgid "{0}'s followers"
 msgstr "{0} 님의 팔로워"
+
+#. placeholder {0}: account().name
+#: src/routes/(root)/[handle]/(profile)/following.tsx:66
+#: src/routes/(root)/[handle]/(profile)/following.tsx:69
+msgid "{0}'s following"
+msgstr "{0} 님의 팔로잉"
 
 #. placeholder {0}: actor().rawName ?? actor().username
 #: src/routes/(root)/[handle]/(profile)/notes.tsx:67
@@ -460,6 +466,10 @@ msgstr "임시 보관 불러오기 실패, 클릭하여 재시도"
 msgid "Failed to load more followers; click to retry"
 msgstr "팔로워 불러오기 실패. 클릭하여 재시도하세요"
 
+#: src/components/ActorFollowingList.tsx:80
+msgid "Failed to load more following; click to retry"
+msgstr "팔로잉 불러오기 실패. 클릭하여 재시도하세요"
+
 #: src/routes/(root)/[handle]/settings/invite.tsx:488
 msgid "Failed to load more invitees; click to retry"
 msgstr "초대받은 사람들을 불러오지 못했습니다. 클릭하여 다시 시도"
@@ -559,7 +569,7 @@ msgstr "맞팔하기"
 msgid "Followers only"
 msgstr "팔로워만"
 
-#: src/components/ProfileCard.tsx:228
+#: src/components/ProfileCard.tsx:232
 msgid "Following you"
 msgstr "당신을 팔로우합니다"
 
@@ -726,6 +736,10 @@ msgstr "게시글 더 불러오기"
 msgid "Load more followers"
 msgstr "팔로워 더 불러오기"
 
+#: src/components/ActorFollowingList.tsx:83
+msgid "Load more following"
+msgstr "팔로잉 더 불러오기"
+
 #: src/routes/(root)/[handle]/settings/invite.tsx:491
 msgid "Load more invitees"
 msgstr "초대받은 사람 더 보기"
@@ -761,6 +775,10 @@ msgstr "게시글 불러오는 중…"
 #: src/components/ActorFollowerList.tsx:77
 msgid "Loading more followers…"
 msgstr "팔로워 불러오는 중…"
+
+#: src/components/ActorFollowingList.tsx:77
+msgid "Loading more following…"
+msgstr "팔로잉 불러오는 중…"
 
 #: src/routes/(root)/[handle]/settings/invite.tsx:485
 msgid "Loading more invitees…"
@@ -860,6 +878,10 @@ msgstr "아직 임시 보관이 없습니다. 첫 게시글을 작성하세요!"
 #: src/components/ActorFollowerList.tsx:90
 msgid "No followers found"
 msgstr "팔로워가 없습니다"
+
+#: src/components/ActorFollowingList.tsx:90
+msgid "No following found"
+msgstr "팔로잉하는 사용자가 없습니다"
 
 #: src/routes/(root)/[handle]/settings/invite.tsx:334
 msgid "No invitations left"

--- a/web-next/src/locales/zh-CN/messages.po
+++ b/web-next/src/locales/zh-CN/messages.po
@@ -14,12 +14,12 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. placeholder {0}: actor().followersCount.totalCount
-#: src/components/ProfileCard.tsx:218
+#: src/components/ProfileCard.tsx:222
 msgid "{0, plural, one {# follower} other {# followers}}"
 msgstr "{0, plural, other {被 # 人关注}}"
 
 #. placeholder {0}: actor().followeesCount.totalCount
-#: src/components/ProfileCard.tsx:203
+#: src/components/ProfileCard.tsx:207
 msgid "{0, plural, one {# following} other {# following}}"
 msgstr "{0, plural, other {关注 # 人}}"
 
@@ -138,6 +138,12 @@ msgstr "{0}的文章"
 #: src/routes/(root)/[handle]/(profile)/followers.tsx:69
 msgid "{0}'s followers"
 msgstr "{0}的粉丝"
+
+#. placeholder {0}: account().name
+#: src/routes/(root)/[handle]/(profile)/following.tsx:66
+#: src/routes/(root)/[handle]/(profile)/following.tsx:69
+msgid "{0}'s following"
+msgstr "{0}的关注"
 
 #. placeholder {0}: actor().rawName ?? actor().username
 #: src/routes/(root)/[handle]/(profile)/notes.tsx:67
@@ -460,6 +466,10 @@ msgstr "加载更多草稿失败，点击重试"
 msgid "Failed to load more followers; click to retry"
 msgstr "加载更多粉丝失败，点击重试"
 
+#: src/components/ActorFollowingList.tsx:80
+msgid "Failed to load more following; click to retry"
+msgstr "加载更多关注失败，点击重试"
+
 #: src/routes/(root)/[handle]/settings/invite.tsx:488
 msgid "Failed to load more invitees; click to retry"
 msgstr "加载更多受邀者失败；点击重试"
@@ -559,7 +569,7 @@ msgstr "回关"
 msgid "Followers only"
 msgstr "只粉丝可见"
 
-#: src/components/ProfileCard.tsx:228
+#: src/components/ProfileCard.tsx:232
 msgid "Following you"
 msgstr "关注了你"
 
@@ -726,6 +736,10 @@ msgstr "加载更多文章"
 msgid "Load more followers"
 msgstr "加载更多粉丝"
 
+#: src/components/ActorFollowingList.tsx:83
+msgid "Load more following"
+msgstr "加载更多关注"
+
 #: src/routes/(root)/[handle]/settings/invite.tsx:491
 msgid "Load more invitees"
 msgstr "加载更多受邀者"
@@ -761,6 +775,10 @@ msgstr "加载更多文章中…"
 #: src/components/ActorFollowerList.tsx:77
 msgid "Loading more followers…"
 msgstr "加载更多粉丝中…"
+
+#: src/components/ActorFollowingList.tsx:77
+msgid "Loading more following…"
+msgstr "正在加载更多关注…"
 
 #: src/routes/(root)/[handle]/settings/invite.tsx:485
 msgid "Loading more invitees…"
@@ -860,6 +878,10 @@ msgstr "还没有草稿。创建您的第一篇文章！"
 #: src/components/ActorFollowerList.tsx:90
 msgid "No followers found"
 msgstr "未找到粉丝"
+
+#: src/components/ActorFollowingList.tsx:90
+msgid "No following found"
+msgstr "没有找到关注的用户"
 
 #: src/routes/(root)/[handle]/settings/invite.tsx:334
 msgid "No invitations left"

--- a/web-next/src/locales/zh-TW/messages.po
+++ b/web-next/src/locales/zh-TW/messages.po
@@ -14,12 +14,12 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. placeholder {0}: actor().followersCount.totalCount
-#: src/components/ProfileCard.tsx:218
+#: src/components/ProfileCard.tsx:222
 msgid "{0, plural, one {# follower} other {# followers}}"
 msgstr "{0, plural, other {被 # 人關注}}"
 
 #. placeholder {0}: actor().followeesCount.totalCount
-#: src/components/ProfileCard.tsx:203
+#: src/components/ProfileCard.tsx:207
 msgid "{0, plural, one {# following} other {# following}}"
 msgstr "{0, plural, other {關注 # 人}}"
 
@@ -138,6 +138,12 @@ msgstr "{0}的文章"
 #: src/routes/(root)/[handle]/(profile)/followers.tsx:69
 msgid "{0}'s followers"
 msgstr "{0}的粉絲"
+
+#. placeholder {0}: account().name
+#: src/routes/(root)/[handle]/(profile)/following.tsx:66
+#: src/routes/(root)/[handle]/(profile)/following.tsx:69
+msgid "{0}'s following"
+msgstr "{0}的關注"
 
 #. placeholder {0}: actor().rawName ?? actor().username
 #: src/routes/(root)/[handle]/(profile)/notes.tsx:67
@@ -460,6 +466,10 @@ msgstr "載入更多草稿失敗，點擊重試"
 msgid "Failed to load more followers; click to retry"
 msgstr "載入更多粉絲失敗，點擊重試"
 
+#: src/components/ActorFollowingList.tsx:80
+msgid "Failed to load more following; click to retry"
+msgstr "載入更多關注失敗，點擊重試"
+
 #: src/routes/(root)/[handle]/settings/invite.tsx:488
 msgid "Failed to load more invitees; click to retry"
 msgstr "載入更多受邀者失敗；點擊重試"
@@ -559,7 +569,7 @@ msgstr "回關"
 msgid "Followers only"
 msgstr "只粉絲可見"
 
-#: src/components/ProfileCard.tsx:228
+#: src/components/ProfileCard.tsx:232
 msgid "Following you"
 msgstr "關注了你"
 
@@ -726,6 +736,10 @@ msgstr "載入更多文章"
 msgid "Load more followers"
 msgstr "載入更多粉絲"
 
+#: src/components/ActorFollowingList.tsx:83
+msgid "Load more following"
+msgstr "載入更多關注"
+
 #: src/routes/(root)/[handle]/settings/invite.tsx:491
 msgid "Load more invitees"
 msgstr "載入更多受邀者"
@@ -761,6 +775,10 @@ msgstr "載入更多文章中…"
 #: src/components/ActorFollowerList.tsx:77
 msgid "Loading more followers…"
 msgstr "載入更多粉絲中…"
+
+#: src/components/ActorFollowingList.tsx:77
+msgid "Loading more following…"
+msgstr "正在載入更多關注…"
 
 #: src/routes/(root)/[handle]/settings/invite.tsx:485
 msgid "Loading more invitees…"
@@ -860,6 +878,10 @@ msgstr "還沒有草稿。建立您的第一篇文章！"
 #: src/components/ActorFollowerList.tsx:90
 msgid "No followers found"
 msgstr "未找到粉絲"
+
+#: src/components/ActorFollowingList.tsx:90
+msgid "No following found"
+msgstr "沒有找到關注的使用者"
 
 #: src/routes/(root)/[handle]/settings/invite.tsx:334
 msgid "No invitations left"

--- a/web-next/src/routes/(root)/[handle]/(profile)/following.tsx
+++ b/web-next/src/routes/(root)/[handle]/(profile)/following.tsx
@@ -1,0 +1,84 @@
+import { Meta } from "@solidjs/meta";
+import { query, type RouteDefinition, useParams } from "@solidjs/router";
+import { graphql } from "relay-runtime";
+import { Show } from "solid-js";
+import {
+  createPreloadedQuery,
+  loadQuery,
+  useRelayEnvironment,
+} from "solid-relay";
+import { ActorFollowingList } from "~/components/ActorFollowingList.tsx";
+import { ProfileCard } from "~/components/ProfileCard.tsx";
+import { Title } from "~/components/Title.tsx";
+import { useLingui } from "~/lib/i18n/macro.d.ts";
+import type { followingPageQuery } from "./__generated__/followingPageQuery.graphql.ts";
+
+export const route = {
+  matchFilters: {
+    handle: /^@[^@]+$/,
+  },
+  preload(args) {
+    const username = args.params.handle!;
+    void loadPageQuery(username.substring(1));
+  },
+} satisfies RouteDefinition;
+
+const followingPageQuery = graphql`
+  query followingPageQuery($username: String!) {
+    accountByUsername(username: $username) {
+      name
+      username
+      actor {
+        ...ProfileCard_actor
+        ...ActorFollowingList_following
+      }
+    }
+  }
+`;
+
+const loadPageQuery = query(
+  (username: string) =>
+    loadQuery<followingPageQuery>(
+      useRelayEnvironment()(),
+      followingPageQuery,
+      { username },
+    ),
+  "loadFollowingPageQuery",
+);
+
+export default function ProfileFollowingPage() {
+  const params = useParams();
+  const { t } = useLingui();
+  const username = params.handle!.substring(1);
+  const data = createPreloadedQuery<followingPageQuery>(
+    followingPageQuery,
+    () => loadPageQuery(username),
+  );
+  return (
+    <Show when={data()}>
+      {(data) => (
+        <>
+          <Show
+            when={data().accountByUsername}
+          >
+            {(account) => (
+              <>
+                <Title>{t`${account().name}'s following`}</Title>
+                <Meta
+                  property="og:title"
+                  content={t`${account().name}'s following`}
+                />
+                <div>
+                  <ProfileCard $actor={account().actor} />
+                </div>
+                <div class="p-4">
+                  <ActorFollowingList $following={account().actor} />
+                </div>
+              </>
+            )}
+          </Show>
+        </>
+      )}
+    </Show>
+  );
+}


### PR DESCRIPTION
This pull request introduces `/<username>/following` page that shows the user's following list like `/<username>/followers`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Users can now view a complete paginated list of accounts that someone is following
* The following count displayed on user profiles is now clickable, navigating to the dedicated following list view
* Added full multilingual support for the following list feature across all supported languages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->