### PR TITLE
feat(graphql): add viewerBlocks field in actor

### DIFF
--- a/graphql/actor.ts
+++ b/graphql/actor.ts
@@ -335,6 +335,21 @@ builder.drizzleObjectFields(Actor, (t) => ({
       }) != null;
     },
   }),
+  viewerBlocks: t.field({
+    type: "Boolean",
+    async resolve(actor, _, ctx) {
+      if (ctx.account == null || ctx.account.actor == null) {
+        return false;
+      }
+      return await ctx.db.query.blockingTable.findFirst({
+        columns: { iri: true },
+        where: {
+          blockerId: ctx.account.actor.id,
+          blockeeId: actor.id,
+        },
+      }) != null;
+    },
+  }),
   followsViewer: t.field({
     type: "Boolean",
     async resolve(actor, _, ctx) {

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -157,6 +157,7 @@ type Actor implements Node {
   url: URL
   username: String!
   uuid: UUID!
+  viewerBlocks: Boolean!
   viewerFollows: Boolean!
 }
 


### PR DESCRIPTION
This PR add `viewerBlocks: Boolean!` field to Actor. Resolve it from blockingTable (viewer -> actor block relation). Return `false` when the viewer is not authenticated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `viewerBlocks` field to Actor queries, enabling users to check whether they are currently blocking a specific actor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->