### PR TITLE
Add mobile header sidebar trigger

### DIFF
--- a/web-next/src/locales/en-US/messages.po
+++ b/web-next/src/locales/en-US/messages.po
@@ -628,10 +628,15 @@ msgstr "Go to My Drafts"
 
 #: src/components/AppSidebar.tsx:125
 #: src/components/AppSidebar.tsx:216
+#: src/routes/(root).tsx:82
 #: src/routes/(root)/coc.tsx:47
 #: src/routes/(root)/markdown.tsx:47
 msgid "Hackers' Pub"
 msgstr "Hackers' Pub"
+
+#: src/routes/(root).tsx:74
+msgid "Hackers' Pub home"
+msgstr "Hackers' Pub home"
 
 #: src/components/AboutHackersPub.tsx:232
 msgid "Hackers' Pub is a place for software engineers to share their knowledge and experience with each other. It's also an ActivityPub-enabled social network, so you can follow your favorite hackers in the fediverse and get their latest posts in your feed."
@@ -1422,6 +1427,10 @@ msgstr "Title cannot be empty"
 #: src/components/RemoteFollowButton.tsx:182
 msgid "To follow {0}, enter your Fediverse handle."
 msgstr "To follow {0}, enter your Fediverse handle."
+
+#: src/routes/(root).tsx:72
+msgid "Toggle sidebar"
+msgstr "Toggle sidebar"
 
 #. placeholder {0}: "LANGUAGE"
 #: src/components/ArticleCard.tsx:173

--- a/web-next/src/locales/ja-JP/messages.po
+++ b/web-next/src/locales/ja-JP/messages.po
@@ -624,10 +624,15 @@ msgstr "マイ下書きへ"
 
 #: src/components/AppSidebar.tsx:125
 #: src/components/AppSidebar.tsx:216
+#: src/routes/(root).tsx:82
 #: src/routes/(root)/coc.tsx:47
 #: src/routes/(root)/markdown.tsx:47
 msgid "Hackers' Pub"
 msgstr "Hackers' Pub"
+
+#: src/routes/(root).tsx:74
+msgid "Hackers' Pub home"
+msgstr "Hackers' Pubホーム"
 
 #: src/components/AboutHackersPub.tsx:232
 msgid "Hackers' Pub is a place for software engineers to share their knowledge and experience with each other. It's also an ActivityPub-enabled social network, so you can follow your favorite hackers in the fediverse and get their latest posts in your feed."
@@ -1417,6 +1422,10 @@ msgstr "タイトルは空にできません"
 #: src/components/RemoteFollowButton.tsx:182
 msgid "To follow {0}, enter your Fediverse handle."
 msgstr "{0}さんをフォローするには、フェディバースのハンドルを入力してください。"
+
+#: src/routes/(root).tsx:72
+msgid "Toggle sidebar"
+msgstr "サイドバーを切り替える"
 
 #. placeholder {0}: "LANGUAGE"
 #: src/components/ArticleCard.tsx:173

--- a/web-next/src/locales/ko-KR/messages.po
+++ b/web-next/src/locales/ko-KR/messages.po
@@ -624,10 +624,15 @@ msgstr "내 임시 보관으로"
 
 #: src/components/AppSidebar.tsx:125
 #: src/components/AppSidebar.tsx:216
+#: src/routes/(root).tsx:82
 #: src/routes/(root)/coc.tsx:47
 #: src/routes/(root)/markdown.tsx:47
 msgid "Hackers' Pub"
 msgstr "Hackers' Pub"
+
+#: src/routes/(root).tsx:74
+msgid "Hackers' Pub home"
+msgstr "Hackers' Pub 홈"
 
 #: src/components/AboutHackersPub.tsx:232
 msgid "Hackers' Pub is a place for software engineers to share their knowledge and experience with each other. It's also an ActivityPub-enabled social network, so you can follow your favorite hackers in the fediverse and get their latest posts in your feed."
@@ -1417,6 +1422,10 @@ msgstr "제목은 비워둘 수 없습니다"
 #: src/components/RemoteFollowButton.tsx:182
 msgid "To follow {0}, enter your Fediverse handle."
 msgstr "{0}님을 팔로하려면 연합우주 핸들을 입력해 주세요."
+
+#: src/routes/(root).tsx:72
+msgid "Toggle sidebar"
+msgstr "사이드바 전환"
 
 #. placeholder {0}: "LANGUAGE"
 #: src/components/ArticleCard.tsx:173

--- a/web-next/src/locales/zh-CN/messages.po
+++ b/web-next/src/locales/zh-CN/messages.po
@@ -624,10 +624,15 @@ msgstr "前往我的草稿"
 
 #: src/components/AppSidebar.tsx:125
 #: src/components/AppSidebar.tsx:216
+#: src/routes/(root).tsx:82
 #: src/routes/(root)/coc.tsx:47
 #: src/routes/(root)/markdown.tsx:47
 msgid "Hackers' Pub"
 msgstr "Hackers' Pub"
+
+#: src/routes/(root).tsx:74
+msgid "Hackers' Pub home"
+msgstr "Hackers' Pub 首页"
 
 #: src/components/AboutHackersPub.tsx:232
 msgid "Hackers' Pub is a place for software engineers to share their knowledge and experience with each other. It's also an ActivityPub-enabled social network, so you can follow your favorite hackers in the fediverse and get their latest posts in your feed."
@@ -1417,6 +1422,10 @@ msgstr "标题不能为空"
 #: src/components/RemoteFollowButton.tsx:182
 msgid "To follow {0}, enter your Fediverse handle."
 msgstr "要关注{0}，请输入你的联邦宇宙用户名。"
+
+#: src/routes/(root).tsx:72
+msgid "Toggle sidebar"
+msgstr "切换侧边栏"
 
 #. placeholder {0}: "LANGUAGE"
 #: src/components/ArticleCard.tsx:173

--- a/web-next/src/locales/zh-TW/messages.po
+++ b/web-next/src/locales/zh-TW/messages.po
@@ -624,10 +624,15 @@ msgstr "前往我的草稿"
 
 #: src/components/AppSidebar.tsx:125
 #: src/components/AppSidebar.tsx:216
+#: src/routes/(root).tsx:82
 #: src/routes/(root)/coc.tsx:47
 #: src/routes/(root)/markdown.tsx:47
 msgid "Hackers' Pub"
 msgstr "Hackers' Pub"
+
+#: src/routes/(root).tsx:74
+msgid "Hackers' Pub home"
+msgstr "Hackers' Pub 首頁"
 
 #: src/components/AboutHackersPub.tsx:232
 msgid "Hackers' Pub is a place for software engineers to share their knowledge and experience with each other. It's also an ActivityPub-enabled social network, so you can follow your favorite hackers in the fediverse and get their latest posts in your feed."
@@ -1417,6 +1422,10 @@ msgstr "標題不能為空"
 #: src/components/RemoteFollowButton.tsx:182
 msgid "To follow {0}, enter your Fediverse handle."
 msgstr "要關注{0}，請輸入你的聯邦宇宙使用者名稱。"
+
+#: src/routes/(root).tsx:72
+msgid "Toggle sidebar"
+msgstr "切換側邊欄"
 
 #. placeholder {0}: "LANGUAGE"
 #: src/components/ArticleCard.tsx:173

--- a/web-next/src/routes/(root).tsx
+++ b/web-next/src/routes/(root).tsx
@@ -1,6 +1,7 @@
 import {
+  A,
   query,
-  RouteDefinition,
+  type RouteDefinition,
   type RouteSectionProps,
 } from "@solidjs/router";
 import { graphql } from "relay-runtime";
@@ -12,7 +13,7 @@ import {
 import { AppSidebar } from "~/components/AppSidebar.tsx";
 import { FloatingComposeButton } from "~/components/FloatingComposeButton.tsx";
 import { NoteComposeModal } from "~/components/NoteComposeModal.tsx";
-import { SidebarProvider } from "~/components/ui/sidebar.tsx";
+import { SidebarProvider, SidebarTrigger } from "~/components/ui/sidebar.tsx";
 import { Toaster } from "~/components/ui/toast.tsx";
 import { NoteComposeProvider } from "~/contexts/NoteComposeContext.tsx";
 import { ViewerProvider } from "~/contexts/ViewerContext.tsx";
@@ -47,7 +48,7 @@ const loadRootLayoutQuery = query(
 );
 
 export default function RootLayout(props: RouteSectionProps) {
-  const { i18n } = useLingui();
+  const { i18n, t } = useLingui();
   const signedAccount = createPreloadedQuery<RootLayoutQuery>(
     RootLayoutQuery,
     () => loadRootLayoutQuery(),
@@ -64,9 +65,33 @@ export default function RootLayout(props: RouteSectionProps) {
             $signedAccount={signedAccount()?.viewer}
             signedAccountLoaded={!signedAccount.pending}
           />
+          <header class="fixed inset-x-0 top-0 z-40 border-b bg-background/80 backdrop-blur md:hidden">
+            <div class="flex h-14 items-center justify-between px-4">
+              <SidebarTrigger
+                class="size-9 rounded-full"
+                aria-label={t`Toggle sidebar`}
+              />
+              <A href="/" aria-label={t`Hackers' Pub home`}>
+                <picture>
+                  <source
+                    srcset="/logo-dark.svg"
+                    media="(prefers-color-scheme: dark)"
+                  />
+                  <img
+                    src="/logo-light.svg"
+                    alt={t`Hackers' Pub`}
+                    width={111}
+                    height={28}
+                    class="h-7 w-auto"
+                  />
+                </picture>
+              </A>
+              <div class="size-9" aria-hidden="true" />
+            </div>
+          </header>
           <main
             lang={new Intl.Locale(i18n.locale).minimize().baseName}
-            class="w-full"
+            class="w-full pt-14 md:pt-0"
             classList={{
               "bg-[url(/dev-bg-light.svg)]": import.meta.env.DEV,
               "dark:bg-[url(/dev-bg-dark.svg)]": import.meta.env.DEV,


### PR DESCRIPTION
| Sidebar closed | Sidebar opened |
|--------|--------|
|<img width="569" height="869" alt="mobile-header" src="https://github.com/user-attachments/assets/73190b1d-72dc-4b25-b882-1e88e74b12b2" />|<img width="568" height="861" alt="side-bar-open" src="https://github.com/user-attachments/assets/f194b9d8-79d6-43bd-90a1-3f4f48bdeb47" /> | 

Added a mobile-only top header with a sidebar toggle button on the left. Users can now access the sidebar menu on mobile screens.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a fixed, translucent mobile header with a sidebar/menu trigger, responsive home link, and adjusted top padding for improved mobile/desktop layout and accessibility
  * Responsive dark/light logo handling for the home link

* **Localization**
  * Added localized labels for site name, home link, and sidebar toggle across supported locales for clearer screen-reader text and anchors
<!-- end of auto-generated comment: release notes by coderabbit.ai -->