### PR TITLE
Add recommendedActors GraphQL query

### DIFF
--- a/graphql/actor.ts
+++ b/graphql/actor.ts
@@ -925,9 +925,12 @@ builder.queryField("recommendedActors", (t) =>
     type: [Actor],
     args: {
       limit: t.arg.int({ required: false, defaultValue: 10 }),
+      locale: t.arg({ type: "Locale", required: false }),
     },
     async resolve(_root, args, ctx) {
-      const accountLocales = ctx.account?.locales ?? ["en"];
+      const accountLocales = args.locale != null
+        ? [args.locale.language]
+        : (ctx.account?.locales ?? ["en"]);
       const actors = await recommendActors(ctx.db, {
         mainLocale: accountLocales[0],
         locales: accountLocales,

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -981,7 +981,7 @@ type Query {
   personalTimeline(after: String, before: String, first: Int, last: Int, local: Boolean = false, postType: PostType, withoutShares: Boolean = false): QueryPersonalTimelineConnection!
   postByUrl(url: String!): Post
   publicTimeline(after: String, before: String, first: Int, languages: [Locale!] = [], last: Int, local: Boolean = false, postType: PostType, withoutShares: Boolean = false): QueryPublicTimelineConnection!
-  recommendedActors(limit: Int = 10): [Actor!]!
+  recommendedActors(limit: Int = 10, locale: Locale): [Actor!]!
   searchActorsByHandle(limit: Int = 25, prefix: String!): [Actor!]!
   searchGuide(
     """The locale for the search guide."""


### PR DESCRIPTION
## Summary

Adds a `recommendedActors(limit: Int = 10): [Actor!]!` GraphQL query field that exposes the existing multi-factor scoring recommendation algorithm from `models/actor.ts`. This enables the web-next frontend to fetch follow recommendations via Relay, achieving parity with the legacy stack's `RecommendedActors` component.

- Reuses the existing `recommendActors()` function (engagement, mutual follows, content, locality scoring)
- No auth required — unauthenticated users get recommendations without mutual follow scoring
- Limit capped at 50 to prevent abuse

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new query to fetch recommended actors, with a configurable limit (default 10, constrained to 1–50).
  * Recommendations respect the requester's locale when provided and fall back to account or English locales, returning a list of actor profiles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->