### PR TITLE
Add HTML email for clickable deep links

### DIFF
--- a/graphql/email-helpers.ts
+++ b/graphql/email-helpers.ts
@@ -2,6 +2,7 @@ import { negotiateLocale } from "@hackerspub/models/i18n";
 import type { Account as AccountTable, Actor } from "@hackerspub/models/schema";
 import type { SignupToken } from "@hackerspub/models/signup";
 import { expandGlob } from "@std/fs";
+import { escape } from "@std/html/entities";
 import { join } from "@std/path";
 import { createMessage, type Message } from "@upyo/core";
 import { parseTemplate } from "url-template";
@@ -131,9 +132,13 @@ export async function getEmailMessage(
     subject: substitute(template.subject),
     content: {
       text: textContent,
-      html: textContent
-        .replaceAll(verifyUrl, `<a href="${verifyUrl}">${verifyUrl}</a>`)
-        .replaceAll("\n", "<br>\n"),
+      html: (() => {
+        const escapedText = escape(textContent);
+        const escapedUrl = escape(verifyUrl);
+        return escapedText
+          .replaceAll(escapedUrl, `<a href="${verifyUrl}">${escapedUrl}</a>`)
+          .replaceAll("\n", "<br>\n");
+      })(),
     },
   });
 }

--- a/graphql/email-helpers.ts
+++ b/graphql/email-helpers.ts
@@ -133,10 +133,21 @@ export async function getEmailMessage(
     content: {
       text: textContent,
       html: (() => {
+        const parsed = URL.canParse(verifyUrl) ? new URL(verifyUrl) : null;
+        if (
+          parsed == null ||
+          !["https:", "http:", "hackerspub:"].includes(parsed.protocol)
+        ) {
+          throw new Error(`Unsupported verify URL scheme: ${verifyUrl}`);
+        }
+        const safeVerifyUrl = parsed.toString();
         const escapedText = escape(textContent);
-        const escapedUrl = escape(verifyUrl);
+        const escapedUrl = escape(safeVerifyUrl);
         return escapedText
-          .replaceAll(escapedUrl, `<a href="${verifyUrl}">${escapedUrl}</a>`)
+          .replaceAll(
+            escapedUrl,
+            `<a href="${escapedUrl}">${escapedUrl}</a>`,
+          )
           .replaceAll("\n", "<br>\n");
       })(),
     },

--- a/graphql/email-helpers.ts
+++ b/graphql/email-helpers.ts
@@ -124,12 +124,16 @@ export async function getEmailMessage(
       },
     );
   }
+  const textContent = substitute(template.content);
   return createMessage({
     from: EMAIL_FROM,
     to,
     subject: substitute(template.subject),
     content: {
-      text: substitute(template.content),
+      text: textContent,
+      html: textContent
+        .replaceAll(verifyUrl, `<a href="${verifyUrl}">${verifyUrl}</a>`)
+        .replaceAll("\n", "<br>\n"),
     },
   });
 }

--- a/graphql/login.ts
+++ b/graphql/login.ts
@@ -383,10 +383,21 @@ async function getEmailMessage({ locale, to, verifyUrlTemplate, token }: {
     content: {
       text: textContent,
       html: (() => {
+        const parsed = URL.canParse(verifyUrl) ? new URL(verifyUrl) : null;
+        if (
+          parsed == null ||
+          !["https:", "http:", "hackerspub:"].includes(parsed.protocol)
+        ) {
+          throw new Error(`Unsupported verify URL scheme: ${verifyUrl}`);
+        }
+        const safeVerifyUrl = parsed.toString();
         const escapedText = escape(textContent);
-        const escapedUrl = escape(verifyUrl);
+        const escapedUrl = escape(safeVerifyUrl);
         return escapedText
-          .replaceAll(escapedUrl, `<a href="${verifyUrl}">${escapedUrl}</a>`)
+          .replaceAll(
+            escapedUrl,
+            `<a href="${escapedUrl}">${escapedUrl}</a>`,
+          )
           .replaceAll("\n", "<br>\n");
       })(),
     },

--- a/graphql/login.ts
+++ b/graphql/login.ts
@@ -19,6 +19,7 @@ import type { Uuid } from "@hackerspub/models/uuid";
 import { getLogger } from "@logtape/logtape";
 import type { AuthenticationResponseJSON } from "@simplewebauthn/server";
 import { expandGlob } from "@std/fs";
+import { escape } from "@std/html/entities";
 import { join } from "@std/path";
 import { createMessage, type Message } from "@upyo/core";
 import { sql } from "drizzle-orm";
@@ -381,9 +382,13 @@ async function getEmailMessage({ locale, to, verifyUrlTemplate, token }: {
     subject: template.subject,
     content: {
       text: textContent,
-      html: textContent
-        .replaceAll(verifyUrl, `<a href="${verifyUrl}">${verifyUrl}</a>`)
-        .replaceAll("\n", "<br>\n"),
+      html: (() => {
+        const escapedText = escape(textContent);
+        const escapedUrl = escape(verifyUrl);
+        return escapedText
+          .replaceAll(escapedUrl, `<a href="${verifyUrl}">${escapedUrl}</a>`)
+          .replaceAll("\n", "<br>\n");
+      })(),
     },
   });
 }

--- a/graphql/login.ts
+++ b/graphql/login.ts
@@ -367,19 +367,23 @@ async function getEmailMessage({ locale, to, verifyUrlTemplate, token }: {
     style: "long",
   });
   const template = await getEmailTemplate(locale);
+  const textContent = template.content
+    .replaceAll(/\{\{(verifyUrl|code|expiration)\}\}/g, (m) => {
+      return m === "{{verifyUrl}}"
+        ? verifyUrl
+        : m === "{{code}}"
+        ? token.code
+        : expiration;
+    });
   return createMessage({
     from: EMAIL_FROM,
     to,
     subject: template.subject,
     content: {
-      text: template.content
-        .replaceAll(/\{\{(verifyUrl|code|expiration)\}\}/g, (m) => {
-          return m === "{{verifyUrl}}"
-            ? verifyUrl
-            : m === "{{code}}"
-            ? token.code
-            : expiration;
-        }),
+      text: textContent,
+      html: textContent
+        .replaceAll(verifyUrl, `<a href="${verifyUrl}">${verifyUrl}</a>`)
+        .replaceAll("\n", "<br>\n"),
     },
   });
 }


### PR DESCRIPTION
## Summary

Email clients don't auto-link custom URL schemes like `hackerspub://` in plain text emails. This adds HTML content alongside plain text in both login and invitation emails, wrapping the verify URL in an `<a>` tag so deep links are clickable. Tapping the link on Android opens the app's in-app verification view via the existing intent filter.

## Test plan
- [x] Trigger a login email from the Android app and verify the `hackerspub://` link is clickable
- [ ] Trigger a login email from the web app and verify the `https://` link is clickable
- [ ] Verify plain text fallback still renders correctly in text-only email clients
- [ ] Trigger an invitation email and verify the verify URL is clickable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved email rendering by ensuring both text and HTML versions are generated from the same content. HTML emails now display clickable links and proper line breaks for better readability across email clients.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->