### PR TITLE
Add Android Digital Asset Links

### DIFF
--- a/web-next/public/.well-known/assetlinks.json
+++ b/web-next/public/.well-known/assetlinks.json
@@ -1,0 +1,15 @@
+[
+  {
+    "relation": [
+      "delegate_permission/common.handle_all_urls",
+      "delegate_permission/common.get_login_creds"
+    ],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "pub.hackers.app",
+      "sha256_cert_fingerprints": [
+        "52:A0:14:21:02:CD:30:FD:8B:29:A3:ED:80:2B:0A:BE:AF:AB:37:29:79:39:84:1A:B7:9E:39:05:AF:64:D5:1A"
+      ]
+    }
+  }
+]

--- a/web/static/.well-known/assetlinks.json
+++ b/web/static/.well-known/assetlinks.json
@@ -1,0 +1,15 @@
+[
+  {
+    "relation": [
+      "delegate_permission/common.handle_all_urls",
+      "delegate_permission/common.get_login_creds"
+    ],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "pub.hackers.app",
+      "sha256_cert_fingerprints": [
+        "52:A0:14:21:02:CD:30:FD:8B:29:A3:ED:80:2B:0A:BE:AF:AB:37:29:79:39:84:1A:B7:9E:39:05:AF:64:D5:1A"
+      ]
+    }
+  }
+]


### PR DESCRIPTION
## Summary
Add `assetlinks.json` to both the legacy (`web/`) and new (`web-next/`) stacks to configure Android App Links for the `pub.hackers.app` Android app. This enables the app to handle URLs from Hackers' Pub and supports credential sharing via Digital Asset Links.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Android app verification configuration to establish secure app-to-web linking across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->