### PR TITLE
Add Android App Links assetlinks.json

### DIFF
--- a/web-next/public/.well-known/assetlinks.json
+++ b/web-next/public/.well-known/assetlinks.json
@@ -6,7 +6,7 @@
     ],
     "target": {
       "namespace": "android_app",
-      "package_name": "pub.hackers.app",
+      "package_name": "pub.hackers.android",
       "sha256_cert_fingerprints": [
         "52:A0:14:21:02:CD:30:FD:8B:29:A3:ED:80:2B:0A:BE:AF:AB:37:29:79:39:84:1A:B7:9E:39:05:AF:64:D5:1A"
       ]

--- a/web/static/.well-known/assetlinks.json
+++ b/web/static/.well-known/assetlinks.json
@@ -6,7 +6,7 @@
     ],
     "target": {
       "namespace": "android_app",
-      "package_name": "pub.hackers.app",
+      "package_name": "pub.hackers.android",
       "sha256_cert_fingerprints": [
         "52:A0:14:21:02:CD:30:FD:8B:29:A3:ED:80:2B:0A:BE:AF:AB:37:29:79:39:84:1A:B7:9E:39:05:AF:64:D5:1A"
       ]


### PR DESCRIPTION
## Summary
- Add `.well-known/assetlinks.json` to both `web/static/` and `web-next/public/` for Android App Links support
- Configure Digital Asset Links for the `pub.hackers.android` package with the appropriate certificate fingerprint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Android app verification configuration with the correct package identifier to ensure proper app linking and verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->