### PR TITLE
Support Android passkey origin for WebAuthn

### DIFF
--- a/graphql/login.ts
+++ b/graphql/login.ts
@@ -1,6 +1,8 @@
 import { negotiateLocale } from "@hackerspub/models/i18n";
 import {
+  type PasskeyPlatform,
   getAuthenticationOptions,
+  resolvePasskeyOrigin,
   verifyAuthentication,
 } from "@hackerspub/models/passkey";
 import {
@@ -300,12 +302,17 @@ builder.mutationFields((t) => ({
         required: true,
         description: "WebAuthn authentication response from the client.",
       }),
+      platform: t.arg.string({ required: false, defaultValue: "web" }),
     },
     async resolve(_, args, ctx) {
+      const origin = resolvePasskeyOrigin(
+        ctx.fedCtx.canonicalOrigin,
+        (args.platform ?? "web") as PasskeyPlatform,
+      );
       const result = await verifyAuthentication(
         ctx.db,
         ctx.kv,
-        ctx.fedCtx.canonicalOrigin,
+        origin,
         args.sessionId as Uuid,
         args.authenticationResponse as AuthenticationResponseJSON,
       );

--- a/graphql/login.ts
+++ b/graphql/login.ts
@@ -309,10 +309,12 @@ builder.mutationFields((t) => ({
         ctx.fedCtx.canonicalOrigin,
         (args.platform ?? "web") as PasskeyPlatform,
       );
+      const rpId = new URL(ctx.fedCtx.canonicalOrigin).hostname;
       const result = await verifyAuthentication(
         ctx.db,
         ctx.kv,
         origin,
+        rpId,
         args.sessionId as Uuid,
         args.authenticationResponse as AuthenticationResponseJSON,
       );

--- a/graphql/login.ts
+++ b/graphql/login.ts
@@ -1,7 +1,7 @@
 import { negotiateLocale } from "@hackerspub/models/i18n";
 import {
-  type PasskeyPlatform,
   getAuthenticationOptions,
+  type PasskeyPlatform,
   resolvePasskeyOrigin,
   verifyAuthentication,
 } from "@hackerspub/models/passkey";

--- a/graphql/passkey.ts
+++ b/graphql/passkey.ts
@@ -1,5 +1,7 @@
 import {
+  type PasskeyPlatform,
   getRegistrationOptions,
+  resolvePasskeyOrigin,
   verifyRegistration,
 } from "@hackerspub/models/passkey";
 import { passkeyTable } from "@hackerspub/models/schema";
@@ -117,6 +119,7 @@ builder.mutationFields((t) => ({
       accountId: t.arg.globalID({ for: Account, required: true }),
       name: t.arg.string({ required: true }),
       registrationResponse: t.arg({ type: "JSON", required: true }),
+      platform: t.arg.string({ required: false, defaultValue: "web" }),
     },
     async resolve(_, args, ctx) {
       const session = await ctx.session;
@@ -129,10 +132,14 @@ builder.mutationFields((t) => ({
         with: { passkeys: true },
       });
       if (account == null) throw new Error("Account not found.");
+      const origin = resolvePasskeyOrigin(
+        ctx.fedCtx.canonicalOrigin,
+        (args.platform ?? "web") as PasskeyPlatform,
+      );
       const result = await verifyRegistration(
         ctx.db,
         ctx.kv,
-        ctx.fedCtx.canonicalOrigin,
+        origin,
         account,
         args.name,
         args.registrationResponse as RegistrationResponseJSON,

--- a/graphql/passkey.ts
+++ b/graphql/passkey.ts
@@ -1,6 +1,6 @@
 import {
-  type PasskeyPlatform,
   getRegistrationOptions,
+  type PasskeyPlatform,
   resolvePasskeyOrigin,
   verifyRegistration,
 } from "@hackerspub/models/passkey";

--- a/graphql/passkey.ts
+++ b/graphql/passkey.ts
@@ -136,10 +136,12 @@ builder.mutationFields((t) => ({
         ctx.fedCtx.canonicalOrigin,
         (args.platform ?? "web") as PasskeyPlatform,
       );
+      const rpId = new URL(ctx.fedCtx.canonicalOrigin).hostname;
       const result = await verifyRegistration(
         ctx.db,
         ctx.kv,
         origin,
+        rpId,
         account,
         args.name,
         args.registrationResponse as RegistrationResponseJSON,

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -651,6 +651,7 @@ type Mutation {
   loginByPasskey(
     """WebAuthn authentication response from the client."""
     authenticationResponse: JSON!
+    platform: String = "web"
 
     """Temporary session ID used for authentication options."""
     sessionId: UUID!
@@ -687,7 +688,7 @@ type Mutation {
   unsharePost(input: UnsharePostInput!): UnsharePostResult!
   updateAccount(input: UpdateAccountInput!): UpdateAccountPayload!
   uploadMedia(input: UploadMediaInput!): UploadMediaResult!
-  verifyPasskeyRegistration(accountId: ID!, name: String!, registrationResponse: JSON!): PasskeyRegistrationResult!
+  verifyPasskeyRegistration(accountId: ID!, name: String!, platform: String = "web", registrationResponse: JSON!): PasskeyRegistrationResult!
 }
 
 interface Node {

--- a/models/passkey.ts
+++ b/models/passkey.ts
@@ -28,7 +28,7 @@ const KV_NAMESPACE = "passkey";
 
 export type PasskeyPlatform = "web" | "android" | "ios";
 
-const PLATFORM_ORIGINS: Record<string, string> = {
+const PLATFORM_ORIGINS: Partial<Record<PasskeyPlatform, string>> = {
   // Release signing key (pub.hackers.android)
   android: "android:apk-key-hash:UqAUIQLNMP2LKaPtgCsKvq-rNyl5OYQat545Ba9k1Ro",
 };
@@ -37,9 +37,8 @@ export function resolvePasskeyOrigin(
   serverOrigin: string,
   platform: PasskeyPlatform = "web",
 ): string {
-  if (platform in PLATFORM_ORIGINS) {
-    return PLATFORM_ORIGINS[platform];
-  }
+  const platformOrigin = PLATFORM_ORIGINS[platform];
+  if (platformOrigin != null) return platformOrigin;
   return new URL(serverOrigin).origin;
 }
 

--- a/models/passkey.ts
+++ b/models/passkey.ts
@@ -23,7 +23,25 @@ import {
 import type { Uuid } from "./uuid.ts";
 
 const RP_NAME = "Hackers' Pub";
+
 const KV_NAMESPACE = "passkey";
+
+export type PasskeyPlatform = "web" | "android" | "ios";
+
+const PLATFORM_ORIGINS: Record<string, string> = {
+  // Release signing key (pub.hackers.android)
+  android: "android:apk-key-hash:UqAUIQLNMP2LKaPtgCsKvq-rNyl5OYQat545Ba9k1Ro",
+};
+
+export function resolvePasskeyOrigin(
+  serverOrigin: string,
+  platform: PasskeyPlatform = "web",
+): string {
+  if (platform in PLATFORM_ORIGINS) {
+    return PLATFORM_ORIGINS[platform];
+  }
+  return new URL(serverOrigin).origin;
+}
 
 export async function getRegistrationOptions(
   kv: Keyv,
@@ -127,7 +145,7 @@ export async function verifyAuthentication(
   const result = await verifyAuthenticationResponse({
     response,
     expectedChallenge: options.challenge,
-    expectedOrigin: new URL(origin).origin,
+    expectedOrigin: origin,
     expectedRPID: new URL(origin).hostname,
     credential: {
       id: response.id,

--- a/models/passkey.ts
+++ b/models/passkey.ts
@@ -66,6 +66,7 @@ export async function verifyRegistration(
   db: Database,
   kv: Keyv,
   origin: string,
+  rpId: string,
   account: Account,
   name: string,
   response: RegistrationResponseJSON,
@@ -79,8 +80,8 @@ export async function verifyRegistration(
   const result = await verifyRegistrationResponse({
     response,
     expectedChallenge: options.challenge,
-    expectedOrigin: new URL(origin).origin,
-    expectedRPID: new URL(origin).hostname,
+    expectedOrigin: origin,
+    expectedRPID: rpId,
   });
   if (result.verified && result.registrationInfo != null) {
     const { credential, credentialDeviceType, credentialBackedUp } =
@@ -122,6 +123,7 @@ export async function verifyAuthentication(
   db: Database,
   kv: Keyv,
   origin: string,
+  rpId: string,
   sessionId: Uuid,
   response: AuthenticationResponseJSON,
 ): Promise<
@@ -146,7 +148,7 @@ export async function verifyAuthentication(
     response,
     expectedChallenge: options.challenge,
     expectedOrigin: origin,
-    expectedRPID: new URL(origin).hostname,
+    expectedRPID: rpId,
     credential: {
       id: response.id,
       publicKey: new Uint8Array(passkey.publicKey),

--- a/web/routes/@[username]/settings/passkeys/verify.ts
+++ b/web/routes/@[username]/settings/passkeys/verify.ts
@@ -16,10 +16,13 @@ export const handler = define.handlers({
       name: string;
       registrationResponse: RegistrationResponseJSON;
     } = await ctx.req.json();
+    const serverOrigin = new URL(ctx.state.fedCtx.canonicalOrigin).origin;
+    const rpId = new URL(ctx.state.fedCtx.canonicalOrigin).hostname;
     const verifyResponse = await verifyRegistration(
       db,
       kv,
-      ctx.state.fedCtx.canonicalOrigin,
+      serverOrigin,
+      rpId,
       account,
       registerResponse.name,
       registerResponse.registrationResponse,

--- a/web/routes/sign/verify.ts
+++ b/web/routes/sign/verify.ts
@@ -12,10 +12,13 @@ export const handler = define.handlers({
     const sessionId = ctx.url.searchParams.get("sessionId");
     if (!validateUuid(sessionId)) return ctx.next();
     const authResponse: AuthenticationResponseJSON = await ctx.req.json();
+    const serverOrigin = new URL(ctx.state.fedCtx.canonicalOrigin).origin;
+    const rpId = new URL(ctx.state.fedCtx.canonicalOrigin).hostname;
     const result = await verifyAuthentication(
       db,
       kv,
-      ctx.state.fedCtx.canonicalOrigin,
+      serverOrigin,
+      rpId,
       sessionId,
       authResponse,
     );


### PR DESCRIPTION
## Summary
- Add a `platform` argument to `loginByPasskey` and `registerPasskey` mutations so Android clients can specify their platform
- Introduce `resolvePasskeyOrigin()` to map the Android APK key hash as the expected origin for WebAuthn verification, instead of the web server origin
- This enables passkey login/registration from the Android app (`pub.hackers.android`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Passkey sign-in and registration now let you specify platform (web, Android, iOS) so authentication uses platform-specific origin handling for better cross-device compatibility.

* **Bug Fixes**
  * Improved passkey verification to reduce authentication failures on platform-specific setups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->