### PR TITLE
Fix notification actors ordering to preserve trigger chronological order

### DIFF
--- a/graphql/notification.ts
+++ b/graphql/notification.ts
@@ -48,7 +48,7 @@ export const Notification = builder.drizzleInterface("notificationTable", {
             args,
             toCursor: (actor) => actor.id,
           },
-          async ({ limit }: ResolveCursorConnectionArgs) => {
+          async (_args: ResolveCursorConnectionArgs) => {
             const actors = await ctx.db.query.actorTable.findMany({
               where: {
                 id: { in: notification.actorIds },
@@ -61,7 +61,7 @@ export const Notification = builder.drizzleInterface("notificationTable", {
               (positionMap.get(b.id) ?? -1) -
               (positionMap.get(a.id) ?? -1)
             );
-            return actors.slice(0, limit);
+            return actors;
           },
         );
       },

--- a/graphql/notification.ts
+++ b/graphql/notification.ts
@@ -1,4 +1,3 @@
-import type { Uuid } from "@hackerspub/models/uuid";
 import {
   resolveCursorConnection,
   type ResolveCursorConnectionArgs,
@@ -49,22 +48,21 @@ export const Notification = builder.drizzleInterface("notificationTable", {
             args,
             toCursor: (actor) => actor.id,
           },
-          ({ before, after, limit, inverted }: ResolveCursorConnectionArgs) =>
-            ctx.db.query.actorTable.findMany(
-              {
-                limit,
-                where: {
-                  id: {
-                    in: notification.actorIds,
-                    lt: before as Uuid,
-                    gt: after as Uuid,
-                  },
-                },
-                orderBy: {
-                  id: (inverted ? "desc" : "asc") as "desc" | "asc",
-                },
+          async ({ limit }: ResolveCursorConnectionArgs) => {
+            const actors = await ctx.db.query.actorTable.findMany({
+              where: {
+                id: { in: notification.actorIds },
               },
-            ),
+            });
+            const positionMap = new Map(
+              notification.actorIds.map((id, index) => [id, index]),
+            );
+            actors.sort((a, b) =>
+              (positionMap.get(b.id) ?? -1) -
+              (positionMap.get(a.id) ?? -1)
+            );
+            return actors.slice(0, limit);
+          },
         );
       },
     }),


### PR DESCRIPTION
## Summary
- The `actors` connection resolver was ordering by `id ASC` (UUID/account-creation order), which is unrelated to when each actor triggered the notification
- The `actorIds` array in the DB preserves trigger chronological order via `array_append`, but this ordering was discarded by the SQL query
- Now fetches all matching actors and sorts by reverse position in `actorIds` so the most recent trigger comes first (`edges[0]`)

## Test plan
- [ ] Verify that for aggregated notifications (share, react with same emoji), the most recent actor appears first
- [ ] Verify single-actor notifications (follow, reply, mention, quote) are unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated notification actors retrieval—removed cursor-based pagination support in favor of simplified ordering and result limiting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->