### PR TITLE
Allow passkey authentication from local Android builds

### DIFF
--- a/graphql/login.ts
+++ b/graphql/login.ts
@@ -2,7 +2,7 @@ import { negotiateLocale } from "@hackerspub/models/i18n";
 import {
   getAuthenticationOptions,
   type PasskeyPlatform,
-  resolvePasskeyOrigin,
+  resolvePasskeyOrigins,
   verifyAuthentication,
 } from "@hackerspub/models/passkey";
 import {
@@ -305,7 +305,7 @@ builder.mutationFields((t) => ({
       platform: t.arg.string({ required: false, defaultValue: "web" }),
     },
     async resolve(_, args, ctx) {
-      const origin = resolvePasskeyOrigin(
+      const origins = resolvePasskeyOrigins(
         ctx.fedCtx.canonicalOrigin,
         (args.platform ?? "web") as PasskeyPlatform,
       );
@@ -313,7 +313,7 @@ builder.mutationFields((t) => ({
       const result = await verifyAuthentication(
         ctx.db,
         ctx.kv,
-        origin,
+        origins,
         rpId,
         args.sessionId as Uuid,
         args.authenticationResponse as AuthenticationResponseJSON,

--- a/graphql/passkey.ts
+++ b/graphql/passkey.ts
@@ -1,7 +1,7 @@
 import {
   getRegistrationOptions,
   type PasskeyPlatform,
-  resolvePasskeyOrigin,
+  resolvePasskeyOrigins,
   verifyRegistration,
 } from "@hackerspub/models/passkey";
 import { passkeyTable } from "@hackerspub/models/schema";
@@ -132,7 +132,7 @@ builder.mutationFields((t) => ({
         with: { passkeys: true },
       });
       if (account == null) throw new Error("Account not found.");
-      const origin = resolvePasskeyOrigin(
+      const origins = resolvePasskeyOrigins(
         ctx.fedCtx.canonicalOrigin,
         (args.platform ?? "web") as PasskeyPlatform,
       );
@@ -140,7 +140,7 @@ builder.mutationFields((t) => ({
       const result = await verifyRegistration(
         ctx.db,
         ctx.kv,
-        origin,
+        origins,
         rpId,
         account,
         args.name,

--- a/models/passkey.test.ts
+++ b/models/passkey.test.ts
@@ -5,7 +5,7 @@ import { Buffer } from "node:buffer";
 import {
   getAuthenticationOptions,
   getRegistrationOptions,
-  resolvePasskeyOrigin,
+  resolvePasskeyOrigins,
   verifyAuthentication,
   verifyRegistration,
 } from "./passkey.ts";
@@ -15,18 +15,21 @@ import {
   withRollback,
 } from "../test/postgres.ts";
 
-Deno.test("resolvePasskeyOrigin() prefers platform-specific origins", () => {
+Deno.test("resolvePasskeyOrigins() prefers platform-specific origins", () => {
   assertEquals(
-    resolvePasskeyOrigin("https://pub.hackers.pub/sign/in", "web"),
-    "https://pub.hackers.pub",
+    resolvePasskeyOrigins("https://pub.hackers.pub/sign/in", "web"),
+    ["https://pub.hackers.pub"],
   );
   assertEquals(
-    resolvePasskeyOrigin("https://pub.hackers.pub/sign/in", "ios"),
-    "https://pub.hackers.pub",
+    resolvePasskeyOrigins("https://pub.hackers.pub/sign/in", "ios"),
+    ["https://pub.hackers.pub"],
   );
   assertEquals(
-    resolvePasskeyOrigin("https://pub.hackers.pub/sign/in", "android"),
-    "android:apk-key-hash:UqAUIQLNMP2LKaPtgCsKvq-rNyl5OYQat545Ba9k1Ro",
+    resolvePasskeyOrigins("https://pub.hackers.pub/sign/in", "android"),
+    [
+      "android:apk-key-hash:UqAUIQLNMP2LKaPtgCsKvq-rNyl5OYQat545Ba9k1Ro",
+      "android:apk-key-hash:yqSW6UZsaCl_dADWM0X3C_ndgblJU4uUMrjQYLIxEFs",
+    ],
   );
 });
 
@@ -98,7 +101,7 @@ Deno.test({
           verifyRegistration(
             tx,
             kv,
-            "https://pub.hackers.pub",
+            ["https://pub.hackers.pub"],
             "pub.hackers.pub",
             account.account,
             "Laptop",
@@ -144,7 +147,7 @@ Deno.test({
       const missingOptions = await verifyAuthentication(
         tx,
         kv,
-        "https://pub.hackers.pub",
+        ["https://pub.hackers.pub"],
         "pub.hackers.pub",
         sessionId,
         { id: "missing-passkey" } as never,
@@ -160,7 +163,7 @@ Deno.test({
       const missingPasskey = await verifyAuthentication(
         tx,
         kv,
-        "https://pub.hackers.pub",
+        ["https://pub.hackers.pub"],
         "pub.hackers.pub",
         sessionId,
         { id: "missing-passkey" } as never,

--- a/models/passkey.ts
+++ b/models/passkey.ts
@@ -28,18 +28,22 @@ const KV_NAMESPACE = "passkey";
 
 export type PasskeyPlatform = "web" | "android" | "ios";
 
-const PLATFORM_ORIGINS: Partial<Record<PasskeyPlatform, string>> = {
-  // Release signing key (pub.hackers.android)
-  android: "android:apk-key-hash:UqAUIQLNMP2LKaPtgCsKvq-rNyl5OYQat545Ba9k1Ro",
+const PLATFORM_ORIGINS: Partial<Record<PasskeyPlatform, string[]>> = {
+  android: [
+    // Release signing key (pub.hackers.android)
+    "android:apk-key-hash:UqAUIQLNMP2LKaPtgCsKvq-rNyl5OYQat545Ba9k1Ro",
+    // Local debug keystore (pub.hackers.android.dev)
+    "android:apk-key-hash:yqSW6UZsaCl_dADWM0X3C_ndgblJU4uUMrjQYLIxEFs",
+  ],
 };
 
-export function resolvePasskeyOrigin(
+export function resolvePasskeyOrigins(
   serverOrigin: string,
   platform: PasskeyPlatform = "web",
-): string {
-  const platformOrigin = PLATFORM_ORIGINS[platform];
-  if (platformOrigin != null) return platformOrigin;
-  return new URL(serverOrigin).origin;
+): string[] {
+  const platformOrigins = PLATFORM_ORIGINS[platform];
+  if (platformOrigins != null) return platformOrigins;
+  return [new URL(serverOrigin).origin];
 }
 
 export async function getRegistrationOptions(
@@ -64,7 +68,7 @@ export async function getRegistrationOptions(
 export async function verifyRegistration(
   db: Database,
   kv: Keyv,
-  origin: string,
+  origins: string[],
   rpId: string,
   account: Account,
   name: string,
@@ -79,7 +83,7 @@ export async function verifyRegistration(
   const result = await verifyRegistrationResponse({
     response,
     expectedChallenge: options.challenge,
-    expectedOrigin: origin,
+    expectedOrigin: origins,
     expectedRPID: rpId,
   });
   if (result.verified && result.registrationInfo != null) {
@@ -121,7 +125,7 @@ export async function getAuthenticationOptions(
 export async function verifyAuthentication(
   db: Database,
   kv: Keyv,
-  origin: string,
+  origins: string[],
   rpId: string,
   sessionId: Uuid,
   response: AuthenticationResponseJSON,
@@ -146,7 +150,7 @@ export async function verifyAuthentication(
   const result = await verifyAuthenticationResponse({
     response,
     expectedChallenge: options.challenge,
-    expectedOrigin: origin,
+    expectedOrigin: origins,
     expectedRPID: rpId,
     credential: {
       id: response.id,

--- a/web/routes/@[username]/settings/passkeys/verify.ts
+++ b/web/routes/@[username]/settings/passkeys/verify.ts
@@ -1,4 +1,7 @@
-import { verifyRegistration } from "@hackerspub/models/passkey";
+import {
+  resolvePasskeyOrigins,
+  verifyRegistration,
+} from "@hackerspub/models/passkey";
 import type { RegistrationResponseJSON } from "@simplewebauthn/server";
 import { db } from "../../../../db.ts";
 import { kv } from "../../../../kv.ts";
@@ -17,11 +20,12 @@ export const handler = define.handlers({
       registrationResponse: RegistrationResponseJSON;
     } = await ctx.req.json();
     const serverOrigin = new URL(ctx.state.fedCtx.canonicalOrigin).origin;
+    const origins = resolvePasskeyOrigins(serverOrigin, "web");
     const rpId = new URL(ctx.state.fedCtx.canonicalOrigin).hostname;
     const verifyResponse = await verifyRegistration(
       db,
       kv,
-      serverOrigin,
+      origins,
       rpId,
       account,
       registerResponse.name,

--- a/web/routes/sign/verify.ts
+++ b/web/routes/sign/verify.ts
@@ -1,4 +1,7 @@
-import { verifyAuthentication } from "@hackerspub/models/passkey";
+import {
+  resolvePasskeyOrigins,
+  verifyAuthentication,
+} from "@hackerspub/models/passkey";
 import { createSession, EXPIRATION } from "@hackerspub/models/session";
 import { validateUuid } from "@hackerspub/models/uuid";
 import type { AuthenticationResponseJSON } from "@simplewebauthn/server";
@@ -13,11 +16,12 @@ export const handler = define.handlers({
     if (!validateUuid(sessionId)) return ctx.next();
     const authResponse: AuthenticationResponseJSON = await ctx.req.json();
     const serverOrigin = new URL(ctx.state.fedCtx.canonicalOrigin).origin;
+    const origins = resolvePasskeyOrigins(serverOrigin, "web");
     const rpId = new URL(ctx.state.fedCtx.canonicalOrigin).hostname;
     const result = await verifyAuthentication(
       db,
       kv,
-      serverOrigin,
+      origins,
       rpId,
       sessionId,
       authResponse,

--- a/web/static/.well-known/assetlinks.json
+++ b/web/static/.well-known/assetlinks.json
@@ -11,5 +11,18 @@
         "AD:C6:2C:B4:7B:C0:7D:26:48:D5:C8:E5:51:88:BF:1E:82:33:B4:CC:5A:A3:74:49:25:D0:C4:3C:32:D7:12:BB"
       ]
     }
+  },
+  {
+    "relation": [
+      "delegate_permission/common.handle_all_urls",
+      "delegate_permission/common.get_login_creds"
+    ],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "pub.hackers.android.dev",
+      "sha256_cert_fingerprints": [
+        "CA:A4:96:E9:46:6C:68:29:7F:74:00:D6:33:45:F7:0B:F9:DD:81:B9:49:53:8B:94:32:B8:D0:60:B2:31:10:5B"
+      ]
+    }
   }
 ]


### PR DESCRIPTION
## Summary

Allow Android passkey flows to work from both the production-signed app and the local debug build. This adds the debug app to `assetlinks.json` and updates passkey verification to accept multiple Android origins instead of a single origin.

## Why

- Local Android builds need to participate in Digital Asset Links.
- Passkey registration and authentication should succeed for both the production app and the local debug app.
- The server-side origin check needs to match the signing context the client is using.

## Before and After

| Before | After |
|--------|-------|
| Only one Android signing origin was accepted for passkey verification. | Both the production Android signing origin and the local debug signing origin are accepted. |
| `pub.hackers.android.dev` was not registered in `assetlinks.json`. | `pub.hackers.android.dev` is registered for app links and login credentials. |

## Test Plan

- [x] Verify `/.well-known/assetlinks.json` includes both `pub.hackers.android` and `pub.hackers.android.dev`
- [x] Test passkey registration from a local debug Android build
- [x] Test passkey authentication from a local debug Android build
- [x] Confirm production Android passkey authentication still works
- [x] Run relevant automated tests

## AI Disclosure

This pull request was prepared with AI assistance and reviewed by a human before submission, in line with `AI_POLICY.md`. AI assistance was used to help draft the PR text and support the implementation described here.