### PR TITLE
web-next: Fix N+1 on `Actor`, custom emoji, and notification fields

### DIFF
--- a/graphql/actor.test.ts
+++ b/graphql/actor.test.ts
@@ -543,6 +543,14 @@ const viewerBlocksBatchQuery = parse(`
   }
 `);
 
+const blockRelationshipBatchQuery = parse(`
+  query BlockRelationshipBatch($a: UUID!, $b: UUID!, $c: UUID!) {
+    a: actorByUuid(uuid: $a) { id viewerBlocks blocksViewer }
+    b: actorByUuid(uuid: $b) { id viewerBlocks blocksViewer }
+    c: actorByUuid(uuid: $c) { id viewerBlocks blocksViewer }
+  }
+`);
+
 Deno.test({
   name: "Actor.viewerFollows returns the right state per actor when batched",
   sanitizeOps: false,
@@ -803,6 +811,74 @@ Deno.test({
       assertEquals(data.a.viewerBlocks, false);
       assertEquals(data.b.viewerBlocks, false);
       assertEquals(data.c.viewerBlocks, false);
+    });
+  },
+});
+
+Deno.test({
+  name:
+    "Actor.viewerBlocks and blocksViewer are batched into independent results",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  async fn() {
+    await withRollback(async (tx) => {
+      const viewer = await insertAccountWithActor(tx, {
+        username: "brelviewer",
+        name: "BREL Viewer",
+        email: "brelviewer@example.com",
+      });
+      const blocked = await insertAccountWithActor(tx, {
+        username: "brelblocked",
+        name: "BREL Blocked",
+        email: "brelblocked@example.com",
+      });
+      const blocker = await insertAccountWithActor(tx, {
+        username: "brelblocker",
+        name: "BREL Blocker",
+        email: "brelblocker@example.com",
+      });
+      const stranger = await insertAccountWithActor(tx, {
+        username: "brelstranger",
+        name: "BREL Stranger",
+        email: "brelstranger@example.com",
+      });
+
+      const fedCtx = createFedCtx(tx);
+      // Viewer blocks `blocked` (viewerBlocks=true on blocked).
+      await block(fedCtx, viewer.account, blocked.actor);
+      // `blocker` blocks viewer (blocksViewer=true on blocker).
+      await block(fedCtx, blocker.account, viewer.actor);
+
+      const result = await execute({
+        schema,
+        document: blockRelationshipBatchQuery,
+        variableValues: {
+          a: blocked.actor.id,
+          b: blocker.actor.id,
+          c: stranger.actor.id,
+        },
+        contextValue: makeUserContext(tx, viewer.account),
+        onError: "NO_PROPAGATE",
+      });
+
+      assertEquals(result.errors, undefined);
+      assertEquals(result.data, {
+        a: {
+          id: encodeGlobalID("Actor", blocked.actor.id),
+          viewerBlocks: true,
+          blocksViewer: false,
+        },
+        b: {
+          id: encodeGlobalID("Actor", blocker.actor.id),
+          viewerBlocks: false,
+          blocksViewer: true,
+        },
+        c: {
+          id: encodeGlobalID("Actor", stranger.actor.id),
+          viewerBlocks: false,
+          blocksViewer: false,
+        },
+      });
     });
   },
 });

--- a/graphql/actor.test.ts
+++ b/graphql/actor.test.ts
@@ -2,6 +2,7 @@ import { assertEquals } from "@std/assert/equals";
 import { and, eq, or } from "drizzle-orm";
 import { encodeGlobalID } from "@pothos/plugin-relay";
 import { execute, parse } from "graphql";
+import { block } from "@hackerspub/models/blocking";
 import { follow } from "@hackerspub/models/following";
 import { blockingTable, followingTable } from "@hackerspub/models/schema";
 import { schema } from "./mod.ts";
@@ -534,6 +535,14 @@ const followRelationshipBatchQuery = parse(`
   }
 `);
 
+const viewerBlocksBatchQuery = parse(`
+  query ViewerBlocksBatch($a: UUID!, $b: UUID!, $c: UUID!) {
+    a: actorByUuid(uuid: $a) { id viewerBlocks }
+    b: actorByUuid(uuid: $b) { id viewerBlocks }
+    c: actorByUuid(uuid: $c) { id viewerBlocks }
+  }
+`);
+
 Deno.test({
   name: "Actor.viewerFollows returns the right state per actor when batched",
   sanitizeOps: false,
@@ -696,6 +705,104 @@ Deno.test({
           followsViewer: false,
         },
       });
+    });
+  },
+});
+
+Deno.test({
+  name: "Actor.viewerBlocks returns the right state per actor when batched",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  async fn() {
+    await withRollback(async (tx) => {
+      const viewer = await insertAccountWithActor(tx, {
+        username: "vbviewer",
+        name: "VB Viewer",
+        email: "vbviewer@example.com",
+      });
+      const blocked = await insertAccountWithActor(tx, {
+        username: "vbblocked",
+        name: "VB Blocked",
+        email: "vbblocked@example.com",
+      });
+      const notBlocked = await insertAccountWithActor(tx, {
+        username: "vbnotblocked",
+        name: "VB Not Blocked",
+        email: "vbnotblocked@example.com",
+      });
+      const stranger = await insertAccountWithActor(tx, {
+        username: "vbstranger",
+        name: "VB Stranger",
+        email: "vbstranger@example.com",
+      });
+
+      const fedCtx = createFedCtx(tx);
+      await block(fedCtx, viewer.account, blocked.actor);
+
+      const result = await execute({
+        schema,
+        document: viewerBlocksBatchQuery,
+        variableValues: {
+          a: blocked.actor.id,
+          b: notBlocked.actor.id,
+          c: stranger.actor.id,
+        },
+        contextValue: makeUserContext(tx, viewer.account),
+        onError: "NO_PROPAGATE",
+      });
+
+      assertEquals(result.errors, undefined);
+      assertEquals(result.data, {
+        a: {
+          id: encodeGlobalID("Actor", blocked.actor.id),
+          viewerBlocks: true,
+        },
+        b: {
+          id: encodeGlobalID("Actor", notBlocked.actor.id),
+          viewerBlocks: false,
+        },
+        c: {
+          id: encodeGlobalID("Actor", stranger.actor.id),
+          viewerBlocks: false,
+        },
+      });
+    });
+  },
+});
+
+Deno.test({
+  name: "Actor.viewerBlocks returns false for a guest viewer",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  async fn() {
+    await withRollback(async (tx) => {
+      const someone = await insertAccountWithActor(tx, {
+        username: "vbguesttarget",
+        name: "VB Guest Target",
+        email: "vbguesttarget@example.com",
+      });
+
+      const result = await execute({
+        schema,
+        document: viewerBlocksBatchQuery,
+        variableValues: {
+          a: someone.actor.id,
+          b: someone.actor.id,
+          c: someone.actor.id,
+        },
+        contextValue: makeGuestContext(tx),
+        onError: "NO_PROPAGATE",
+      });
+
+      assertEquals(result.errors, undefined);
+      const data = result.data as {
+        a: { viewerBlocks: boolean };
+        b: { viewerBlocks: boolean };
+        c: { viewerBlocks: boolean };
+      };
+      assertEquals(data.a.viewerBlocks, false);
+      assertEquals(data.b.viewerBlocks, false);
+      assertEquals(data.c.viewerBlocks, false);
     });
   },
 });

--- a/graphql/actor.test.ts
+++ b/graphql/actor.test.ts
@@ -517,3 +517,109 @@ Deno.test({
     });
   },
 });
+
+const viewerFollowsBatchQuery = parse(`
+  query ViewerFollowsBatch($a: UUID!, $b: UUID!, $c: UUID!) {
+    a: actorByUuid(uuid: $a) { id viewerFollows }
+    b: actorByUuid(uuid: $b) { id viewerFollows }
+    c: actorByUuid(uuid: $c) { id viewerFollows }
+  }
+`);
+
+Deno.test({
+  name: "Actor.viewerFollows returns the right state per actor when batched",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  async fn() {
+    await withRollback(async (tx) => {
+      const viewer = await insertAccountWithActor(tx, {
+        username: "vfviewer",
+        name: "VF Viewer",
+        email: "vfviewer@example.com",
+      });
+      const followed = await insertAccountWithActor(tx, {
+        username: "vffollowed",
+        name: "VF Followed",
+        email: "vffollowed@example.com",
+      });
+      const notFollowed = await insertAccountWithActor(tx, {
+        username: "vfnotfollowed",
+        name: "VF Not Followed",
+        email: "vfnotfollowed@example.com",
+      });
+      const stranger = await insertAccountWithActor(tx, {
+        username: "vfstranger",
+        name: "VF Stranger",
+        email: "vfstranger@example.com",
+      });
+
+      const fedCtx = createFedCtx(tx);
+      await follow(fedCtx, viewer.account, followed.actor);
+
+      const result = await execute({
+        schema,
+        document: viewerFollowsBatchQuery,
+        variableValues: {
+          a: followed.actor.id,
+          b: notFollowed.actor.id,
+          c: stranger.actor.id,
+        },
+        contextValue: makeUserContext(tx, viewer.account),
+        onError: "NO_PROPAGATE",
+      });
+
+      assertEquals(result.errors, undefined);
+      assertEquals(result.data, {
+        a: {
+          id: encodeGlobalID("Actor", followed.actor.id),
+          viewerFollows: true,
+        },
+        b: {
+          id: encodeGlobalID("Actor", notFollowed.actor.id),
+          viewerFollows: false,
+        },
+        c: {
+          id: encodeGlobalID("Actor", stranger.actor.id),
+          viewerFollows: false,
+        },
+      });
+    });
+  },
+});
+
+Deno.test({
+  name: "Actor.viewerFollows returns false for a guest viewer",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  async fn() {
+    await withRollback(async (tx) => {
+      const someone = await insertAccountWithActor(tx, {
+        username: "vfguesttarget",
+        name: "VF Guest Target",
+        email: "vfguesttarget@example.com",
+      });
+
+      const result = await execute({
+        schema,
+        document: viewerFollowsBatchQuery,
+        variableValues: {
+          a: someone.actor.id,
+          b: someone.actor.id,
+          c: someone.actor.id,
+        },
+        contextValue: makeGuestContext(tx),
+        onError: "NO_PROPAGATE",
+      });
+
+      assertEquals(result.errors, undefined);
+      const data = result.data as {
+        a: { viewerFollows: boolean };
+        b: { viewerFollows: boolean };
+        c: { viewerFollows: boolean };
+      };
+      assertEquals(data.a.viewerFollows, false);
+      assertEquals(data.b.viewerFollows, false);
+      assertEquals(data.c.viewerFollows, false);
+    });
+  },
+});

--- a/graphql/actor.test.ts
+++ b/graphql/actor.test.ts
@@ -888,18 +888,37 @@ Deno.test({
 // state.  If someone removes `cache: false` (default DataLoader cache
 // is `true`), the second `viewerBlocks` would return the cached `true`
 // from the first read and this test would fail.
+//
+// All four follow/block loaders are selected on the mutation payload
+// to smoke-test their plumbing.  Of the four, only `viewerBlocks`
+// actually flips between the two reads in this scenario; the others
+// stay at `false` because the viewer can't flip them in a single
+// authenticated mutation document.  A companion follow/unfollow test
+// below locks `cache: false` in for `viewerFollows`.
 const blockUnblockMutation = parse(`
   mutation BlockThenUnblock($actorId: ID!) {
     block: blockActor(input: { actorId: $actorId }) {
       __typename
       ... on BlockActorPayload {
-        blockee { id viewerBlocks }
+        blockee {
+          id
+          viewerBlocks
+          blocksViewer
+          viewerFollows
+          followsViewer
+        }
       }
     }
     unblock: unblockActor(input: { actorId: $actorId }) {
       __typename
       ... on UnblockActorPayload {
-        blockee { id viewerBlocks }
+        blockee {
+          id
+          viewerBlocks
+          blocksViewer
+          viewerFollows
+          followsViewer
+        }
       }
     }
   }
@@ -936,21 +955,115 @@ Deno.test({
       const data = result.data as {
         block: {
           __typename: string;
-          blockee?: { id: string; viewerBlocks: boolean };
+          blockee?: {
+            id: string;
+            viewerBlocks: boolean;
+            blocksViewer: boolean;
+            viewerFollows: boolean;
+            followsViewer: boolean;
+          };
         };
         unblock: {
           __typename: string;
-          blockee?: { id: string; viewerBlocks: boolean };
+          blockee?: {
+            id: string;
+            viewerBlocks: boolean;
+            blocksViewer: boolean;
+            viewerFollows: boolean;
+            followsViewer: boolean;
+          };
         };
       };
 
       assertEquals(data.block.__typename, "BlockActorPayload");
       assertEquals(data.unblock.__typename, "UnblockActorPayload");
+
+      // Crucial: this asserts the `viewerBlocks` loader re-queried after
+      // the unblock mutation flipped state.  A `cache: true` regression
+      // on `viewerBlocks` would surface here as the stale cached `true`.
       assertEquals(data.block.blockee?.viewerBlocks, true);
-      // Crucial: this asserts the loader re-queried after the unblock
-      // mutation flipped state.  A `cache: true` regression would
-      // surface here as `viewerBlocks: true` (the stale cached value).
       assertEquals(data.unblock.blockee?.viewerBlocks, false);
+
+      // Smoke-test the other three loaders on the mutation payload.
+      // Their values don't flip between the two reads in this scenario,
+      // so cache: true vs cache: false isn't differentiated here — but
+      // a regression that breaks the field plumbing or returns
+      // undefined/null would surface.
+      assertEquals(data.block.blockee?.blocksViewer, false);
+      assertEquals(data.unblock.blockee?.blocksViewer, false);
+      assertEquals(data.block.blockee?.viewerFollows, false);
+      assertEquals(data.unblock.blockee?.viewerFollows, false);
+      assertEquals(data.block.blockee?.followsViewer, false);
+      assertEquals(data.unblock.blockee?.followsViewer, false);
+    });
+  },
+});
+
+// Companion test that genuinely locks `cache: false` in for
+// `viewerFollows`.  followActor creates the follow row and unfollowActor
+// removes it, so the loader's value flips between the two payload reads.
+const followUnfollowMutation = parse(`
+  mutation FollowThenUnfollow($actorId: ID!) {
+    follow: followActor(input: { actorId: $actorId }) {
+      __typename
+      ... on FollowActorPayload {
+        followee { id viewerFollows }
+      }
+    }
+    unfollow: unfollowActor(input: { actorId: $actorId }) {
+      __typename
+      ... on UnfollowActorPayload {
+        followee { id viewerFollows }
+      }
+    }
+  }
+`);
+
+Deno.test({
+  name:
+    "Actor.viewerFollows loader does not cache stale state across serial mutations",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  async fn() {
+    await withRollback(async (tx) => {
+      const follower = await insertAccountWithActor(tx, {
+        username: "vfcachefollower",
+        name: "VF Cache Follower",
+        email: "vfcachefollower@example.com",
+      });
+      const followee = await insertAccountWithActor(tx, {
+        username: "vfcachefollowee",
+        name: "VF Cache Followee",
+        email: "vfcachefollowee@example.com",
+      });
+
+      const actorId = encodeGlobalID("Actor", followee.actor.id);
+      const result = await execute({
+        schema,
+        document: followUnfollowMutation,
+        variableValues: { actorId },
+        contextValue: makeUserContext(tx, follower.account),
+        onError: "NO_PROPAGATE",
+      });
+
+      assertEquals(result.errors, undefined);
+      const data = result.data as {
+        follow: {
+          __typename: string;
+          followee?: { id: string; viewerFollows: boolean };
+        };
+        unfollow: {
+          __typename: string;
+          followee?: { id: string; viewerFollows: boolean };
+        };
+      };
+
+      assertEquals(data.follow.__typename, "FollowActorPayload");
+      assertEquals(data.unfollow.__typename, "UnfollowActorPayload");
+      assertEquals(data.follow.followee?.viewerFollows, true);
+      // A `cache: true` regression on `viewerFollows` would surface
+      // here as a stale cached `true`.
+      assertEquals(data.unfollow.followee?.viewerFollows, false);
     });
   },
 });

--- a/graphql/actor.test.ts
+++ b/graphql/actor.test.ts
@@ -882,3 +882,75 @@ Deno.test({
     });
   },
 });
+
+// GraphQL spec: top-level mutation fields execute serially.  With
+// `cache: false` on the loader, the second read sees the post-unblock
+// state.  If someone removes `cache: false` (default DataLoader cache
+// is `true`), the second `viewerBlocks` would return the cached `true`
+// from the first read and this test would fail.
+const blockUnblockMutation = parse(`
+  mutation BlockThenUnblock($actorId: ID!) {
+    block: blockActor(input: { actorId: $actorId }) {
+      __typename
+      ... on BlockActorPayload {
+        blockee { id viewerBlocks }
+      }
+    }
+    unblock: unblockActor(input: { actorId: $actorId }) {
+      __typename
+      ... on UnblockActorPayload {
+        blockee { id viewerBlocks }
+      }
+    }
+  }
+`);
+
+Deno.test({
+  name:
+    "Actor.viewerBlocks loader does not cache stale state across serial mutations",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  async fn() {
+    await withRollback(async (tx) => {
+      const blocker = await insertAccountWithActor(tx, {
+        username: "vbcacheblocker",
+        name: "VB Cache Blocker",
+        email: "vbcacheblocker@example.com",
+      });
+      const blockee = await insertAccountWithActor(tx, {
+        username: "vbcacheblockee",
+        name: "VB Cache Blockee",
+        email: "vbcacheblockee@example.com",
+      });
+
+      const actorId = encodeGlobalID("Actor", blockee.actor.id);
+      const result = await execute({
+        schema,
+        document: blockUnblockMutation,
+        variableValues: { actorId },
+        contextValue: makeUserContext(tx, blocker.account),
+        onError: "NO_PROPAGATE",
+      });
+
+      assertEquals(result.errors, undefined);
+      const data = result.data as {
+        block: {
+          __typename: string;
+          blockee?: { id: string; viewerBlocks: boolean };
+        };
+        unblock: {
+          __typename: string;
+          blockee?: { id: string; viewerBlocks: boolean };
+        };
+      };
+
+      assertEquals(data.block.__typename, "BlockActorPayload");
+      assertEquals(data.unblock.__typename, "UnblockActorPayload");
+      assertEquals(data.block.blockee?.viewerBlocks, true);
+      // Crucial: this asserts the loader re-queried after the unblock
+      // mutation flipped state.  A `cache: true` regression would
+      // surface here as `viewerBlocks: true` (the stale cached value).
+      assertEquals(data.unblock.blockee?.viewerBlocks, false);
+    });
+  },
+});

--- a/graphql/actor.test.ts
+++ b/graphql/actor.test.ts
@@ -526,6 +526,14 @@ const viewerFollowsBatchQuery = parse(`
   }
 `);
 
+const followRelationshipBatchQuery = parse(`
+  query FollowRelationshipBatch($a: UUID!, $b: UUID!, $c: UUID!) {
+    a: actorByUuid(uuid: $a) { id viewerFollows followsViewer }
+    b: actorByUuid(uuid: $b) { id viewerFollows followsViewer }
+    c: actorByUuid(uuid: $c) { id viewerFollows followsViewer }
+  }
+`);
+
 Deno.test({
   name: "Actor.viewerFollows returns the right state per actor when batched",
   sanitizeOps: false,
@@ -620,6 +628,74 @@ Deno.test({
       assertEquals(data.a.viewerFollows, false);
       assertEquals(data.b.viewerFollows, false);
       assertEquals(data.c.viewerFollows, false);
+    });
+  },
+});
+
+Deno.test({
+  name:
+    "Actor.viewerFollows and followsViewer are batched into independent results",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  async fn() {
+    await withRollback(async (tx) => {
+      const viewer = await insertAccountWithActor(tx, {
+        username: "frelviewer",
+        name: "FREL Viewer",
+        email: "frelviewer@example.com",
+      });
+      const followed = await insertAccountWithActor(tx, {
+        username: "frelfollowed",
+        name: "FREL Followed",
+        email: "frelfollowed@example.com",
+      });
+      const fan = await insertAccountWithActor(tx, {
+        username: "frelfan",
+        name: "FREL Fan",
+        email: "frelfan@example.com",
+      });
+      const stranger = await insertAccountWithActor(tx, {
+        username: "frelstranger",
+        name: "FREL Stranger",
+        email: "frelstranger@example.com",
+      });
+
+      const fedCtx = createFedCtx(tx);
+      // Viewer follows `followed` (viewerFollows=true on followed).
+      await follow(fedCtx, viewer.account, followed.actor);
+      // `fan` follows viewer (followsViewer=true on fan).
+      await follow(fedCtx, fan.account, viewer.actor);
+
+      const result = await execute({
+        schema,
+        document: followRelationshipBatchQuery,
+        variableValues: {
+          a: followed.actor.id,
+          b: fan.actor.id,
+          c: stranger.actor.id,
+        },
+        contextValue: makeUserContext(tx, viewer.account),
+        onError: "NO_PROPAGATE",
+      });
+
+      assertEquals(result.errors, undefined);
+      assertEquals(result.data, {
+        a: {
+          id: encodeGlobalID("Actor", followed.actor.id),
+          viewerFollows: true,
+          followsViewer: false,
+        },
+        b: {
+          id: encodeGlobalID("Actor", fan.actor.id),
+          viewerFollows: false,
+          followsViewer: true,
+        },
+        c: {
+          id: encodeGlobalID("Actor", stranger.actor.id),
+          viewerFollows: false,
+          followsViewer: false,
+        },
+      });
     });
   },
 });

--- a/graphql/actor.ts
+++ b/graphql/actor.ts
@@ -6,7 +6,11 @@ import {
   persistActor,
   recommendActors,
 } from "@hackerspub/models/actor";
-import { block, unblock } from "@hackerspub/models/blocking";
+import {
+  block,
+  getBlockedActorIds,
+  unblock,
+} from "@hackerspub/models/blocking";
 import { renderCustomEmojis } from "@hackerspub/models/emoji";
 import {
   follow,
@@ -390,20 +394,22 @@ builder.drizzleObjectFields(Actor, (t) => ({
     },
     resolve: (actor) => actor.id,
   }),
-  viewerBlocks: t.field({
+  viewerBlocks: t.loadable({
     type: "Boolean",
-    async resolve(actor, _, ctx) {
-      if (ctx.account == null || ctx.account.actor == null) {
-        return false;
-      }
-      return await ctx.db.query.blockingTable.findFirst({
-        columns: { iri: true },
-        where: {
-          blockerId: ctx.account.actor.id,
-          blockeeId: actor.id,
-        },
-      }) != null;
+    // cache: false so blockActor and unblockActor mutations are
+    // reflected by subsequent reads of the field within the same
+    // request rather than a stale per-request cached value.
+    loaderOptions: { cache: false },
+    load: async (actorIds: Uuid[], ctx: UserContext): Promise<boolean[]> => {
+      if (ctx.account?.actor == null) return actorIds.map(() => false);
+      const blocked = await getBlockedActorIds(
+        ctx.db,
+        ctx.account.actor.id,
+        actorIds,
+      );
+      return actorIds.map((id) => blocked.has(id));
     },
+    resolve: (actor) => actor.id,
   }),
   blocksViewer: t.field({
     type: "Boolean",

--- a/graphql/actor.ts
+++ b/graphql/actor.ts
@@ -1,6 +1,7 @@
 import { assert } from "@std/assert";
 import { isActor } from "@fedify/vocab";
-import { desc, eq } from "drizzle-orm";
+import DataLoader from "dataloader";
+import { desc, eq, inArray } from "drizzle-orm";
 import {
   getAvatarUrl,
   persistActor,
@@ -21,7 +22,7 @@ import {
   unfollow,
 } from "@hackerspub/models/following";
 import { getPostVisibilityFilter } from "@hackerspub/models/post";
-import type { Actor as ActorModel } from "@hackerspub/models/schema";
+import { type Actor as ActorRow, actorTable } from "@hackerspub/models/schema";
 import { type Uuid, validateUuid } from "@hackerspub/models/uuid";
 import { drizzleConnectionHelpers } from "@pothos/plugin-drizzle";
 import { assertNever } from "@std/assert/unstable-never";
@@ -31,6 +32,31 @@ import { builder, type UserContext } from "./builder.ts";
 import { InvalidInputError } from "./error.ts";
 import { Article, Note, Post, Question } from "./post.ts";
 import { NotAuthenticatedError } from "./session.ts";
+
+// Per-request loader keyed by actor id.  Several resolvers (e.g.,
+// `Notification.actors`) need to fetch actor rows by id one-by-one
+// while iterating a list; without batching, that fans out to one
+// `SELECT` per actor.  This helper collapses every actor id requested
+// across the active GraphQL execution into a single
+// `SELECT … WHERE id = ANY($1)` and dedupes overlapping ids via
+// DataLoader's per-request cache.
+export function getActorById(
+  ctx: UserContext,
+  actorId: Uuid,
+): Promise<ActorRow | null> {
+  ctx.actorByIdLoader ??= new DataLoader<Uuid, ActorRow | null>(
+    async (ids) => {
+      const idList = ids as Uuid[];
+      const rows = await ctx.db
+        .select()
+        .from(actorTable)
+        .where(inArray(actorTable.id, idList));
+      const byId = new Map(rows.map((row) => [row.id, row]));
+      return idList.map((id) => byId.get(id) ?? null);
+    },
+  );
+  return ctx.actorByIdLoader.load(actorId);
+}
 
 export const ActorType = builder.enumType("ActorType", {
   values: [
@@ -604,7 +630,7 @@ builder.queryFields((t) => ({
     async resolve(query, _, { handle, allowLocalHandle }, ctx) {
       if (handle.startsWith("@")) handle = handle.substring(1);
       const split = handle.split("@");
-      let actor: ActorModel | undefined = undefined;
+      let actor: ActorRow | undefined = undefined;
       if (split.length === 2) {
         const [username, host] = split;
         actor = await ctx.db.query.actorTable.findFirst(

--- a/graphql/actor.ts
+++ b/graphql/actor.ts
@@ -58,6 +58,33 @@ export function getActorById(
   return ctx.actorByIdLoader.load(actorId);
 }
 
+// Builds a Pothos `t.loadable` `load` function for boolean relationship
+// fields like `viewerFollows`/`viewerBlocks`/`blocksViewer`/`followsViewer`.
+// Each of those fields asks "for these N actor ids, which ones are in the
+// directional relationship with the viewer?" and only differs by which
+// model helper produces the matched-id Set.  Hoisting the shared shape
+// here keeps the field declarations to one line of `load:` each.
+function createRelationshipBooleanLoader(
+  getMatchedIds: (
+    db: UserContext["db"],
+    viewerId: Uuid,
+    targetIds: readonly Uuid[],
+  ) => Promise<Set<Uuid>>,
+) {
+  return async (
+    actorIds: Uuid[],
+    ctx: UserContext,
+  ): Promise<boolean[]> => {
+    if (ctx.account?.actor == null) return actorIds.map(() => false);
+    const matched = await getMatchedIds(
+      ctx.db,
+      ctx.account.actor.id,
+      actorIds,
+    );
+    return actorIds.map((id) => matched.has(id));
+  };
+}
+
 export const ActorType = builder.enumType("ActorType", {
   values: [
     "APPLICATION",
@@ -410,15 +437,7 @@ builder.drizzleObjectFields(Actor, (t) => ({
     // request (e.g., followActor + read viewerFollows in the payload)
     // re-queries instead of returning the pre-mutation value.
     loaderOptions: { cache: false },
-    load: async (actorIds: Uuid[], ctx: UserContext): Promise<boolean[]> => {
-      if (ctx.account?.actor == null) return actorIds.map(() => false);
-      const followed = await getFollowedActorIds(
-        ctx.db,
-        ctx.account.actor.id,
-        actorIds,
-      );
-      return actorIds.map((id) => followed.has(id));
-    },
+    load: createRelationshipBooleanLoader(getFollowedActorIds),
     resolve: (actor) => actor.id,
   }),
   viewerBlocks: t.loadable({
@@ -427,15 +446,7 @@ builder.drizzleObjectFields(Actor, (t) => ({
     // reflected by subsequent reads of the field within the same
     // request rather than a stale per-request cached value.
     loaderOptions: { cache: false },
-    load: async (actorIds: Uuid[], ctx: UserContext): Promise<boolean[]> => {
-      if (ctx.account?.actor == null) return actorIds.map(() => false);
-      const blocked = await getBlockedActorIds(
-        ctx.db,
-        ctx.account.actor.id,
-        actorIds,
-      );
-      return actorIds.map((id) => blocked.has(id));
-    },
+    load: createRelationshipBooleanLoader(getBlockedActorIds),
     resolve: (actor) => actor.id,
   }),
   blocksViewer: t.loadable({
@@ -444,15 +455,7 @@ builder.drizzleObjectFields(Actor, (t) => ({
     // reflected by a subsequent read of the field rather than a
     // stale per-request cached value.
     loaderOptions: { cache: false },
-    load: async (actorIds: Uuid[], ctx: UserContext): Promise<boolean[]> => {
-      if (ctx.account?.actor == null) return actorIds.map(() => false);
-      const blockers = await getBlockerActorIds(
-        ctx.db,
-        ctx.account.actor.id,
-        actorIds,
-      );
-      return actorIds.map((id) => blockers.has(id));
-    },
+    load: createRelationshipBooleanLoader(getBlockerActorIds),
     resolve: (actor) => actor.id,
   }),
   followsViewer: t.loadable({
@@ -461,15 +464,7 @@ builder.drizzleObjectFields(Actor, (t) => ({
     // (e.g., removeFollower) is reflected by a subsequent read of
     // the field rather than a stale per-request cached value.
     loaderOptions: { cache: false },
-    load: async (actorIds: Uuid[], ctx: UserContext): Promise<boolean[]> => {
-      if (ctx.account?.actor == null) return actorIds.map(() => false);
-      const followers = await getFollowerActorIds(
-        ctx.db,
-        ctx.account.actor.id,
-        actorIds,
-      );
-      return actorIds.map((id) => followers.has(id));
-    },
+    load: createRelationshipBooleanLoader(getFollowerActorIds),
     resolve: (actor) => actor.id,
   }),
   followees: t.connection(

--- a/graphql/actor.ts
+++ b/graphql/actor.ts
@@ -10,17 +10,18 @@ import { block, unblock } from "@hackerspub/models/blocking";
 import { renderCustomEmojis } from "@hackerspub/models/emoji";
 import {
   follow,
+  getFollowedActorIds,
   removeFollower as removeFollowerModel,
   unfollow,
 } from "@hackerspub/models/following";
 import { getPostVisibilityFilter } from "@hackerspub/models/post";
 import type { Actor as ActorModel } from "@hackerspub/models/schema";
-import { validateUuid } from "@hackerspub/models/uuid";
+import { type Uuid, validateUuid } from "@hackerspub/models/uuid";
 import { drizzleConnectionHelpers } from "@pothos/plugin-drizzle";
 import { assertNever } from "@std/assert/unstable-never";
 import { escape } from "@std/html/entities";
 import xss from "xss";
-import { builder } from "./builder.ts";
+import { builder, type UserContext } from "./builder.ts";
 import { InvalidInputError } from "./error.ts";
 import { Article, Note, Post, Question } from "./post.ts";
 import { NotAuthenticatedError } from "./session.ts";
@@ -371,20 +372,22 @@ builder.drizzleObjectFields(Actor, (t) => ({
       return ctx.account?.actor?.id === actor.id;
     },
   }),
-  viewerFollows: t.field({
+  viewerFollows: t.loadable({
     type: "Boolean",
-    async resolve(actor, _, ctx) {
-      if (ctx.account == null || ctx.account.actor == null) {
-        return false;
-      }
-      return await ctx.db.query.followingTable.findFirst({
-        columns: { iri: true },
-        where: {
-          followerId: ctx.account.actor.id,
-          followeeId: actor.id,
-        },
-      }) != null;
+    // cache: false so a mutation that changes follow state in the same
+    // request (e.g., followActor + read viewerFollows in the payload)
+    // re-queries instead of returning the pre-mutation value.
+    loaderOptions: { cache: false },
+    load: async (actorIds: Uuid[], ctx: UserContext): Promise<boolean[]> => {
+      if (ctx.account?.actor == null) return actorIds.map(() => false);
+      const followed = await getFollowedActorIds(
+        ctx.db,
+        ctx.account.actor.id,
+        actorIds,
+      );
+      return actorIds.map((id) => followed.has(id));
     },
+    resolve: (actor) => actor.id,
   }),
   viewerBlocks: t.field({
     type: "Boolean",

--- a/graphql/actor.ts
+++ b/graphql/actor.ts
@@ -9,6 +9,7 @@ import {
 import {
   block,
   getBlockedActorIds,
+  getBlockerActorIds,
   unblock,
 } from "@hackerspub/models/blocking";
 import { renderCustomEmojis } from "@hackerspub/models/emoji";
@@ -411,20 +412,22 @@ builder.drizzleObjectFields(Actor, (t) => ({
     },
     resolve: (actor) => actor.id,
   }),
-  blocksViewer: t.field({
+  blocksViewer: t.loadable({
     type: "Boolean",
-    async resolve(actor, _, ctx) {
-      if (ctx.account == null || ctx.account.actor == null) {
-        return false;
-      }
-      return await ctx.db.query.blockingTable.findFirst({
-        columns: { iri: true },
-        where: {
-          blockerId: actor.id,
-          blockeeId: ctx.account.actor.id,
-        },
-      }) != null;
+    // cache: false so a block-state mutation in the same request is
+    // reflected by a subsequent read of the field rather than a
+    // stale per-request cached value.
+    loaderOptions: { cache: false },
+    load: async (actorIds: Uuid[], ctx: UserContext): Promise<boolean[]> => {
+      if (ctx.account?.actor == null) return actorIds.map(() => false);
+      const blockers = await getBlockerActorIds(
+        ctx.db,
+        ctx.account.actor.id,
+        actorIds,
+      );
+      return actorIds.map((id) => blockers.has(id));
     },
+    resolve: (actor) => actor.id,
   }),
   followsViewer: t.loadable({
     type: "Boolean",

--- a/graphql/actor.ts
+++ b/graphql/actor.ts
@@ -11,6 +11,7 @@ import { renderCustomEmojis } from "@hackerspub/models/emoji";
 import {
   follow,
   getFollowedActorIds,
+  getFollowerActorIds,
   removeFollower as removeFollowerModel,
   unfollow,
 } from "@hackerspub/models/following";
@@ -419,20 +420,22 @@ builder.drizzleObjectFields(Actor, (t) => ({
       }) != null;
     },
   }),
-  followsViewer: t.field({
+  followsViewer: t.loadable({
     type: "Boolean",
-    async resolve(actor, _, ctx) {
-      if (ctx.account == null || ctx.account.actor == null) {
-        return false;
-      }
-      return await ctx.db.query.followingTable.findFirst({
-        columns: { iri: true },
-        where: {
-          followerId: actor.id,
-          followeeId: ctx.account.actor.id,
-        },
-      }) != null;
+    // cache: false so a follow-state mutation in the same request
+    // (e.g., removeFollower) is reflected by a subsequent read of
+    // the field rather than a stale per-request cached value.
+    loaderOptions: { cache: false },
+    load: async (actorIds: Uuid[], ctx: UserContext): Promise<boolean[]> => {
+      if (ctx.account?.actor == null) return actorIds.map(() => false);
+      const followers = await getFollowerActorIds(
+        ctx.db,
+        ctx.account.actor.id,
+        actorIds,
+      );
+      return actorIds.map((id) => followers.has(id));
     },
+    resolve: (actor) => actor.id,
   }),
   followees: t.connection(
     {

--- a/graphql/builder.ts
+++ b/graphql/builder.ts
@@ -63,6 +63,7 @@ export interface UserContext extends ServerContext {
   pollViewerVotes?: Map<Uuid, Promise<ReadonlySet<number>>>;
   adminAccountStatsLoader?: DataLoader<Uuid, AdminAccountStats>;
   inviteeCountLoader?: DataLoader<Uuid, number>;
+  actorByIdLoader?: DataLoader<Uuid, Actor | null>;
 }
 
 export interface PothosTypes {

--- a/graphql/notification.test.ts
+++ b/graphql/notification.test.ts
@@ -1,7 +1,14 @@
 import { assert } from "@std/assert/assert";
 import { assertEquals } from "@std/assert/equals";
-import { notificationTable } from "@hackerspub/models/schema";
+import {
+  type Actor as ActorRow,
+  actorTable,
+  notificationTable,
+} from "@hackerspub/models/schema";
+import { generateUuidV7, type Uuid } from "@hackerspub/models/uuid";
 import { encodeGlobalID } from "@pothos/plugin-relay";
+import DataLoader from "dataloader";
+import { inArray } from "drizzle-orm";
 import { execute, parse } from "graphql";
 import { schema } from "./mod.ts";
 import {
@@ -93,6 +100,250 @@ Deno.test({
           encodeGlobalID("Actor", newerActor.actor.id),
           encodeGlobalID("Actor", olderActor.actor.id),
         ],
+      );
+    });
+  },
+});
+
+Deno.test({
+  name: "Notification.actors batches across multiple notifications",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  async fn() {
+    await withRollback(async (tx) => {
+      const recipient = await insertAccountWithActor(tx, {
+        username: "notifybatchme",
+        name: "Notify Batch Me",
+        email: "notifybatchme@example.com",
+      });
+      const actorA = await insertAccountWithActor(tx, {
+        username: "notifybatchactora",
+        name: "Notify Batch Actor A",
+        email: "notifybatchactora@example.com",
+      });
+      const actorB = await insertAccountWithActor(tx, {
+        username: "notifybatchactorb",
+        name: "Notify Batch Actor B",
+        email: "notifybatchactorb@example.com",
+      });
+      const actorC = await insertAccountWithActor(tx, {
+        username: "notifybatchactorc",
+        name: "Notify Batch Actor C",
+        email: "notifybatchactorc@example.com",
+      });
+
+      // Two notifications for the same recipient.  actorB appears in
+      // both — exercising the per-request DataLoader cache path that
+      // dedupes overlapping ids across notifications.
+      await tx.insert(notificationTable).values([
+        {
+          id: generateUuidV7(),
+          accountId: recipient.account.id,
+          type: "follow",
+          actorIds: [actorA.actor.id, actorB.actor.id],
+          // Newer notification — surfaces first via desc(created).
+          created: new Date("2026-04-15T00:00:01.000Z"),
+        },
+        {
+          id: generateUuidV7(),
+          accountId: recipient.account.id,
+          type: "follow",
+          actorIds: [actorB.actor.id, actorC.actor.id],
+          created: new Date("2026-04-15T00:00:00.000Z"),
+        },
+      ]);
+
+      const result = await execute({
+        schema,
+        document: notificationActorsQuery,
+        contextValue: makeUserContext(tx, recipient.account),
+        onError: "NO_PROPAGATE",
+      });
+
+      assertEquals(result.errors, undefined);
+
+      const data = result.data as {
+        viewer: {
+          notifications: {
+            edges: {
+              node: {
+                actors: {
+                  edges: { node: { id: string } }[];
+                };
+              };
+            }[];
+          };
+        } | null;
+      };
+
+      const edges = data.viewer?.notifications.edges;
+      assert(edges != null);
+      assertEquals(edges.length, 2);
+
+      // Each notification still resolves to its own ordered actor list,
+      // newest-position-first (the resolver's existing semantics).
+      assertEquals(
+        edges[0].node.actors.edges.map((edge) => edge.node.id),
+        [
+          encodeGlobalID("Actor", actorB.actor.id),
+          encodeGlobalID("Actor", actorA.actor.id),
+        ],
+      );
+      assertEquals(
+        edges[1].node.actors.edges.map((edge) => edge.node.id),
+        [
+          encodeGlobalID("Actor", actorC.actor.id),
+          encodeGlobalID("Actor", actorB.actor.id),
+        ],
+      );
+    });
+  },
+});
+
+Deno.test({
+  name:
+    "Notification.actors filters out missing actor ids without breaking the batch",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  async fn() {
+    await withRollback(async (tx) => {
+      const recipient = await insertAccountWithActor(tx, {
+        username: "notifymissingme",
+        name: "Notify Missing Me",
+        email: "notifymissingme@example.com",
+      });
+      const realActor = await insertAccountWithActor(tx, {
+        username: "notifymissingreal",
+        name: "Notify Missing Real",
+        email: "notifymissingreal@example.com",
+      });
+      const phantomId = generateUuidV7();
+
+      await tx.insert(notificationTable).values({
+        id: generateUuidV7(),
+        accountId: recipient.account.id,
+        type: "follow",
+        actorIds: [phantomId, realActor.actor.id],
+        created: new Date("2026-04-15T00:00:00.000Z"),
+      });
+
+      const result = await execute({
+        schema,
+        document: notificationActorsQuery,
+        contextValue: makeUserContext(tx, recipient.account),
+        onError: "NO_PROPAGATE",
+      });
+
+      assertEquals(result.errors, undefined);
+      const data = result.data as {
+        viewer: {
+          notifications: {
+            edges: {
+              node: { actors: { edges: { node: { id: string } }[] } };
+            }[];
+          };
+        } | null;
+      };
+
+      const edges = data.viewer?.notifications.edges;
+      assert(edges != null && edges.length === 1);
+      assertEquals(
+        edges[0].node.actors.edges.map((edge) => edge.node.id),
+        [encodeGlobalID("Actor", realActor.actor.id)],
+      );
+    });
+  },
+});
+
+Deno.test({
+  name:
+    "Notification.actors fires one DataLoader batch for the deduped actor id union",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  async fn() {
+    await withRollback(async (tx) => {
+      const recipient = await insertAccountWithActor(tx, {
+        username: "notifyspyme",
+        name: "Notify Spy Me",
+        email: "notifyspyme@example.com",
+      });
+      const actorA = await insertAccountWithActor(tx, {
+        username: "notifyspyactora",
+        name: "Notify Spy Actor A",
+        email: "notifyspyactora@example.com",
+      });
+      const actorB = await insertAccountWithActor(tx, {
+        username: "notifyspyactorb",
+        name: "Notify Spy Actor B",
+        email: "notifyspyactorb@example.com",
+      });
+      const actorC = await insertAccountWithActor(tx, {
+        username: "notifyspyactorc",
+        name: "Notify Spy Actor C",
+        email: "notifyspyactorc@example.com",
+      });
+
+      // Two notifications with overlapping actor ids — actorB appears
+      // in both.  After dedupe, the loader should batch exactly the
+      // three distinct ids in a single call.
+      await tx.insert(notificationTable).values([
+        {
+          id: generateUuidV7(),
+          accountId: recipient.account.id,
+          type: "follow",
+          actorIds: [actorA.actor.id, actorB.actor.id],
+          created: new Date("2026-04-15T00:00:01.000Z"),
+        },
+        {
+          id: generateUuidV7(),
+          accountId: recipient.account.id,
+          type: "follow",
+          actorIds: [actorB.actor.id, actorC.actor.id],
+          created: new Date("2026-04-15T00:00:00.000Z"),
+        },
+      ]);
+
+      const batches: Uuid[][] = [];
+      const actorByIdLoader = new DataLoader<Uuid, ActorRow | null>(
+        async (ids) => {
+          const idList = ids as Uuid[];
+          batches.push([...idList]);
+          const rows = await tx
+            .select()
+            .from(actorTable)
+            .where(inArray(actorTable.id, idList));
+          const byId = new Map(rows.map((row) => [row.id, row]));
+          return idList.map((id) => byId.get(id) ?? null);
+        },
+      );
+
+      const result = await execute({
+        schema,
+        document: notificationActorsQuery,
+        contextValue: makeUserContext(tx, recipient.account, {
+          actorByIdLoader,
+        }),
+        onError: "NO_PROPAGATE",
+      });
+
+      assertEquals(result.errors, undefined);
+
+      // Exactly one batch — the loader collapsed both notifications'
+      // actor lookups into one SQL query.
+      assertEquals(batches.length, 1);
+
+      // The batch contains exactly the deduped union (3 ids) of every
+      // actor id requested across both notifications, in some order.
+      // The length check rules out an undeduped payload that happens
+      // to contain the right Set.
+      assertEquals(batches[0].length, 3);
+      assertEquals(
+        new Set(batches[0]),
+        new Set([
+          actorA.actor.id,
+          actorB.actor.id,
+          actorC.actor.id,
+        ]),
       );
     });
   },

--- a/graphql/notification.test.ts
+++ b/graphql/notification.test.ts
@@ -348,3 +348,63 @@ Deno.test({
     });
   },
 });
+
+Deno.test({
+  name:
+    "Notification.actors deduplicates repeated actor ids within a notification",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  async fn() {
+    await withRollback(async (tx) => {
+      const recipient = await insertAccountWithActor(tx, {
+        username: "notifydedupeme",
+        name: "Notify Dedupe Me",
+        email: "notifydedupeme@example.com",
+      });
+      const actor = await insertAccountWithActor(tx, {
+        username: "notifydedupeactor",
+        name: "Notify Dedupe Actor",
+        email: "notifydedupeactor@example.com",
+      });
+
+      // Bypass the createNotification merge logic and write a row with
+      // a duplicated actorId directly, so we can verify the resolver
+      // dedupes on read.  In production this is prevented at write
+      // time, but the resolver still defends the parity.
+      await tx.insert(notificationTable).values({
+        id: generateUuidV7(),
+        accountId: recipient.account.id,
+        type: "follow",
+        actorIds: [actor.actor.id, actor.actor.id],
+        created: new Date("2026-04-15T00:00:00.000Z"),
+      });
+
+      const result = await execute({
+        schema,
+        document: notificationActorsQuery,
+        contextValue: makeUserContext(tx, recipient.account),
+        onError: "NO_PROPAGATE",
+      });
+
+      assertEquals(result.errors, undefined);
+      const data = result.data as {
+        viewer: {
+          notifications: {
+            edges: {
+              node: { actors: { edges: { node: { id: string } }[] } };
+            }[];
+          };
+        } | null;
+      };
+
+      const edges = data.viewer?.notifications.edges;
+      assert(edges != null && edges.length === 1);
+      // Duplicate id in actorIds yields a single edge in the
+      // connection, matching the prior findMany IN (…) semantics.
+      assertEquals(
+        edges[0].node.actors.edges.map((edge) => edge.node.id),
+        [encodeGlobalID("Actor", actor.actor.id)],
+      );
+    });
+  },
+});

--- a/graphql/notification.ts
+++ b/graphql/notification.ts
@@ -1,43 +1,16 @@
 import {
   accountTable,
   type Actor as ActorRow,
-  actorTable,
 } from "@hackerspub/models/schema";
-import type { Uuid } from "@hackerspub/models/uuid";
 import {
   resolveCursorConnection,
   type ResolveCursorConnectionArgs,
 } from "@pothos/plugin-relay";
-import DataLoader from "dataloader";
-import { eq, inArray, sql } from "drizzle-orm";
-import { Actor } from "./actor.ts";
-import { builder, Node, type UserContext } from "./builder.ts";
+import { eq, sql } from "drizzle-orm";
+import { Actor, getActorById } from "./actor.ts";
+import { builder, Node } from "./builder.ts";
 import { Post } from "./post.ts";
 import { NotAuthenticatedError } from "./session.ts";
-
-// Per-request loader keyed by actor id.  Notifications carry an
-// `actorIds: Uuid[]` column, so the unbatched resolver fired one
-// `findMany` per notification.  The loader collapses every actor
-// id requested across the active execution into a single
-// `SELECT … WHERE id = ANY($1)` and dedupes overlapping ids
-// (e.g., the same person mentioned in two notifications).
-function getActorById(
-  ctx: UserContext,
-  actorId: Uuid,
-): Promise<ActorRow | null> {
-  ctx.actorByIdLoader ??= new DataLoader<Uuid, ActorRow | null>(
-    async (ids) => {
-      const idList = ids as Uuid[];
-      const rows = await ctx.db
-        .select()
-        .from(actorTable)
-        .where(inArray(actorTable.id, idList));
-      const byId = new Map(rows.map((row) => [row.id, row]));
-      return idList.map((id) => byId.get(id) ?? null);
-    },
-  );
-  return ctx.actorByIdLoader.load(actorId);
-}
 
 export const NotificationType = builder.enumType("NotificationType", {
   values: [

--- a/graphql/notification.ts
+++ b/graphql/notification.ts
@@ -1,13 +1,43 @@
-import { accountTable } from "@hackerspub/models/schema";
+import {
+  accountTable,
+  type Actor as ActorRow,
+  actorTable,
+} from "@hackerspub/models/schema";
+import type { Uuid } from "@hackerspub/models/uuid";
 import {
   resolveCursorConnection,
   type ResolveCursorConnectionArgs,
 } from "@pothos/plugin-relay";
-import { eq, sql } from "drizzle-orm";
+import DataLoader from "dataloader";
+import { eq, inArray, sql } from "drizzle-orm";
 import { Actor } from "./actor.ts";
-import { builder, Node } from "./builder.ts";
+import { builder, Node, type UserContext } from "./builder.ts";
 import { Post } from "./post.ts";
 import { NotAuthenticatedError } from "./session.ts";
+
+// Per-request loader keyed by actor id.  Notifications carry an
+// `actorIds: Uuid[]` column, so the unbatched resolver fired one
+// `findMany` per notification.  The loader collapses every actor
+// id requested across the active execution into a single
+// `SELECT … WHERE id = ANY($1)` and dedupes overlapping ids
+// (e.g., the same person mentioned in two notifications).
+function getActorById(
+  ctx: UserContext,
+  actorId: Uuid,
+): Promise<ActorRow | null> {
+  ctx.actorByIdLoader ??= new DataLoader<Uuid, ActorRow | null>(
+    async (ids) => {
+      const idList = ids as Uuid[];
+      const rows = await ctx.db
+        .select()
+        .from(actorTable)
+        .where(inArray(actorTable.id, idList));
+      const byId = new Map(rows.map((row) => [row.id, row]));
+      return idList.map((id) => byId.get(id) ?? null);
+    },
+  );
+  return ctx.actorByIdLoader.load(actorId);
+}
 
 export const NotificationType = builder.enumType("NotificationType", {
   values: [
@@ -52,11 +82,12 @@ export const Notification = builder.drizzleInterface("notificationTable", {
             toCursor: (actor) => actor.id,
           },
           async (_args: ResolveCursorConnectionArgs) => {
-            const actors = await ctx.db.query.actorTable.findMany({
-              where: {
-                id: { in: notification.actorIds },
-              },
-            });
+            const loaded = await Promise.all(
+              notification.actorIds.map((id) => getActorById(ctx, id)),
+            );
+            const actors = loaded.filter(
+              (actor): actor is ActorRow => actor != null,
+            );
             const positionMap = new Map(
               notification.actorIds.map((id, index) => [id, index]),
             );

--- a/graphql/notification.ts
+++ b/graphql/notification.ts
@@ -55,8 +55,14 @@ export const Notification = builder.drizzleInterface("notificationTable", {
             toCursor: (actor) => actor.id,
           },
           async (_args: ResolveCursorConnectionArgs) => {
+            // Dedupe actorIds before loading so the resolver matches the
+            // prior `findMany({ id: { in: actorIds } })` behavior, which
+            // implicitly returned each row at most once.  The notification
+            // write path in models/notification.ts already prevents
+            // duplicates, but the dedupe here defends the parity.
+            const uniqueActorIds = [...new Set(notification.actorIds)];
             const loaded = await Promise.all(
-              notification.actorIds.map((id) => getActorById(ctx, id)),
+              uniqueActorIds.map((id) => getActorById(ctx, id)),
             );
             const actors = loaded.filter(
               (actor): actor is ActorRow => actor != null,

--- a/graphql/reactable.test.ts
+++ b/graphql/reactable.test.ts
@@ -134,6 +134,154 @@ Deno.test({
   },
 });
 
+const customEmojiBatchQuery = parse(`
+  query CustomEmojiBatchQuery($a: ID!, $b: ID!) {
+    a: node(id: $a) {
+      ... on Post {
+        reactionGroups {
+          ... on CustomEmojiReactionGroup {
+            customEmoji {
+              id
+              name
+              imageUrl
+            }
+          }
+        }
+      }
+    }
+    b: node(id: $b) {
+      ... on Post {
+        reactionGroups {
+          ... on CustomEmojiReactionGroup {
+            customEmoji {
+              id
+              name
+              imageUrl
+            }
+          }
+        }
+      }
+    }
+  }
+`);
+
+Deno.test({
+  name:
+    "CustomEmojiReactionGroup.customEmoji resolves the right emoji per post when batched",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  async fn() {
+    await withRollback(async (tx) => {
+      const timestamp = new Date("2026-04-15T00:00:00.000Z");
+      const suffix = crypto.randomUUID().replaceAll("-", "").slice(0, 8);
+
+      await seedLocalInstance(tx);
+
+      const author = await insertAccountWithActor(tx, {
+        username: `author${suffix}`,
+        name: "Author",
+        email: `author-${suffix}@example.com`,
+      });
+      const reactor = await insertAccountWithActor(tx, {
+        username: `reactor${suffix}`,
+        name: "Reactor",
+        email: `reactor-${suffix}@example.com`,
+      });
+
+      const partyId = generateUuidV7();
+      const cakeId = generateUuidV7();
+      await tx.insert(customEmojiTable).values([
+        {
+          id: partyId,
+          iri: `http://localhost/emojis/${partyId}`,
+          name: ":party:",
+          imageUrl: `https://cdn.example/emoji/${partyId}.png`,
+        },
+        {
+          id: cakeId,
+          iri: `http://localhost/emojis/${cakeId}`,
+          name: ":cake:",
+          imageUrl: `https://cdn.example/emoji/${cakeId}.png`,
+        },
+      ]);
+
+      const { post: postA } = await insertNotePost(tx, {
+        account: author.account,
+        content: "First",
+        contentHtml: "<p>First</p>",
+        published: timestamp,
+        updated: timestamp,
+        reactionsCounts: { [partyId]: 1 },
+      });
+      const { post: postB } = await insertNotePost(tx, {
+        account: author.account,
+        content: "Second",
+        contentHtml: "<p>Second</p>",
+        published: new Date(timestamp.getTime() + 1000),
+        updated: new Date(timestamp.getTime() + 1000),
+        reactionsCounts: { [cakeId]: 1 },
+      });
+
+      await tx.insert(reactionTable).values([
+        {
+          iri: `http://localhost/reactions/${generateUuidV7()}`,
+          postId: postA.id,
+          actorId: reactor.actor.id,
+          customEmojiId: partyId,
+          created: new Date(timestamp.getTime() + 100),
+        },
+        {
+          iri: `http://localhost/reactions/${generateUuidV7()}`,
+          postId: postB.id,
+          actorId: reactor.actor.id,
+          customEmojiId: cakeId,
+          created: new Date(timestamp.getTime() + 1100),
+        },
+      ]);
+
+      const result = await execute({
+        schema,
+        document: customEmojiBatchQuery,
+        variableValues: {
+          a: encodeGlobalID("Note", postA.id),
+          b: encodeGlobalID("Note", postB.id),
+        },
+        contextValue: makeUserContext(tx, reactor.account),
+        onError: "NO_PROPAGATE",
+      });
+
+      assertEquals(result.errors, undefined);
+
+      const data = result.data as {
+        a: {
+          reactionGroups: {
+            customEmoji?: { id: string; name: string; imageUrl: string };
+          }[];
+        } | null;
+        b: {
+          reactionGroups: {
+            customEmoji?: { id: string; name: string; imageUrl: string };
+          }[];
+        } | null;
+      };
+
+      const aEmoji = data.a?.reactionGroups
+        .map((group) => group.customEmoji)
+        .find((emoji) => emoji != null);
+      const bEmoji = data.b?.reactionGroups
+        .map((group) => group.customEmoji)
+        .find((emoji) => emoji != null);
+
+      assert(aEmoji != null);
+      assert(bEmoji != null);
+      assertEquals(aEmoji.name, ":party:");
+      assertEquals(aEmoji.imageUrl, `https://cdn.example/emoji/${partyId}.png`);
+      assertEquals(bEmoji.name, ":cake:");
+      assertEquals(bEmoji.imageUrl, `https://cdn.example/emoji/${cakeId}.png`);
+    });
+  },
+});
+
 async function seedReactedNote(
   tx: Transaction,
 ): Promise<ReactedNoteSeedResult> {

--- a/graphql/reactable.ts
+++ b/graphql/reactable.ts
@@ -195,26 +195,6 @@ export interface CustomEmojiReactionGroup extends ReactionGroup {
   customEmojiId: Uuid;
 }
 
-const CustomEmojiReactionGroup = builder.objectRef<CustomEmojiReactionGroup>(
-  "CustomEmojiReactionGroup",
-);
-
-CustomEmojiReactionGroup.implement({
-  interfaces: [ReactionGroup],
-  fields: (t) => ({
-    customEmoji: t.drizzleField({
-      type: "customEmojiTable",
-      async resolve(query, group, _, ctx) {
-        const customEmoji = await ctx.db.query.customEmojiTable.findFirst(
-          query({ where: { id: group.customEmojiId } }),
-        );
-        if (!customEmoji) throw new Error(`Custom emoji not found`);
-        return customEmoji;
-      },
-    }),
-  }),
-});
-
 export const CustomEmoji = builder.drizzleNode("customEmojiTable", {
   name: "CustomEmoji",
   id: {
@@ -227,6 +207,33 @@ export const CustomEmoji = builder.drizzleNode("customEmojiTable", {
     }),
     name: t.exposeString("name"),
     imageUrl: t.exposeString("imageUrl"),
+  }),
+});
+
+const CustomEmojiReactionGroup = builder.objectRef<CustomEmojiReactionGroup>(
+  "CustomEmojiReactionGroup",
+);
+
+CustomEmojiReactionGroup.implement({
+  interfaces: [ReactionGroup],
+  fields: (t) => ({
+    customEmoji: t.loadable({
+      type: CustomEmoji,
+      load: async (ids: Uuid[], ctx: UserContext) => {
+        const rows = await ctx.db.query.customEmojiTable.findMany({
+          where: { id: { in: ids } },
+        });
+        const byId = new Map(rows.map((row) => [row.id, row]));
+        return ids.map((id) => {
+          const row = byId.get(id);
+          if (row == null) {
+            return new Error(`Custom emoji not found: ${id}`);
+          }
+          return row;
+        });
+      },
+      resolve: (group) => group.customEmojiId,
+    }),
   }),
 });
 

--- a/models/blocking.test.ts
+++ b/models/blocking.test.ts
@@ -1,13 +1,15 @@
 import { assert } from "@std/assert/assert";
 import { assertEquals } from "@std/assert/equals";
 import { and, eq } from "drizzle-orm";
-import { block, unblock } from "./blocking.ts";
+import { block, getBlockedActorIds, unblock } from "./blocking.ts";
 import { follow } from "./following.ts";
 import { blockingTable, followingTable } from "./schema.ts";
+import { generateUuidV7, type Uuid } from "./uuid.ts";
 import {
   createFedCtx,
   insertAccountWithActor,
   insertRemoteActor,
+  seedLocalInstance,
   withRollback,
 } from "../test/postgres.ts";
 
@@ -146,6 +148,62 @@ Deno.test({
         ),
       );
       assertEquals(reverseFollow, []);
+    });
+  },
+});
+
+Deno.test({
+  name: "getBlockedActorIds returns the subset that the blocker has blocked",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  async fn() {
+    await withRollback(async (tx) => {
+      await seedLocalInstance(tx);
+      const fedCtx = createFedCtx(tx);
+      const suffix = crypto.randomUUID().replaceAll("-", "").slice(0, 8);
+      const blocker = await insertAccountWithActor(tx, {
+        username: `gbaiblocker${suffix}`,
+        name: "GBAI Blocker",
+        email: `gbaiblocker-${suffix}@example.com`,
+      });
+      const blocked = await insertAccountWithActor(tx, {
+        username: `gbaiblocked${suffix}`,
+        name: "GBAI Blocked",
+        email: `gbaiblocked-${suffix}@example.com`,
+      });
+      const notBlocked = await insertAccountWithActor(tx, {
+        username: `gbainotblocked${suffix}`,
+        name: "GBAI Not Blocked",
+        email: `gbainotblocked-${suffix}@example.com`,
+      });
+
+      await block(fedCtx, blocker.account, blocked.actor);
+
+      const result = await getBlockedActorIds(tx, blocker.actor.id, [
+        blocked.actor.id,
+        notBlocked.actor.id,
+        generateUuidV7() as Uuid,
+      ]);
+
+      assertEquals(result.has(blocked.actor.id), true);
+      assertEquals(result.has(notBlocked.actor.id), false);
+      assertEquals(result.size, 1);
+    });
+  },
+});
+
+Deno.test({
+  name: "getBlockedActorIds returns empty for empty input",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  async fn() {
+    await withRollback(async (tx) => {
+      const result = await getBlockedActorIds(
+        tx,
+        generateUuidV7() as Uuid,
+        [],
+      );
+      assertEquals(result.size, 0);
     });
   },
 });

--- a/models/blocking.test.ts
+++ b/models/blocking.test.ts
@@ -1,7 +1,12 @@
 import { assert } from "@std/assert/assert";
 import { assertEquals } from "@std/assert/equals";
 import { and, eq } from "drizzle-orm";
-import { block, getBlockedActorIds, unblock } from "./blocking.ts";
+import {
+  block,
+  getBlockedActorIds,
+  getBlockerActorIds,
+  unblock,
+} from "./blocking.ts";
 import { follow } from "./following.ts";
 import { blockingTable, followingTable } from "./schema.ts";
 import { generateUuidV7, type Uuid } from "./uuid.ts";
@@ -199,6 +204,62 @@ Deno.test({
   async fn() {
     await withRollback(async (tx) => {
       const result = await getBlockedActorIds(
+        tx,
+        generateUuidV7() as Uuid,
+        [],
+      );
+      assertEquals(result.size, 0);
+    });
+  },
+});
+
+Deno.test({
+  name: "getBlockerActorIds returns the subset that has blocked the blockee",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  async fn() {
+    await withRollback(async (tx) => {
+      await seedLocalInstance(tx);
+      const fedCtx = createFedCtx(tx);
+      const suffix = crypto.randomUUID().replaceAll("-", "").slice(0, 8);
+      const target = await insertAccountWithActor(tx, {
+        username: `gbraitarget${suffix}`,
+        name: "GBRAI Target",
+        email: `gbraitarget-${suffix}@example.com`,
+      });
+      const blocker = await insertAccountWithActor(tx, {
+        username: `gbraiblocker${suffix}`,
+        name: "GBRAI Blocker",
+        email: `gbraiblocker-${suffix}@example.com`,
+      });
+      const stranger = await insertAccountWithActor(tx, {
+        username: `gbraistranger${suffix}`,
+        name: "GBRAI Stranger",
+        email: `gbraistranger-${suffix}@example.com`,
+      });
+
+      await block(fedCtx, blocker.account, target.actor);
+
+      const result = await getBlockerActorIds(tx, target.actor.id, [
+        blocker.actor.id,
+        stranger.actor.id,
+        generateUuidV7() as Uuid,
+      ]);
+
+      assertEquals(result.has(blocker.actor.id), true);
+      assertEquals(result.has(stranger.actor.id), false);
+      assertEquals(result.size, 1);
+    });
+  },
+});
+
+Deno.test({
+  name: "getBlockerActorIds returns empty for empty input",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  async fn() {
+    await withRollback(async (tx) => {
+      const result = await getBlockerActorIds(
         tx,
         generateUuidV7() as Uuid,
         [],

--- a/models/blocking.ts
+++ b/models/blocking.ts
@@ -1,9 +1,10 @@
 import type { Context, DocumentLoader } from "@fedify/fedify";
 import { isActor } from "@fedify/vocab";
 import * as vocab from "@fedify/vocab";
-import { and, eq } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 import { getPersistedActor, persistActor, toRecipient } from "./actor.ts";
 import type { ContextData } from "./context.ts";
+import type { Database } from "./db.ts";
 import { removeFollower, unfollow } from "./following.ts";
 import {
   type Account,
@@ -11,7 +12,7 @@ import {
   type Blocking,
   blockingTable,
 } from "./schema.ts";
-import { generateUuidV7 } from "./uuid.ts";
+import { generateUuidV7, type Uuid } from "./uuid.ts";
 
 export async function persistBlocking(
   fedCtx: Context<ContextData>,
@@ -153,4 +154,22 @@ export async function unblock(
     );
   }
   return rows[0];
+}
+
+export async function getBlockedActorIds(
+  db: Database,
+  blockerId: Uuid,
+  blockeeIds: readonly Uuid[],
+): Promise<Set<Uuid>> {
+  if (blockeeIds.length < 1) return new Set();
+  const rows = await db
+    .select({ blockeeId: blockingTable.blockeeId })
+    .from(blockingTable)
+    .where(
+      and(
+        eq(blockingTable.blockerId, blockerId),
+        inArray(blockingTable.blockeeId, blockeeIds as Uuid[]),
+      ),
+    );
+  return new Set(rows.map((row) => row.blockeeId));
 }

--- a/models/blocking.ts
+++ b/models/blocking.ts
@@ -173,3 +173,21 @@ export async function getBlockedActorIds(
     );
   return new Set(rows.map((row) => row.blockeeId));
 }
+
+export async function getBlockerActorIds(
+  db: Database,
+  blockeeId: Uuid,
+  blockerIds: readonly Uuid[],
+): Promise<Set<Uuid>> {
+  if (blockerIds.length < 1) return new Set();
+  const rows = await db
+    .select({ blockerId: blockingTable.blockerId })
+    .from(blockingTable)
+    .where(
+      and(
+        eq(blockingTable.blockeeId, blockeeId),
+        inArray(blockingTable.blockerId, blockerIds as Uuid[]),
+      ),
+    );
+  return new Set(rows.map((row) => row.blockerId));
+}

--- a/models/following.test.ts
+++ b/models/following.test.ts
@@ -1,9 +1,14 @@
 import { assert } from "@std/assert/assert";
 import { assertEquals } from "@std/assert/equals";
 import { eq } from "drizzle-orm";
-import { acceptFollowing, follow, unfollow } from "./following.ts";
+import {
+  acceptFollowing,
+  follow,
+  getFollowedActorIds,
+  unfollow,
+} from "./following.ts";
 import { actorTable, followingTable, notificationTable } from "./schema.ts";
-import { generateUuidV7 } from "./uuid.ts";
+import { generateUuidV7, type Uuid } from "./uuid.ts";
 import {
   createFedCtx,
   insertAccountWithActor,
@@ -189,6 +194,62 @@ Deno.test({
         followee.actor.id,
       ));
       assertEquals(followings, []);
+    });
+  },
+});
+
+Deno.test({
+  name: "getFollowedActorIds returns the subset that the follower follows",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  async fn() {
+    await withRollback(async (tx) => {
+      await seedLocalInstance(tx);
+      const fedCtx = createFedCtx(tx);
+      const suffix = crypto.randomUUID().replaceAll("-", "").slice(0, 8);
+      const viewer = await insertAccountWithActor(tx, {
+        username: `gfaiviewer${suffix}`,
+        name: "GFAI Viewer",
+        email: `gfaiviewer-${suffix}@example.com`,
+      });
+      const followed = await insertAccountWithActor(tx, {
+        username: `gfaifollowed${suffix}`,
+        name: "GFAI Followed",
+        email: `gfaifollowed-${suffix}@example.com`,
+      });
+      const notFollowed = await insertAccountWithActor(tx, {
+        username: `gfainotfollowed${suffix}`,
+        name: "GFAI Not Followed",
+        email: `gfainotfollowed-${suffix}@example.com`,
+      });
+
+      await follow(fedCtx, viewer.account, followed.actor);
+
+      const result = await getFollowedActorIds(tx, viewer.actor.id, [
+        followed.actor.id,
+        notFollowed.actor.id,
+        generateUuidV7() as Uuid,
+      ]);
+
+      assertEquals(result.has(followed.actor.id), true);
+      assertEquals(result.has(notFollowed.actor.id), false);
+      assertEquals(result.size, 1);
+    });
+  },
+});
+
+Deno.test({
+  name: "getFollowedActorIds returns empty for empty input",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  async fn() {
+    await withRollback(async (tx) => {
+      const result = await getFollowedActorIds(
+        tx,
+        generateUuidV7() as Uuid,
+        [],
+      );
+      assertEquals(result.size, 0);
     });
   },
 });

--- a/models/following.test.ts
+++ b/models/following.test.ts
@@ -5,6 +5,7 @@ import {
   acceptFollowing,
   follow,
   getFollowedActorIds,
+  getFollowerActorIds,
   unfollow,
 } from "./following.ts";
 import { actorTable, followingTable, notificationTable } from "./schema.ts";
@@ -245,6 +246,62 @@ Deno.test({
   async fn() {
     await withRollback(async (tx) => {
       const result = await getFollowedActorIds(
+        tx,
+        generateUuidV7() as Uuid,
+        [],
+      );
+      assertEquals(result.size, 0);
+    });
+  },
+});
+
+Deno.test({
+  name: "getFollowerActorIds returns the subset that follows the followee",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  async fn() {
+    await withRollback(async (tx) => {
+      await seedLocalInstance(tx);
+      const fedCtx = createFedCtx(tx);
+      const suffix = crypto.randomUUID().replaceAll("-", "").slice(0, 8);
+      const target = await insertAccountWithActor(tx, {
+        username: `gfraitarget${suffix}`,
+        name: "GFRAI Target",
+        email: `gfraitarget-${suffix}@example.com`,
+      });
+      const fan = await insertAccountWithActor(tx, {
+        username: `gfraifan${suffix}`,
+        name: "GFRAI Fan",
+        email: `gfraifan-${suffix}@example.com`,
+      });
+      const stranger = await insertAccountWithActor(tx, {
+        username: `gfraistranger${suffix}`,
+        name: "GFRAI Stranger",
+        email: `gfraistranger-${suffix}@example.com`,
+      });
+
+      await follow(fedCtx, fan.account, target.actor);
+
+      const result = await getFollowerActorIds(tx, target.actor.id, [
+        fan.actor.id,
+        stranger.actor.id,
+        generateUuidV7() as Uuid,
+      ]);
+
+      assertEquals(result.has(fan.actor.id), true);
+      assertEquals(result.has(stranger.actor.id), false);
+      assertEquals(result.size, 1);
+    });
+  },
+});
+
+Deno.test({
+  name: "getFollowerActorIds returns empty for empty input",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  async fn() {
+    await withRollback(async (tx) => {
+      const result = await getFollowerActorIds(
         tx,
         generateUuidV7() as Uuid,
         [],

--- a/models/following.ts
+++ b/models/following.ts
@@ -1,6 +1,6 @@
 import type { Context } from "@fedify/fedify";
 import { Follow, Reject, Undo } from "@fedify/vocab";
-import { and, eq, isNull, sql } from "drizzle-orm";
+import { and, eq, inArray, isNull, sql } from "drizzle-orm";
 import { toRecipient } from "./actor.ts";
 import type { ContextData } from "./context.ts";
 import type { Database } from "./db.ts";
@@ -190,6 +190,24 @@ export async function removeFollower(
     );
   }
   return rows[0];
+}
+
+export async function getFollowedActorIds(
+  db: Database,
+  followerId: Uuid,
+  followeeIds: readonly Uuid[],
+): Promise<Set<Uuid>> {
+  if (followeeIds.length < 1) return new Set();
+  const rows = await db
+    .select({ followeeId: followingTable.followeeId })
+    .from(followingTable)
+    .where(
+      and(
+        eq(followingTable.followerId, followerId),
+        inArray(followingTable.followeeId, followeeIds as Uuid[]),
+      ),
+    );
+  return new Set(rows.map((row) => row.followeeId));
 }
 
 export async function updateFolloweesCount(

--- a/models/following.ts
+++ b/models/following.ts
@@ -210,6 +210,24 @@ export async function getFollowedActorIds(
   return new Set(rows.map((row) => row.followeeId));
 }
 
+export async function getFollowerActorIds(
+  db: Database,
+  followeeId: Uuid,
+  followerIds: readonly Uuid[],
+): Promise<Set<Uuid>> {
+  if (followerIds.length < 1) return new Set();
+  const rows = await db
+    .select({ followerId: followingTable.followerId })
+    .from(followingTable)
+    .where(
+      and(
+        eq(followingTable.followeeId, followeeId),
+        inArray(followingTable.followerId, followerIds as Uuid[]),
+      ),
+    );
+  return new Set(rows.map((row) => row.followerId));
+}
+
 export async function updateFolloweesCount(
   db: Database,
   followerId: Uuid,


### PR DESCRIPTION
Six GraphQL resolvers used by *web-next/* issue one DB query per parent when they resolve list rows. For example, a follower list with 20 actors can issue 80 queries against *following*/*blocking* for `viewerFollows`, `followsViewer`, `viewerBlocks`, and `blocksViewer`. Five custom-emoji reactions add five `findFirst` calls for `customEmoji`. A notifications page with 20 rows does 20 *actor* lookups even when rows share avatars.

This PR converts those resolvers to the same `t.loadable` pattern used in #270, so each field batches its parent ids into one query per GraphQL request.

Resolver changes:

- `CustomEmojiReactionGroup.customEmoji` in *graphql/reactable.ts* moves to `t.loadable` keyed by `customEmojiId`. Missing rows return a per-key `Error`, so one missing emoji does not reject the whole batch.
- `Actor.viewerFollows` and `Actor.followsViewer` in *graphql/actor.ts* use new `getFollowedActorIds` and `getFollowerActorIds` helpers in *models/following.ts*, mirroring `arePostsBookmarkedBy` from *models/bookmark.ts*.
- `Actor.viewerBlocks` and `Actor.blocksViewer` use `getBlockedActorIds` and `getBlockerActorIds` in *models/blocking.ts*.
- `Notification.actors` in *graphql/notification.ts* uses a per-request `actorByIdLoader: DataLoader<Uuid, Actor | null>` slot on `UserContext` (added in *graphql/builder.ts* next to `inviteeCountLoader`). The connection resolver runs `Promise.all` over the actor-id list inside `resolveCursorConnection`, so N notifications use one `SELECT … WHERE id = ANY($1)`. Overlapping ids are deduplicated by DataLoader's per-request cache.

The four follow/block loaders keep `loaderOptions: { cache: false }` for the same reason as #270: `followActor`, `unfollowActor`, `blockActor`, and `unblockActor` can change state mid-request, and their mutation payloads read those booleans. `customEmoji` and `actorByIdLoader` keep `cache: true` since nothing on the read path mutates them.

GraphQL field names and types are unchanged.

A spy-loader test in *graphql/notification.test.ts* injects a custom `DataLoader` via `makeUserContext`'s `overrides` hook, captures every batch invocation, and asserts that two notifications with overlapping actor ids fire exactly one batch with a deduped key set of three. A serial-mutation regression test in *graphql/actor.test.ts* runs `block` and then `unblock` on the same actor in one mutation document and asserts the second `viewerBlocks` read sees the unblocked state. I also checked that this test fails if `cache: false` is removed.