### PR TITLE
Exclude `<details>` blocks from AI summaries

### DIFF
--- a/ai/summary.test.ts
+++ b/ai/summary.test.ts
@@ -146,6 +146,88 @@ test("removeDetailsFromSummaryInput() preserves inline code literals", () => {
   assert.equal(output.includes("Hidden answer."), false);
 });
 
+test("removeDetailsFromSummaryInput() handles many unclosed inline code markers", () => {
+  const input = `${"` ".repeat(2_000)}\nVisible after markers.`;
+
+  const output = removeDetailsFromSummaryInput(input);
+
+  assert.equal(output.includes("Visible after markers."), true);
+});
+
+test("removeDetailsFromSummaryInput() handles many unterminated less-than signs", () => {
+  const input = [
+    "Visible before.",
+    Array.from({ length: 2_000 }, (_, index) => `a${index} < b${index}`).join(
+      "\n",
+    ),
+    "<details>",
+    "<summary>Answer</summary>",
+    "Hidden answer.",
+    "</details>",
+    "Visible after.",
+  ].join("\n");
+
+  const output = removeDetailsFromSummaryInput(input);
+
+  assert.equal(output.includes("Visible before."), true);
+  assert.equal(output.includes("Visible after."), true);
+  assert.equal(output.includes("Hidden answer."), false);
+});
+
+test("removeDetailsFromSummaryInput() preserves indented code blocks", () => {
+  const input = [
+    "Visible before.",
+    "",
+    "    <details>",
+    "    <summary>Example</summary>",
+    "    Example body.",
+    "    </details>",
+    "",
+    "<details>",
+    "<summary>Answer</summary>",
+    "Hidden answer.",
+    "</details>",
+    "",
+    "Visible after.",
+  ].join("\n");
+
+  const output = removeDetailsFromSummaryInput(input);
+
+  assert.equal(output.includes("<summary>Example</summary>"), true);
+  assert.equal(output.includes("Example body."), true);
+  assert.equal(output.includes("Visible after."), true);
+  assert.equal(output.includes("Answer"), false);
+  assert.equal(output.includes("Hidden answer."), false);
+});
+
+test("removeDetailsFromSummaryInput() preserves fenced code blocks in block quotes", () => {
+  const input = [
+    "Visible before.",
+    "",
+    "> ```html",
+    "> <details>",
+    "> <summary>Example</summary>",
+    "> Example body.",
+    "> </details>",
+    "> ```",
+    "",
+    "<details>",
+    "<summary>Answer</summary>",
+    "Hidden answer.",
+    "</details>",
+    "",
+    "Visible after.",
+  ].join("\n");
+
+  const output = removeDetailsFromSummaryInput(input);
+
+  assert.equal(output.includes("<summary>Example</summary>"), true);
+  assert.equal(output.includes("Example body."), true);
+  assert.equal(output.includes("Visible after."), true);
+  assert.equal(output.includes("Answer"), false);
+  assert.equal(output.includes("Hidden answer."), false);
+});
+
 test("summarize() sends text without details blocks to the model", async () => {
   let promptText: string | undefined;
   const model = new MockLanguageModelV3({

--- a/ai/summary.test.ts
+++ b/ai/summary.test.ts
@@ -200,6 +200,75 @@ test("removeDetailsFromSummaryInput() preserves indented code blocks", () => {
   assert.equal(output.includes("Hidden answer."), false);
 });
 
+test("removeDetailsFromSummaryInput() preserves indented code blocks in block quotes", () => {
+  const input = [
+    "Visible before.",
+    "",
+    ">     <details>",
+    ">     <summary>Example</summary>",
+    ">     Example body.",
+    ">     </details>",
+    "",
+    "<details>",
+    "<summary>Answer</summary>",
+    "Hidden answer.",
+    "</details>",
+    "",
+    "Visible after.",
+  ].join("\n");
+
+  const output = removeDetailsFromSummaryInput(input);
+
+  assert.equal(output.includes("<summary>Example</summary>"), true);
+  assert.equal(output.includes("Example body."), true);
+  assert.equal(output.includes("Visible after."), true);
+  assert.equal(output.includes("Answer"), false);
+  assert.equal(output.includes("Hidden answer."), false);
+});
+
+test("removeDetailsFromSummaryInput() removes details blocks nested in lists", () => {
+  const input = [
+    "Visible before.",
+    "",
+    "- Visible list item.",
+    "    <details>",
+    "    <summary>Answer</summary>",
+    "    Hidden answer.",
+    "    </details>",
+    "",
+    "Visible after.",
+  ].join("\n");
+
+  const output = removeDetailsFromSummaryInput(input);
+
+  assert.equal(output.includes("Visible before."), true);
+  assert.equal(output.includes("Visible list item."), true);
+  assert.equal(output.includes("Visible after."), true);
+  assert.equal(output.includes("Answer"), false);
+  assert.equal(output.includes("Hidden answer."), false);
+});
+
+test("removeDetailsFromSummaryInput() removes multiline details tags", () => {
+  const input = [
+    "Visible before.",
+    "<details",
+    '  class="spoiler"',
+    "  open",
+    ">",
+    "<summary>Answer</summary>",
+    "Hidden answer.",
+    "</details>",
+    "Visible after.",
+  ].join("\n");
+
+  const output = removeDetailsFromSummaryInput(input);
+
+  assert.equal(output.includes("Visible before."), true);
+  assert.equal(output.includes("Visible after."), true);
+  assert.equal(output.includes("Answer"), false);
+  assert.equal(output.includes("Hidden answer."), false);
+});
+
 test("removeDetailsFromSummaryInput() preserves fenced code blocks in block quotes", () => {
   const input = [
     "Visible before.",

--- a/ai/summary.test.ts
+++ b/ai/summary.test.ts
@@ -1,0 +1,119 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { MockLanguageModelV3 } from "ai/test";
+import { removeDetailsFromSummaryInput, summarize } from "./summary.ts";
+
+test("removeDetailsFromSummaryInput() removes details blocks", () => {
+  const input = [
+    "# Quiz",
+    "",
+    "Visible question.",
+    "",
+    "<details>",
+    "<summary>Answer</summary>",
+    "",
+    "Hidden answer.",
+    "",
+    "</details>",
+    "",
+    "Visible outro.",
+  ].join("\n");
+
+  const output = removeDetailsFromSummaryInput(input);
+
+  assert.equal(output.includes("Visible question."), true);
+  assert.equal(output.includes("Visible outro."), true);
+  assert.equal(output.includes("Answer"), false);
+  assert.equal(output.includes("Hidden answer."), false);
+});
+
+test(
+  "removeDetailsFromSummaryInput() handles attributes, case, and nesting",
+  () => {
+    const input = [
+      "Visible before.",
+      '<DETAILS open data-kind="spoiler">',
+      "<summary>Outer</summary>",
+      "Outer secret.",
+      "<details>",
+      "<summary>Inner</summary>",
+      "Inner secret.",
+      "</details>",
+      "More outer secret.",
+      "</DETAILS>",
+      "Visible after.",
+    ].join("\n");
+
+    const output = removeDetailsFromSummaryInput(input);
+
+    assert.equal(output.includes("Visible before."), true);
+    assert.equal(output.includes("Visible after."), true);
+    assert.equal(output.includes("Outer"), false);
+    assert.equal(output.includes("Inner"), false);
+    assert.equal(output.includes("secret"), false);
+  },
+);
+
+test("removeDetailsFromSummaryInput() removes unclosed details to EOF", () => {
+  const input = [
+    "Visible.",
+    "<details>",
+    "<summary>Answer</summary>",
+    "Hidden answer.",
+    "Still hidden.",
+  ].join("\n");
+
+  const output = removeDetailsFromSummaryInput(input);
+
+  assert.equal(output.includes("Visible."), true);
+  assert.equal(output.includes("Answer"), false);
+  assert.equal(output.includes("Hidden answer."), false);
+  assert.equal(output.includes("Still hidden."), false);
+});
+
+test("summarize() sends text without details blocks to the model", async () => {
+  let promptText: string | undefined;
+  const model = new MockLanguageModelV3({
+    doGenerate: async (options) => {
+      const userMessage = options.prompt.find((m) => m.role === "user");
+      const textPart = userMessage?.content[0];
+      promptText = textPart?.type === "text" ? textPart.text : undefined;
+      return {
+        content: [{ type: "text", text: "A safe summary." }],
+        finishReason: { unified: "stop", raw: undefined },
+        usage: {
+          inputTokens: {
+            total: 10,
+            noCache: 10,
+            cacheRead: undefined,
+            cacheWrite: undefined,
+          },
+          outputTokens: {
+            total: 5,
+            text: 5,
+            reasoning: undefined,
+          },
+        },
+        warnings: [],
+      };
+    },
+  });
+
+  const summary = await summarize({
+    model,
+    sourceLanguage: "en",
+    targetLanguage: "en",
+    text: [
+      "Visible question.",
+      "<details>",
+      "<summary>Answer</summary>",
+      "Hidden answer.",
+      "</details>",
+    ].join("\n"),
+  });
+
+  assert.equal(summary, "A safe summary.");
+  assert.equal(promptText?.includes("Visible question."), true);
+  assert.equal(promptText?.includes("Answer"), false);
+  assert.equal(promptText?.includes("Hidden answer."), false);
+});

--- a/ai/summary.test.ts
+++ b/ai/summary.test.ts
@@ -99,6 +99,53 @@ test("removeDetailsFromSummaryInput() preserves fenced code blocks", () => {
   assert.equal(output.includes("Hidden answer."), false);
 });
 
+test("removeDetailsFromSummaryInput() ignores details tags inside hidden fenced code", () => {
+  const input = [
+    "Visible before.",
+    "",
+    "<details>",
+    "<summary>Answer</summary>",
+    "Hidden before.",
+    "```html",
+    "</details>",
+    "```",
+    "Hidden after.",
+    "</details>",
+    "",
+    "Visible after.",
+  ].join("\n");
+
+  const output = removeDetailsFromSummaryInput(input);
+
+  assert.equal(output.includes("Visible before."), true);
+  assert.equal(output.includes("Visible after."), true);
+  assert.equal(output.includes("Hidden before."), false);
+  assert.equal(output.includes("Hidden after."), false);
+});
+
+test("removeDetailsFromSummaryInput() preserves inline code literals", () => {
+  const input = [
+    "Use `<details>` for spoilers.",
+    "",
+    "This line should remain visible.",
+    "",
+    "<details>",
+    "<summary>Answer</summary>",
+    "Hidden answer.",
+    "</details>",
+    "",
+    "Visible after.",
+  ].join("\n");
+
+  const output = removeDetailsFromSummaryInput(input);
+
+  assert.equal(output.includes("Use `<details>` for spoilers."), true);
+  assert.equal(output.includes("This line should remain visible."), true);
+  assert.equal(output.includes("Visible after."), true);
+  assert.equal(output.includes("Answer"), false);
+  assert.equal(output.includes("Hidden answer."), false);
+});
+
 test("summarize() sends text without details blocks to the model", async () => {
   let promptText: string | undefined;
   const model = new MockLanguageModelV3({

--- a/ai/summary.test.ts
+++ b/ai/summary.test.ts
@@ -71,6 +71,34 @@ test("removeDetailsFromSummaryInput() removes unclosed details to EOF", () => {
   assert.equal(output.includes("Still hidden."), false);
 });
 
+test("removeDetailsFromSummaryInput() preserves fenced code blocks", () => {
+  const input = [
+    "Visible before.",
+    "",
+    "```html",
+    "<details>",
+    "<summary>Example</summary>",
+    "Example body.",
+    "</details>",
+    "```",
+    "",
+    "<details>",
+    "<summary>Answer</summary>",
+    "Hidden answer.",
+    "</details>",
+    "",
+    "Visible after.",
+  ].join("\n");
+
+  const output = removeDetailsFromSummaryInput(input);
+
+  assert.equal(output.includes("<summary>Example</summary>"), true);
+  assert.equal(output.includes("Example body."), true);
+  assert.equal(output.includes("Visible after."), true);
+  assert.equal(output.includes("Answer"), false);
+  assert.equal(output.includes("Hidden answer."), false);
+});
+
 test("summarize() sends text without details blocks to the model", async () => {
   let promptText: string | undefined;
   const model = new MockLanguageModelV3({

--- a/ai/summary.ts
+++ b/ai/summary.ts
@@ -43,6 +43,60 @@ export interface SummaryOptions {
   text: string;
 }
 
+interface HtmlTag {
+  closing: boolean;
+  end: number;
+  name: string;
+  start: number;
+}
+
+function readHtmlTagAt(text: string, start: number): HtmlTag | undefined {
+  if (text[start] !== "<") return undefined;
+  let index = start + 1;
+  let closing = false;
+  if (text[index] === "/") {
+    closing = true;
+    index++;
+  }
+  while (/\s/.test(text[index] ?? "")) index++;
+  const nameStart = index;
+  while (/[A-Za-z0-9:-]/.test(text[index] ?? "")) index++;
+  if (index === nameStart) return undefined;
+  const name = text.slice(nameStart, index).toLowerCase();
+  let quote: '"' | "'" | undefined;
+  for (; index < text.length; index++) {
+    const char = text[index];
+    if (quote == null && (char === '"' || char === "'")) {
+      quote = char;
+    } else if (char === quote) {
+      quote = undefined;
+    } else if (quote == null && char === ">") {
+      return { closing, end: index + 1, name, start };
+    }
+  }
+  return { closing, end: text.length, name, start };
+}
+
+export function removeDetailsFromSummaryInput(text: string): string {
+  let result = "";
+  let keepStart = 0;
+  let depth = 0;
+  for (let index = 0; index < text.length; index++) {
+    if (text[index] !== "<") continue;
+    const tag = readHtmlTagAt(text, index);
+    if (tag?.name !== "details") continue;
+    if (tag.closing) {
+      if (depth > 0 && --depth === 0) keepStart = tag.end;
+    } else {
+      if (depth === 0) result += text.slice(keepStart, tag.start);
+      depth++;
+    }
+    index = tag.end - 1;
+  }
+  if (depth === 0) result += text.slice(keepStart);
+  return result;
+}
+
 export async function summarize(options: SummaryOptions): Promise<string> {
   const system = await getSummaryPrompt(
     options.sourceLanguage,
@@ -51,7 +105,7 @@ export async function summarize(options: SummaryOptions): Promise<string> {
   const { text } = await generateText({
     model: options.model,
     system,
-    prompt: options.text,
+    prompt: removeDetailsFromSummaryInput(options.text),
   });
   return text;
 }

--- a/ai/summary.ts
+++ b/ai/summary.ts
@@ -50,9 +50,31 @@ interface HtmlTag {
   start: number;
 }
 
+interface HtmlTagScan {
+  end: number;
+  tag?: HtmlTag;
+}
+
 interface TextRange {
   end: number;
   start: number;
+}
+
+function stripMarkdownContainerPrefix(line: string): string {
+  let rest = line.replace(/^ {0,3}/, "");
+  while (true) {
+    const quoted = rest.match(/^> ?(.*)$/);
+    if (quoted != null) {
+      rest = quoted[1].replace(/^ {0,3}/, "");
+      continue;
+    }
+    const listed = rest.match(/^(?:[-+*]|\d{1,9}[.)]) {1,4}(.*)$/);
+    if (listed != null) {
+      rest = listed[1].replace(/^ {0,3}/, "");
+      continue;
+    }
+    return rest;
+  }
 }
 
 function findFencedCodeRanges(text: string): TextRange[] {
@@ -65,8 +87,9 @@ function findFencedCodeRanges(text: string): TextRange[] {
     const newline = text.indexOf("\n", offset);
     const lineEnd = newline < 0 ? text.length : newline + 1;
     const line = text.slice(offset, lineEnd).replace(/\r?\n$/, "");
+    const contentLine = stripMarkdownContainerPrefix(line);
     if (opened == null) {
-      const opening = line.match(/^(?: {0,3})(`{3,}|~{3,})/);
+      const opening = contentLine.match(/^(`{3,}|~{3,})/);
       if (opening != null) {
         const fence = opening[1];
         opened = {
@@ -76,7 +99,7 @@ function findFencedCodeRanges(text: string): TextRange[] {
         };
       }
     } else {
-      const closing = line.match(/^(?: {0,3})(`{3,}|~{3,})[ \t]*$/);
+      const closing = contentLine.match(/^(`{3,}|~{3,})[ \t]*$/);
       if (
         closing != null &&
         closing[1][0] === opened.char &&
@@ -103,82 +126,103 @@ function advanceRangeIndex(
   return rangeIndex;
 }
 
-function findInlineCodeRanges(
+function findIndentedCodeRanges(
   text: string,
   fencedCodeRanges: readonly TextRange[],
 ): TextRange[] {
   const ranges: TextRange[] = [];
   let fencedCodeRangeIndex = 0;
-  for (let index = 0; index < text.length; index++) {
+  let openedStart: number | undefined;
+  let offset = 0;
+  while (offset < text.length) {
     fencedCodeRangeIndex = advanceRangeIndex(
       fencedCodeRanges,
       fencedCodeRangeIndex,
-      index,
+      offset,
     );
     const fencedCodeRange = fencedCodeRanges[fencedCodeRangeIndex];
-    if (fencedCodeRange != null && index >= fencedCodeRange.start) {
-      index = fencedCodeRange.end - 1;
+    if (fencedCodeRange != null && offset >= fencedCodeRange.start) {
+      if (openedStart != null) {
+        ranges.push({ start: openedStart, end: offset });
+        openedStart = undefined;
+      }
+      offset = fencedCodeRange.end;
+      continue;
+    }
+
+    const newline = text.indexOf("\n", offset);
+    const lineEnd = newline < 0 ? text.length : newline + 1;
+    const line = text.slice(offset, lineEnd).replace(/\r?\n$/, "");
+    if (/^(?: {4}|\t)/.test(line)) {
+      openedStart ??= offset;
+    } else if (openedStart != null) {
+      ranges.push({ start: openedStart, end: offset });
+      openedStart = undefined;
+    }
+    offset = lineEnd;
+  }
+  if (openedStart != null) {
+    ranges.push({ start: openedStart, end: text.length });
+  }
+  return ranges;
+}
+
+function findInlineCodeRanges(
+  text: string,
+  blockCodeRanges: readonly TextRange[],
+): TextRange[] {
+  const ranges: TextRange[] = [];
+  let blockCodeRangeIndex = 0;
+  let opened: { length: number; start: number } | undefined;
+  for (let index = 0; index < text.length; index++) {
+    blockCodeRangeIndex = advanceRangeIndex(
+      blockCodeRanges,
+      blockCodeRangeIndex,
+      index,
+    );
+    const blockCodeRange = blockCodeRanges[blockCodeRangeIndex];
+    if (blockCodeRange != null && index >= blockCodeRange.start) {
+      index = blockCodeRange.end - 1;
       continue;
     }
     if (text[index] !== "`") continue;
     const start = index;
     let length = 1;
     while (text[start + length] === "`") length++;
-
-    let searchIndex = start + length;
-    let searchFencedCodeRangeIndex = fencedCodeRangeIndex;
-    while (searchIndex < text.length) {
-      searchFencedCodeRangeIndex = advanceRangeIndex(
-        fencedCodeRanges,
-        searchFencedCodeRangeIndex,
-        searchIndex,
-      );
-      const searchFencedCodeRange =
-        fencedCodeRanges[searchFencedCodeRangeIndex];
-      if (
-        searchFencedCodeRange != null &&
-        searchIndex >= searchFencedCodeRange.start
-      ) {
-        searchIndex = searchFencedCodeRange.end;
-        continue;
-      }
-
-      const closeStart = text.indexOf("`", searchIndex);
-      if (closeStart < 0) break;
-      searchIndex = closeStart;
-      let closeLength = 1;
-      while (text[closeStart + closeLength] === "`") closeLength++;
-      if (closeLength === length) {
-        ranges.push({ start, end: closeStart + closeLength });
-        index = closeStart + closeLength - 1;
-        break;
-      }
-      searchIndex = closeStart + closeLength;
+    if (opened == null) {
+      opened = { length, start };
+    } else if (length === opened.length) {
+      ranges.push({ start: opened.start, end: start + length });
+      opened = undefined;
     }
+    index = start + length - 1;
   }
   return ranges;
 }
 
 function findMarkdownCodeRanges(text: string): TextRange[] {
   const fencedCodeRanges = findFencedCodeRanges(text);
-  return [
+  const blockCodeRanges = [
     ...fencedCodeRanges,
-    ...findInlineCodeRanges(text, fencedCodeRanges),
+    ...findIndentedCodeRanges(text, fencedCodeRanges),
+  ].sort((a, b) => a.start - b.start);
+  return [
+    ...blockCodeRanges,
+    ...findInlineCodeRanges(text, blockCodeRanges),
   ].sort((a, b) => a.start - b.start);
 }
 
-function readHtmlTagAt(text: string, start: number): HtmlTag | undefined {
-  if (text[start] !== "<") return undefined;
+function readHtmlTagAt(text: string, start: number): HtmlTagScan {
+  if (text[start] !== "<") return { end: start + 1 };
   let index = start + 1;
   let closing = false;
   if (text[index] === "/") {
     closing = true;
     index++;
   }
-  while (/\s/.test(text[index] ?? "")) index++;
   const nameStart = index;
   while (/[A-Za-z0-9:-]/.test(text[index] ?? "")) index++;
-  if (index === nameStart) return undefined;
+  if (index === nameStart) return { end: start + 1 };
   const name = text.slice(nameStart, index).toLowerCase();
   let quote: '"' | "'" | undefined;
   for (; index < text.length; index++) {
@@ -188,10 +232,15 @@ function readHtmlTagAt(text: string, start: number): HtmlTag | undefined {
     } else if (char === quote) {
       quote = undefined;
     } else if (quote == null && char === ">") {
-      return { closing, end: index + 1, name, start };
+      return {
+        end: index + 1,
+        tag: { closing, end: index + 1, name, start },
+      };
+    } else if (quote == null && (char === "\n" || char === "\r")) {
+      return { end: index + 1 };
     }
   }
-  return { closing, end: text.length, name, start };
+  return { end: text.length };
 }
 
 export function removeDetailsFromSummaryInput(text: string): string {
@@ -212,8 +261,12 @@ export function removeDetailsFromSummaryInput(text: string): string {
       continue;
     }
     if (text[index] !== "<") continue;
-    const tag = readHtmlTagAt(text, index);
-    if (tag?.name !== "details") continue;
+    const scan = readHtmlTagAt(text, index);
+    const tag = scan.tag;
+    if (tag?.name !== "details") {
+      index = scan.end - 1;
+      continue;
+    }
     if (tag.closing) {
       if (depth > 0 && --depth === 0) keepStart = tag.end;
     } else {

--- a/ai/summary.ts
+++ b/ai/summary.ts
@@ -92,6 +92,81 @@ function findFencedCodeRanges(text: string): TextRange[] {
   return ranges;
 }
 
+function advanceRangeIndex(
+  ranges: readonly TextRange[],
+  rangeIndex: number,
+  offset: number,
+): number {
+  while (rangeIndex < ranges.length && offset >= ranges[rangeIndex].end) {
+    rangeIndex++;
+  }
+  return rangeIndex;
+}
+
+function findInlineCodeRanges(
+  text: string,
+  fencedCodeRanges: readonly TextRange[],
+): TextRange[] {
+  const ranges: TextRange[] = [];
+  let fencedCodeRangeIndex = 0;
+  for (let index = 0; index < text.length; index++) {
+    fencedCodeRangeIndex = advanceRangeIndex(
+      fencedCodeRanges,
+      fencedCodeRangeIndex,
+      index,
+    );
+    const fencedCodeRange = fencedCodeRanges[fencedCodeRangeIndex];
+    if (fencedCodeRange != null && index >= fencedCodeRange.start) {
+      index = fencedCodeRange.end - 1;
+      continue;
+    }
+    if (text[index] !== "`") continue;
+    const start = index;
+    let length = 1;
+    while (text[start + length] === "`") length++;
+
+    let searchIndex = start + length;
+    let searchFencedCodeRangeIndex = fencedCodeRangeIndex;
+    while (searchIndex < text.length) {
+      searchFencedCodeRangeIndex = advanceRangeIndex(
+        fencedCodeRanges,
+        searchFencedCodeRangeIndex,
+        searchIndex,
+      );
+      const searchFencedCodeRange =
+        fencedCodeRanges[searchFencedCodeRangeIndex];
+      if (
+        searchFencedCodeRange != null &&
+        searchIndex >= searchFencedCodeRange.start
+      ) {
+        searchIndex = searchFencedCodeRange.end;
+        continue;
+      }
+
+      const closeStart = text.indexOf("`", searchIndex);
+      if (closeStart < 0) break;
+      searchIndex = closeStart;
+      let closeLength = 1;
+      while (text[closeStart + closeLength] === "`") closeLength++;
+      if (closeLength === length) {
+        ranges.push({ start, end: closeStart + closeLength });
+        index = closeStart + closeLength - 1;
+        break;
+      }
+      searchIndex = closeStart + closeLength;
+    }
+  }
+  return ranges;
+}
+
+function findMarkdownCodeRanges(text: string): TextRange[] {
+  const fencedCodeRanges = findFencedCodeRanges(text);
+  return [
+    ...fencedCodeRanges,
+    ...findInlineCodeRanges(text, fencedCodeRanges),
+  ].sort((a, b) => a.start - b.start);
+}
+
 function readHtmlTagAt(text: string, start: number): HtmlTag | undefined {
   if (text[start] !== "<") return undefined;
   let index = start + 1;
@@ -120,25 +195,20 @@ function readHtmlTagAt(text: string, start: number): HtmlTag | undefined {
 }
 
 export function removeDetailsFromSummaryInput(text: string): string {
-  const fencedCodeRanges = findFencedCodeRanges(text);
-  let fencedCodeRangeIndex = 0;
+  const markdownCodeRanges = findMarkdownCodeRanges(text);
+  let markdownCodeRangeIndex = 0;
   let result = "";
   let keepStart = 0;
   let depth = 0;
   for (let index = 0; index < text.length; index++) {
-    while (
-      fencedCodeRangeIndex < fencedCodeRanges.length &&
-      index >= fencedCodeRanges[fencedCodeRangeIndex].end
-    ) {
-      fencedCodeRangeIndex++;
-    }
-    const fencedCodeRange = fencedCodeRanges[fencedCodeRangeIndex];
-    if (
-      depth === 0 &&
-      fencedCodeRange != null &&
-      index >= fencedCodeRange.start
-    ) {
-      index = fencedCodeRange.end - 1;
+    markdownCodeRangeIndex = advanceRangeIndex(
+      markdownCodeRanges,
+      markdownCodeRangeIndex,
+      index,
+    );
+    const markdownCodeRange = markdownCodeRanges[markdownCodeRangeIndex];
+    if (markdownCodeRange != null && index >= markdownCodeRange.start) {
+      index = markdownCodeRange.end - 1;
       continue;
     }
     if (text[index] !== "<") continue;

--- a/ai/summary.ts
+++ b/ai/summary.ts
@@ -50,6 +50,48 @@ interface HtmlTag {
   start: number;
 }
 
+interface TextRange {
+  end: number;
+  start: number;
+}
+
+function findFencedCodeRanges(text: string): TextRange[] {
+  const ranges: TextRange[] = [];
+  let opened:
+    | { char: "`" | "~"; length: number; start: number }
+    | undefined;
+  let offset = 0;
+  while (offset < text.length) {
+    const newline = text.indexOf("\n", offset);
+    const lineEnd = newline < 0 ? text.length : newline + 1;
+    const line = text.slice(offset, lineEnd).replace(/\r?\n$/, "");
+    if (opened == null) {
+      const opening = line.match(/^(?: {0,3})(`{3,}|~{3,})/);
+      if (opening != null) {
+        const fence = opening[1];
+        opened = {
+          char: fence[0] as "`" | "~",
+          length: fence.length,
+          start: offset,
+        };
+      }
+    } else {
+      const closing = line.match(/^(?: {0,3})(`{3,}|~{3,})[ \t]*$/);
+      if (
+        closing != null &&
+        closing[1][0] === opened.char &&
+        closing[1].length >= opened.length
+      ) {
+        ranges.push({ start: opened.start, end: lineEnd });
+        opened = undefined;
+      }
+    }
+    offset = lineEnd;
+  }
+  if (opened != null) ranges.push({ start: opened.start, end: text.length });
+  return ranges;
+}
+
 function readHtmlTagAt(text: string, start: number): HtmlTag | undefined {
   if (text[start] !== "<") return undefined;
   let index = start + 1;
@@ -78,10 +120,27 @@ function readHtmlTagAt(text: string, start: number): HtmlTag | undefined {
 }
 
 export function removeDetailsFromSummaryInput(text: string): string {
+  const fencedCodeRanges = findFencedCodeRanges(text);
+  let fencedCodeRangeIndex = 0;
   let result = "";
   let keepStart = 0;
   let depth = 0;
   for (let index = 0; index < text.length; index++) {
+    while (
+      fencedCodeRangeIndex < fencedCodeRanges.length &&
+      index >= fencedCodeRanges[fencedCodeRangeIndex].end
+    ) {
+      fencedCodeRangeIndex++;
+    }
+    const fencedCodeRange = fencedCodeRanges[fencedCodeRangeIndex];
+    if (
+      depth === 0 &&
+      fencedCodeRange != null &&
+      index >= fencedCodeRange.start
+    ) {
+      index = fencedCodeRange.end - 1;
+      continue;
+    }
     if (text[index] !== "<") continue;
     const tag = readHtmlTagAt(text, index);
     if (tag?.name !== "details") continue;

--- a/ai/summary.ts
+++ b/ai/summary.ts
@@ -60,17 +60,27 @@ interface TextRange {
   start: number;
 }
 
-function stripMarkdownContainerPrefix(line: string): string {
-  let rest = line.replace(/^ {0,3}/, "");
+function stripMarkdownBlockQuoteMarkers(line: string): string {
+  let rest = line;
   while (true) {
-    const quoted = rest.match(/^> ?(.*)$/);
+    const quoted = rest.match(/^ {0,3}> ?(.*)$/);
     if (quoted != null) {
-      rest = quoted[1].replace(/^ {0,3}/, "");
+      rest = quoted[1];
       continue;
     }
+    return rest;
+  }
+}
+
+function stripMarkdownContainerPrefix(line: string): string {
+  let rest = stripMarkdownBlockQuoteMarkers(line).replace(/^ {0,3}/, "");
+  while (true) {
     const listed = rest.match(/^(?:[-+*]|\d{1,9}[.)]) {1,4}(.*)$/);
     if (listed != null) {
-      rest = listed[1].replace(/^ {0,3}/, "");
+      rest = stripMarkdownBlockQuoteMarkers(listed[1]).replace(
+        /^ {0,3}/,
+        "",
+      );
       continue;
     }
     return rest;
@@ -133,6 +143,7 @@ function findIndentedCodeRanges(
   const ranges: TextRange[] = [];
   let fencedCodeRangeIndex = 0;
   let openedStart: number | undefined;
+  let canStartIndentedCode = true;
   let offset = 0;
   while (offset < text.length) {
     fencedCodeRangeIndex = advanceRangeIndex(
@@ -153,12 +164,19 @@ function findIndentedCodeRanges(
     const newline = text.indexOf("\n", offset);
     const lineEnd = newline < 0 ? text.length : newline + 1;
     const line = text.slice(offset, lineEnd).replace(/\r?\n$/, "");
-    if (/^(?: {4}|\t)/.test(line)) {
+    const contentLine = stripMarkdownBlockQuoteMarkers(line);
+    const blankLine = contentLine.trim().length === 0;
+    const indentedCodeLine = /^(?: {4}|\t)/.test(contentLine);
+    if (
+      indentedCodeLine &&
+      (openedStart != null || canStartIndentedCode)
+    ) {
       openedStart ??= offset;
     } else if (openedStart != null) {
       ranges.push({ start: openedStart, end: offset });
       openedStart = undefined;
     }
+    canStartIndentedCode = blankLine || openedStart != null;
     offset = lineEnd;
   }
   if (openedStart != null) {
@@ -236,8 +254,8 @@ function readHtmlTagAt(text: string, start: number): HtmlTagScan {
         end: index + 1,
         tag: { closing, end: index + 1, name, start },
       };
-    } else if (quote == null && (char === "\n" || char === "\r")) {
-      return { end: index + 1 };
+    } else if (quote == null && char === "<") {
+      return { end: index };
     }
   }
   return { end: text.length };

--- a/models/article.summary.test.ts
+++ b/models/article.summary.test.ts
@@ -879,3 +879,64 @@ test(
     });
   },
 );
+
+test(
+  "applyArticleContentSummary() compares summaries against visible content " +
+    "outside details blocks",
+  async () => {
+    await withRollback(async (tx) => {
+      const author = await insertAccountWithActor(tx, {
+        username: "summarydetails",
+        name: "Summary Details",
+        email: "summarydetails@example.com",
+      });
+      const sourceId = generateUuidV7();
+      const published = new Date("2026-04-15T00:00:00.000Z");
+      const content = [
+        "Visible.",
+        "",
+        "<details>",
+        "<summary>Answer</summary>",
+        "This hidden answer is intentionally much longer than the visible " +
+        "question text and must not make an otherwise too-long summary look " +
+        "acceptable.",
+        "</details>",
+      ].join("\n");
+      const summary = "Visible plus extra.";
+
+      await tx.insert(articleSourceTable).values({
+        id: sourceId,
+        accountId: author.account.id,
+        publishedYear: 2026,
+        slug: "summary-details",
+        tags: [],
+        allowLlmTranslation: false,
+        published,
+        updated: published,
+      });
+      await tx.insert(articleContentTable).values({
+        sourceId,
+        language: "en",
+        title: "Details",
+        content,
+        summaryStarted: published,
+        published,
+        updated: published,
+      });
+
+      const row = await tx.query.articleContentTable.findFirst({
+        where: { sourceId, language: "en" },
+      });
+      assert.ok(row != null);
+
+      await applyArticleContentSummary(tx, row, summary);
+
+      const after = await tx.query.articleContentTable.findFirst({
+        where: { sourceId, language: "en" },
+      });
+      assert.equal(after?.summary, null);
+      assert.equal(after?.summaryUnnecessary, true);
+      assert.equal(after?.summaryStarted, null);
+    });
+  },
+);

--- a/models/article.ts
+++ b/models/article.ts
@@ -1,6 +1,9 @@
 import type { Context } from "@fedify/fedify";
 import * as vocab from "@fedify/vocab";
-import { summarize } from "@hackerspub/ai/summary";
+import {
+  removeDetailsFromSummaryInput,
+  summarize,
+} from "@hackerspub/ai/summary";
 import { translate } from "@hackerspub/ai/translate";
 import { getArticle } from "@hackerspub/federation/objects";
 import { sendTagsPubRelayActivity } from "@hackerspub/federation/tags-pub";
@@ -631,9 +634,12 @@ export async function applyArticleContentSummary(
       claim,
     );
     const trimmedSummary = summary.trim();
+    const summaryComparisonContent = removeDetailsFromSummaryInput(
+      current.content,
+    ).trim();
     if (
       trimmedSummary.length === 0 ||
-      graphemeCount(trimmedSummary) >= graphemeCount(current.content.trim())
+      graphemeCount(trimmedSummary) >= graphemeCount(summaryComparisonContent)
     ) {
       logger.debug(
         "Summary is not shorter than the original content (or is empty); " +


### PR DESCRIPTION
## What changed

This fixes https://github.com/hackers-pub/hackerspub/issues/101 by removing `<details>...</details>` blocks from article text before it is sent to the LLM summarizer.

The filtering lives in *ai/summary.ts*. It removes the full details block, including `<summary>`, supports attributes, case differences, nested details blocks, and unclosed details blocks. It also skips fenced code blocks so examples that mention `<details>` are not stripped by mistake.

*models/article.ts* now uses the same filtered text when deciding whether a generated summary is shorter than the article body, so hidden spoiler text cannot make an otherwise too-long summary look acceptable.

## Tests

Added coverage in *ai/summary.test.ts* for normal details blocks, nested details blocks, unclosed details blocks, fenced code blocks, and the actual prompt text passed to the model.

Added a regression test in *models/article.summary.test.ts* for the summary length check against visible content outside details blocks.

Verified with targeted Deno tests for *ai/summary.test.ts* and *models/article.summary.test.ts*.

Verified with `deno task check`.