### PR TITLE
web-next: Restore `?lang=` override on the locale resolver

### DIFF
--- a/web-next/src/lib/i18n/index.tsx
+++ b/web-next/src/lib/i18n/index.tsx
@@ -2,18 +2,20 @@ import { loadMessages } from "#i18n";
 import { negotiateLocale } from "@hackerspub/models/i18n";
 import { I18nProvider as KobalteI18nProvider } from "@kobalte/core/i18n";
 import { type I18n as LinguiI18n, setupI18n } from "@lingui/core";
-import { createAsync, query } from "@solidjs/router";
-import { getQuery, getRequestHeader } from "@solidjs/start/http";
+import { createAsync, query, useLocation } from "@solidjs/router";
+import { getRequestHeader } from "@solidjs/start/http";
 import { parseAcceptLanguage } from "intl-parse-accept-language";
 import { graphql, readInlineData } from "relay-runtime";
 import { createContext, type ParentProps, Show, useContext } from "solid-js";
 import linguiConfig from "../../../lingui.config.ts";
 import type { i18nProviderLoadI18n_query$key } from "./__generated__/i18nProviderLoadI18n_query.graphql.ts";
 
-const loadI18n = query(async ($query: i18nProviderLoadI18n_query$key) => {
+const loadI18n = query(async (
+  $query: i18nProviderLoadI18n_query$key,
+  langOverride: string | undefined,
+) => {
   "use server";
 
-  const query = getQuery();
   const accountLocales = readInlineData(
     graphql`
       fragment i18nProviderLoadI18n_query on Query @inline {
@@ -27,8 +29,15 @@ const loadI18n = query(async ($query: i18nProviderLoadI18n_query$key) => {
 
   let loc: Intl.Locale | undefined;
   const locales: string[] = [];
-  if (typeof query.lang === "string") {
-    loc = negotiateLocale(query.lang, linguiConfig.locales);
+  if (langOverride) {
+    try {
+      loc = negotiateLocale(
+        new Intl.Locale(langOverride),
+        linguiConfig.locales,
+      );
+    } catch {
+      // Ignore unparseable locale codes from ?lang=… and fall through.
+    }
   }
   if (loc == null && accountLocales != null && accountLocales.length > 0) {
     loc = negotiateLocale(accountLocales, linguiConfig.locales);
@@ -56,7 +65,13 @@ export interface I18nProviderProps {
 }
 
 export function I18nProvider(props: ParentProps<I18nProviderProps>) {
-  const locale = createAsync(() => loadI18n(props.$query));
+  const location = useLocation();
+  const langOverride = () => {
+    const value = location.query.lang;
+    if (Array.isArray(value)) return value[0] || undefined;
+    return value || undefined;
+  };
+  const locale = createAsync(() => loadI18n(props.$query, langOverride()));
   const i18n = () => {
     const loaded = locale();
     if (!loaded) return;


### PR DESCRIPTION
## Summary

`?lang=ko` used to switch the web-next UI locale regardless of the signed-in user's preferences. It later regressed: the resolver silently fell back to account locales, or to `Accept-Language` for guests.

The resolver in *web-next/src/lib/i18n/index.tsx* is wrapped in `query()` from `@solidjs/router` and marked `"use server"`. It read the override from `getQuery().lang` of `@solidjs/start/http`. That works on the initial SSR render, where the server function runs inside the page request handler. After hydration, the same `query()` runs as a server RPC against `/_server?id=…`, and `getQuery()` then sees the RPC endpoint's own query string. The page URL's `?lang=` never arrives.

The fix reads `?lang=` reactively on the client through `useLocation().query.lang` and passes it as an explicit `langOverride` argument to the server function. The value is sent in the RPC payload and becomes part of the `query()` cache key, so SSR and client navigation resolve the same locale.

The override is parsed with `new Intl.Locale(...)` before it reaches `negotiateLocale`, which lets script tags resolve correctly: `ko`, `zh-TW`, `zh-Hant` (→ `zh-TW`), and `zh-Hans` (→ `zh-CN`) all work. That call is wrapped in `try`/`catch` because `new Intl.Locale("invalid!")` throws `RangeError`, and a bad query string should not 500 the page.

## Test plan

- [ ] `/local?lang=ko` signed out: UI is Korean.
- [ ] `/local?lang=ja` and `/local?lang=ja-JP`: UI is Japanese.
- [ ] `/local?lang=zh-TW` and `/local?lang=zh-Hant`: UI is 繁體中文.
- [ ] `/local?lang=zh-Hans`: UI is 简体中文.
- [ ] `/local?lang=invalid!`: UI falls back to `Accept-Language` without throwing.
- [ ] Signed in as an account whose locale is `en`, visit `/feed?lang=ko`: UI is Korean (override beats account locale).
