### PR TITLE
web-next: Plausible tracker

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -137,6 +137,7 @@
     "npm:@peculiar/asn1-x509@^2.6.1": "2.6.1",
     "npm:@peculiar/x509@^1.13.0": "1.14.3",
     "npm:@peculiar/x509@^1.14.3": "1.14.3",
+    "npm:@plausible-analytics/tracker@~0.4.4": "0.4.4",
     "npm:@pothos/core@^4.12.0": "4.12.0_graphql@16.11.0-canary.pr.4364.2b4ffe237616247a733274dfdcb404c3d55d9f02",
     "npm:@pothos/plugin-complexity@^4.1.2": "4.1.2_@pothos+core@4.12.0__graphql@16.11.0-canary.pr.4364.2b4ffe237616247a733274dfdcb404c3d55d9f02_graphql@16.11.0-canary.pr.4364.2b4ffe237616247a733274dfdcb404c3d55d9f02",
     "npm:@pothos/plugin-dataloader@^4.4.3": "4.4.3_@pothos+core@4.12.0__graphql@16.11.0-canary.pr.4364.2b4ffe237616247a733274dfdcb404c3d55d9f02_dataloader@2.2.3_graphql@16.11.0-canary.pr.4364.2b4ffe237616247a733274dfdcb404c3d55d9f02",
@@ -4476,6 +4477,9 @@
     },
     "@pkgjs/parseargs@0.11.0": {
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="
+    },
+    "@plausible-analytics/tracker@0.4.4": {
+      "integrity": "sha512-fz0NOYUEYXtg1TBaPEEvtcBq3FfmLFuTe1VZw4M8sTWX129br5dguu3M15+plOQnc181ShYe67RfwhKgK89VnA=="
     },
     "@poppinss/colors@4.1.6": {
       "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
@@ -13509,6 +13513,7 @@
             "npm:@lingui/cli@^5.3.3",
             "npm:@lingui/core@^5.3.3",
             "npm:@lingui/vite-plugin@^5.3.3",
+            "npm:@plausible-analytics/tracker@~0.4.4",
             "npm:@sentry/solidstart@^10.51.0",
             "npm:@sentry/vite-plugin@^5.2.1",
             "npm:@solidjs/meta@~0.29.4",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,7 @@ services:
       NO_WATCHMAN: "1"
       API_URL: http://app:8000/graphql
       HOST: "0.0.0.0"
+      PLAUSIBLE: ${PLAUSIBLE}
     ports:
       - "3000:3000"
     depends_on:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,8 +25,8 @@ catalogs:
       specifier: ^1.0.1
       version: 1.0.1
     '@logtape/logtape':
-      specifier: jsr:2.0.0
-      version: 2.0.0
+      specifier: jsr:2.0.6
+      version: 2.0.6
     '@mdit-vue/plugin-title':
       specifier: ^2.1.4
       version: 2.1.4
@@ -195,7 +195,7 @@ importers:
         version: link:../models
       '@logtape/logtape':
         specifier: 'catalog:'
-        version: '@jsr/logtape__logtape@2.0.0'
+        version: '@jsr/logtape__logtape@2.0.6'
       '@std/assert':
         specifier: 'catalog:'
         version: '@jsr/std__assert@1.0.19'
@@ -234,7 +234,7 @@ importers:
         version: 1.0.1
       '@logtape/logtape':
         specifier: 'catalog:'
-        version: '@jsr/logtape__logtape@2.0.0'
+        version: '@jsr/logtape__logtape@2.0.6'
       '@mdit-vue/plugin-title':
         specifier: 'catalog:'
         version: 2.1.4
@@ -388,6 +388,9 @@ importers:
       '@lingui/core':
         specifier: ^5.3.3
         version: 5.9.4(@lingui/babel-plugin-lingui-macro@5.9.4(typescript@6.0.3))
+      '@plausible-analytics/tracker':
+        specifier: ^0.4.4
+        version: 0.4.4
       '@sentry/solidstart':
         specifier: ^10.51.0
         version: 10.51.0(@solidjs/router@0.15.4(solid-js@1.9.12))(@solidjs/start@2.0.0-alpha.2(@testing-library/jest-dom@6.9.1)(vite@7.3.2(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)))(rollup@4.60.1)(solid-js@1.9.12)
@@ -1356,11 +1359,11 @@ packages:
   '@jsr/logtape__logtape@1.3.7':
     resolution: {integrity: sha512-5bK97jZGkIn0UBuqy8Jroei1imZtOmFAeJAjB22NBBr2KsuaoLHgXBe9o6WkwlYUb4LRayH050UgDVw/uCP5zQ==, tarball: https://npm.jsr.io/~/11/@jsr/logtape__logtape/1.3.7.tgz}
 
-  '@jsr/logtape__logtape@2.0.0':
-    resolution: {integrity: sha512-PYUzoBNu0TVJnQa4oE8sY1YmNie9TWNKxaDzTktv7+y63gL3C9midwnb0PAr8HZ5kLaqsIHPBmWgrB8kYJm4aw==, tarball: https://npm.jsr.io/~/11/@jsr/logtape__logtape/2.0.0.tgz}
-
   '@jsr/logtape__logtape@2.0.5':
     resolution: {integrity: sha512-0aP3+87bWAsqoaa8l4siqF8AonEzv8frV6oawXsFhFtXK16ttiSMj0yMMjy3BDNW2EMHQPRoifzGGWQFHKx+kA==, tarball: https://npm.jsr.io/~/11/@jsr/logtape__logtape/2.0.5.tgz}
+
+  '@jsr/logtape__logtape@2.0.6':
+    resolution: {integrity: sha512-Lw0+sFlpD9U+WzE/77diiDzEoYkhTuhrE53Fl5sXcNqWnlOJNi2x3K2elF+EhqdrZub2mHGSYznPRttlf/ah7Q==, tarball: https://npm.jsr.io/~/11/@jsr/logtape__logtape/2.0.6.tgz}
 
   '@jsr/simplewebauthn__browser@13.3.0':
     resolution: {integrity: sha512-gpkJOfaq69RjBbs3UkOCa3ENQ+8TM3vt+52SUGaq/ZkSpmabc9R6XNoo4penXis1cWGpKBwo+KYmctPmmSVOSg==, tarball: https://npm.jsr.io/~/11/@jsr/simplewebauthn__browser/13.3.0.tgz}
@@ -2044,6 +2047,9 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@plausible-analytics/tracker@0.4.4':
+    resolution: {integrity: sha512-fz0NOYUEYXtg1TBaPEEvtcBq3FfmLFuTe1VZw4M8sTWX129br5dguu3M15+plOQnc181ShYe67RfwhKgK89VnA==}
 
   '@poppinss/colors@4.1.6':
     resolution: {integrity: sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==}
@@ -7221,9 +7227,9 @@ snapshots:
 
   '@jsr/logtape__logtape@1.3.7': {}
 
-  '@jsr/logtape__logtape@2.0.0': {}
-
   '@jsr/logtape__logtape@2.0.5': {}
+
+  '@jsr/logtape__logtape@2.0.6': {}
 
   '@jsr/simplewebauthn__browser@13.3.0': {}
 
@@ -8077,6 +8083,8 @@ snapshots:
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
+
+  '@plausible-analytics/tracker@0.4.4': {}
 
   '@poppinss/colors@4.1.6':
     dependencies:

--- a/web-next/package.json
+++ b/web-next/package.json
@@ -28,6 +28,7 @@
     "@hackerspub/models": "workspace:*",
     "@kobalte/core": "^0.13.10",
     "@lingui/core": "^5.3.3",
+    "@plausible-analytics/tracker": "^0.4.4",
     "@sentry/solidstart": "^10.51.0",
     "@simplewebauthn/browser": "catalog:",
     "@solidjs/meta": "^0.29.4",

--- a/web-next/src/entry-client.tsx
+++ b/web-next/src/entry-client.tsx
@@ -1,4 +1,5 @@
 // @refresh reload
+import { init as initPlausible } from "@plausible-analytics/tracker";
 import * as Sentry from "@sentry/solidstart";
 import { solidRouterBrowserTracingIntegration } from "@sentry/solidstart/solidrouter";
 import { mount, StartClient } from "@solidjs/start/client";
@@ -29,6 +30,17 @@ if (sentryDsn) {
     // Send default PII (e.g. IP address) so we can correlate errors with
     // users where useful.
     sendDefaultPii: true,
+  });
+}
+
+// PLAUSIBLE is injected at runtime by the SSR document (entry-server.tsx).
+// Keep initialization client-only because the tracker relies on browser APIs.
+const plausibleEnabled =
+  (window as { __PLAUSIBLE__?: boolean }).__PLAUSIBLE__ ?? false;
+if (plausibleEnabled) {
+  initPlausible({
+    domain: window.location.hostname,
+    outboundLinks: true,
   });
 }
 

--- a/web-next/src/entry-server.tsx
+++ b/web-next/src/entry-server.tsx
@@ -25,6 +25,17 @@ const SENTRY_DSN_SCRIPT = `window.__SENTRY_DSN__=${
   JSON.stringify(nodeProcess.env.SENTRY_DSN ?? "")
 };`;
 
+function isEnabledRuntimeFlag(name: string): boolean {
+  const value = nodeProcess.env[name]?.trim().toLowerCase();
+  return value != null && value !== "" && value !== "false" && value !== "0";
+}
+
+// Keep Plausible opt-in runtime-only for the same reason as Sentry: the
+// public Docker image should not decide analytics behavior at build time.
+const PLAUSIBLE_SCRIPT = `window.__PLAUSIBLE__=${
+  JSON.stringify(isEnabledRuntimeFlag("PLAUSIBLE"))
+};`;
+
 // Sentry's automatic instrumentation (set up in instrument.server.mjs and
 // activated by `node --import` before this module loads) hooks the Node
 // HTTP server, uncaught exceptions, and unhandled rejections via
@@ -55,6 +66,7 @@ export default createHandler(() => (
           <link rel="manifest" href="/manifest.json" />
           <meta name="theme-color" content="#000000" />
           <script innerHTML={SENTRY_DSN_SCRIPT} />
+          <script innerHTML={PLAUSIBLE_SCRIPT} />
           {assets}
         </head>
         <body>


### PR DESCRIPTION
## What changed

- Added `@plausible-analytics/tracker` to *web-next/package.json* and updated *pnpm-lock.yaml* and *deno.lock*.
- Injected the runtime `PLAUSIBLE` flag from *web-next/src/entry-server.tsx*, so analytics behavior is decided when the server runs instead of when the app is built.
- Initialized Plausible from *web-next/src/entry-client.tsx* only when that runtime flag is enabled, using the current hostname as the Plausible domain and enabling outbound link tracking to match the legacy *web* setup.
- Passed `PLAUSIBLE` through to the `web-next` service in *docker-compose.yml* for local Compose usage.

## Verification

- `pnpm --filter @hackerspub/web-next build`
- `deno task check`