### PR TITLE
fix: scroll infection from sidebar to main

### DIFF
--- a/web-next/src/components/ui/sidebar.tsx
+++ b/web-next/src/components/ui/sidebar.tsx
@@ -439,7 +439,7 @@ const SidebarContent: Component<ComponentProps<"div">> = (props) => {
     <div
       data-sidebar="content"
       class={cn(
-        "flex min-h-0 flex-1 flex-col gap-2 overflow-auto group-data-[collapsible=icon]:overflow-hidden",
+        "flex min-h-0 flex-1 flex-col gap-2 overflow-auto overscroll-contain group-data-[collapsible=icon]:overflow-hidden",
         local.class,
       )}
       {...others}


### PR DESCRIPTION
fix #290

## Original problem
When sidebar is scrollable and not scrolled and the main content is scrollable, the scroll in sidebar affects to main content.

## Why this fixes it
https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/overscroll-behavior
You can try overscroll-behavior: contain; behaviour in here.
In auto, scroll in child box affects to parent content. but, the overscroll-behavior: contain does not.