### PR TITLE
Support Universal Link for iOS App

### DIFF
--- a/graphql/static/.well-known/apple-app-site-association
+++ b/graphql/static/.well-known/apple-app-site-association
@@ -1,4 +1,15 @@
 {
+  "applinks": {
+    "apps": [],
+    "details": [
+      {
+        "appID": "883MRT4TF9.pub.hackers.HackersPub",
+        "paths": [
+          "/*"
+        ]
+      }
+    ]
+  },
   "webcredentials": {
     "apps": [
       "883MRT4TF9.pub.hackers.HackersPub"


### PR DESCRIPTION
This PR adjusts the `apple-app-site-association` content, ensuring the iOS app supports [Universal Links](https://developer.apple.com/documentation/xcode/supporting-universal-links-in-your-app). Details of the iOS app implementation can be found at https://github.com/hackers-pub/ios/tree/universal-link .