### PR TITLE
Prevent disposed Relay preloaded query reuse in web-next routes

### DIFF
--- a/web-next/deno.jsonc
+++ b/web-next/deno.jsonc
@@ -5,7 +5,10 @@
     "#i18n": "./src/lib/i18n/server.ts"
   },
   "lint": {
-    "plugins": ["./lint-plugins/keyed-show.ts"],
+    "plugins": [
+      "./lint-plugins/keyed-show.ts",
+      "./lint-plugins/no-load-query-in-router-query.ts"
+    ],
     "rules": {
       "exclude": [
         // SolidStart server functions must be async functions at all time

--- a/web-next/lint-plugins/no-load-query-in-router-query.test.ts
+++ b/web-next/lint-plugins/no-load-query-in-router-query.test.ts
@@ -66,6 +66,36 @@ Deno.test("flags object spread of loadQuery result", () => {
   assertEquals(diagnostics[0].id, RULE);
 });
 
+Deno.test("flags named router query fetchers", () => {
+  const diagnostics = lint(`
+    import { query } from "@solidjs/router";
+    import { loadQuery } from "solid-relay";
+
+    function fetcher() {
+      return loadQuery(env, PageQuery, {});
+    }
+
+    const loadPageQuery = query(fetcher, "loadPageQuery");
+  `);
+  assertEquals(diagnostics.length, 1);
+  assertEquals(diagnostics[0].id, RULE);
+});
+
+Deno.test("flags named router query fetchers declared later", () => {
+  const diagnostics = lint(`
+    import { query } from "@solidjs/router";
+    import { loadQuery } from "solid-relay";
+
+    const loadPageQuery = query(fetcher, "loadPageQuery");
+
+    function fetcher() {
+      return loadQuery(env, PageQuery, {});
+    }
+  `);
+  assertEquals(diagnostics.length, 1);
+  assertEquals(diagnostics[0].id, RULE);
+});
+
 Deno.test("does not flag plain router query fetchers", () => {
   const diagnostics = lint(`
     import { query } from "@solidjs/router";
@@ -118,6 +148,23 @@ Deno.test("respects shadowed query binding", () => {
   assertEquals(diagnostics.length, 0);
 });
 
+Deno.test("respects later shadowed query binding", () => {
+  const diagnostics = lint(`
+    import { query } from "@solidjs/router";
+    import { loadQuery } from "solid-relay";
+
+    function setup() {
+      const loadPageQuery = query(
+        () => loadQuery(env, PageQuery, {}),
+        "loadPageQuery",
+      );
+      const query = () => ({ kind: "not router query" });
+      return loadPageQuery;
+    }
+  `);
+  assertEquals(diagnostics.length, 0);
+});
+
 Deno.test("respects shadowed loadQuery binding inside fetcher", () => {
   const diagnostics = lint(`
     import { query } from "@solidjs/router";
@@ -127,6 +174,23 @@ Deno.test("respects shadowed loadQuery binding inside fetcher", () => {
       () => {
         const loadQuery = () => ({ kind: "not relay" });
         return loadQuery();
+      },
+      "loadPageQuery",
+    );
+  `);
+  assertEquals(diagnostics.length, 0);
+});
+
+Deno.test("respects later shadowed loadQuery binding inside fetcher", () => {
+  const diagnostics = lint(`
+    import { query } from "@solidjs/router";
+    import { loadQuery } from "solid-relay";
+
+    const loadPageQuery = query(
+      () => {
+        const result = loadQuery(env, PageQuery, {});
+        const loadQuery = () => ({ kind: "not relay" });
+        return result;
       },
       "loadPageQuery",
     );

--- a/web-next/lint-plugins/no-load-query-in-router-query.test.ts
+++ b/web-next/lint-plugins/no-load-query-in-router-query.test.ts
@@ -1,0 +1,135 @@
+import { assertEquals } from "@std/assert";
+import plugin from "./no-load-query-in-router-query.ts";
+
+const RULE = "hackerspub-solid-relay/no-load-query-in-router-query";
+
+function lint(source: string) {
+  return Deno.lint.runPlugin(plugin, "test.tsx", source);
+}
+
+Deno.test("flags loadQuery returned from router query fetcher", () => {
+  const diagnostics = lint(`
+    import { query } from "@solidjs/router";
+    import { loadQuery } from "solid-relay";
+
+    const loadPageQuery = query(
+      () => loadQuery(env, PageQuery, {}),
+      "loadPageQuery",
+    );
+  `);
+  assertEquals(diagnostics.length, 1);
+  assertEquals(diagnostics[0].id, RULE);
+});
+
+Deno.test("flags aliased imports", () => {
+  const diagnostics = lint(`
+    import { query as routerQuery } from "@solidjs/router";
+    import { loadQuery as relayLoadQuery } from "solid-relay";
+
+    const loadPageQuery = routerQuery(
+      () => relayLoadQuery(env, PageQuery, {}),
+      "loadPageQuery",
+    );
+  `);
+  assertEquals(diagnostics.length, 1);
+  assertEquals(diagnostics[0].id, RULE);
+});
+
+Deno.test("flags namespace imports", () => {
+  const diagnostics = lint(`
+    import * as router from "@solidjs/router";
+    import * as relay from "solid-relay";
+
+    const loadPageQuery = router.query(
+      () => relay.loadQuery(env, PageQuery, {}),
+      "loadPageQuery",
+    );
+  `);
+  assertEquals(diagnostics.length, 1);
+  assertEquals(diagnostics[0].id, RULE);
+});
+
+Deno.test("flags object spread of loadQuery result", () => {
+  const diagnostics = lint(`
+    import { query } from "@solidjs/router";
+    import { loadQuery } from "solid-relay";
+
+    const loadPageQuery = query(
+      () => ({
+        ...loadQuery(env, PageQuery, {}),
+        fetchKey: "custom",
+      }),
+      "loadPageQuery",
+    );
+  `);
+  assertEquals(diagnostics.length, 1);
+  assertEquals(diagnostics[0].id, RULE);
+});
+
+Deno.test("does not flag plain router query fetchers", () => {
+  const diagnostics = lint(`
+    import { query } from "@solidjs/router";
+
+    const loadPageData = query(
+      async () => ({ ok: true }),
+      "loadPageData",
+    );
+  `);
+  assertEquals(diagnostics.length, 0);
+});
+
+Deno.test("does not flag createPreloadedQuery direct loadQuery source", () => {
+  const diagnostics = lint(`
+    import { loadQuery, createPreloadedQuery } from "solid-relay";
+
+    const data = createPreloadedQuery(
+      PageQuery,
+      () => loadQuery(env, PageQuery, {}),
+    );
+  `);
+  assertEquals(diagnostics.length, 0);
+});
+
+Deno.test("does not flag fetchQuery in router query fetcher", () => {
+  const diagnostics = lint(`
+    import { query } from "@solidjs/router";
+    import { fetchQuery } from "relay-runtime";
+
+    const loadPageData = query(
+      () => fetchQuery(env, PageQuery, {}).toPromise(),
+      "loadPageData",
+    );
+  `);
+  assertEquals(diagnostics.length, 0);
+});
+
+Deno.test("respects shadowed query binding", () => {
+  const diagnostics = lint(`
+    import { query } from "@solidjs/router";
+    import { loadQuery } from "solid-relay";
+
+    function setup(query: (fn: unknown, key: string) => unknown) {
+      return query(
+        () => loadQuery(env, PageQuery, {}),
+        "loadPageQuery",
+      );
+    }
+  `);
+  assertEquals(diagnostics.length, 0);
+});
+
+Deno.test("respects shadowed loadQuery binding inside fetcher", () => {
+  const diagnostics = lint(`
+    import { query } from "@solidjs/router";
+    import { loadQuery } from "solid-relay";
+
+    const loadPageQuery = query(
+      () => {
+        const loadQuery = () => ({ kind: "not relay" });
+        return loadQuery();
+      },
+      "loadPageQuery",
+    );
+  `);
+  assertEquals(diagnostics.length, 0);
+});

--- a/web-next/lint-plugins/no-load-query-in-router-query.test.ts
+++ b/web-next/lint-plugins/no-load-query-in-router-query.test.ts
@@ -96,6 +96,41 @@ Deno.test("flags named router query fetchers declared later", () => {
   assertEquals(diagnostics[0].id, RULE);
 });
 
+Deno.test("flags indirect loadQuery calls inside router query fetchers", () => {
+  const diagnostics = lint(`
+    import { query } from "@solidjs/router";
+    import { loadQuery } from "solid-relay";
+
+    const build = () => loadQuery(env, PageQuery, {});
+
+    const loadPageQuery = query(
+      () => build(),
+      "loadPageQuery",
+    );
+  `);
+  assertEquals(diagnostics.length, 1);
+  assertEquals(diagnostics[0].id, RULE);
+});
+
+Deno.test("flags indirect loadQuery calls through nested fetcher helpers", () => {
+  const diagnostics = lint(`
+    import { query } from "@solidjs/router";
+    import { loadQuery } from "solid-relay";
+
+    const loadPageQuery = query(
+      () => {
+        function build() {
+          return loadQuery(env, PageQuery, {});
+        }
+        return build();
+      },
+      "loadPageQuery",
+    );
+  `);
+  assertEquals(diagnostics.length, 1);
+  assertEquals(diagnostics[0].id, RULE);
+});
+
 Deno.test("does not flag plain router query fetchers", () => {
   const diagnostics = lint(`
     import { query } from "@solidjs/router";
@@ -191,6 +226,24 @@ Deno.test("respects later shadowed loadQuery binding inside fetcher", () => {
         const result = loadQuery(env, PageQuery, {});
         const loadQuery = () => ({ kind: "not relay" });
         return result;
+      },
+      "loadPageQuery",
+    );
+  `);
+  assertEquals(diagnostics.length, 0);
+});
+
+Deno.test("respects shadowed indirect loadQuery helpers inside fetcher", () => {
+  const diagnostics = lint(`
+    import { query } from "@solidjs/router";
+    import { loadQuery } from "solid-relay";
+
+    const build = () => loadQuery(env, PageQuery, {});
+
+    const loadPageQuery = query(
+      () => {
+        const build = () => ({ kind: "not relay" });
+        return build();
       },
       "loadPageQuery",
     );

--- a/web-next/lint-plugins/no-load-query-in-router-query.ts
+++ b/web-next/lint-plugins/no-load-query-in-router-query.ts
@@ -18,27 +18,53 @@ const plugin: Deno.lint.Plugin = {
         type ImportBinding =
           | { kind: "named"; imported: string }
           | { kind: "namespace" };
+        interface Scope {
+          bindings: Set<string>;
+          functions: Map<string, any>;
+        }
 
         const routerImports = new Map<string, ImportBinding>();
         const relayImports = new Map<string, ImportBinding>();
-        const scopes: Set<string>[] = [];
+        const scopes: Scope[] = [];
 
-        const pushScope = () => scopes.push(new Set());
+        const currentScope = () => scopes[scopes.length - 1];
+        const pushScope = () =>
+          scopes.push({ bindings: new Set(), functions: new Map() });
         const popScope = () => scopes.pop();
         const recordBinding = (name: string) => {
-          scopes[scopes.length - 1]?.add(name);
+          currentScope()?.bindings.add(name);
+        };
+        const recordFunctionBinding = (name: string, fn: any) => {
+          const scope = currentScope();
+          scope?.bindings.add(name);
+          scope?.functions.set(name, fn);
         };
         const isShadowed = (name: string) => {
           for (let i = scopes.length - 1; i >= 0; i--) {
-            if (scopes[i].has(name)) return true;
+            if (scopes[i].bindings.has(name)) return true;
           }
           return false;
+        };
+        const resolveFunctionBinding = (name: string): any | undefined => {
+          for (let i = scopes.length - 1; i >= 0; i--) {
+            const fn = scopes[i].functions.get(name);
+            if (fn != null) return fn;
+            if (scopes[i].bindings.has(name)) return undefined;
+          }
+          return undefined;
         };
         const recordPatternBindings = (pattern: any) => {
           walkPatternIdentifiers(pattern, recordBinding);
         };
         const recordParamBindings = (params: any[] | undefined) => {
           for (const param of params ?? []) recordPatternBindings(param);
+        };
+        const predeclareScopeBindings = (body: any) => {
+          for (const statement of body?.body ?? []) {
+            predeclareStatementBinding(statement, recordBinding, (name, fn) => {
+              recordFunctionBinding(name, fn);
+            });
+          }
         };
 
         const isRouterQueryCall = (call: any): boolean => {
@@ -75,7 +101,10 @@ const plugin: Deno.lint.Plugin = {
           parent?.type === "FunctionDeclaration";
 
         return {
-          Program: pushScope,
+          Program(node: any) {
+            pushScope();
+            predeclareScopeBindings(node);
+          },
           "Program:exit": popScope,
 
           ImportDeclaration(node: any) {
@@ -103,9 +132,9 @@ const plugin: Deno.lint.Plugin = {
           },
 
           FunctionDeclaration(node: any) {
-            if (node.id?.type === "Identifier") recordBinding(node.id.name);
             pushScope();
             recordParamBindings(node.params);
+            predeclareScopeBindings(node.body);
           },
           "FunctionDeclaration:exit": popScope,
 
@@ -113,18 +142,23 @@ const plugin: Deno.lint.Plugin = {
             pushScope();
             if (node.id?.type === "Identifier") recordBinding(node.id.name);
             recordParamBindings(node.params);
+            predeclareScopeBindings(node.body);
           },
           "FunctionExpression:exit": popScope,
 
           ArrowFunctionExpression(node: any) {
             pushScope();
             recordParamBindings(node.params);
+            if (node.body?.type === "BlockStatement") {
+              predeclareScopeBindings(node.body);
+            }
           },
           "ArrowFunctionExpression:exit": popScope,
 
           BlockStatement(node: any) {
             if (isFunctionParent(node.parent)) return;
             pushScope();
+            predeclareScopeBindings(node);
             if (node.parent?.type === "CatchClause" && node.parent.param) {
               recordPatternBindings(node.parent.param);
             }
@@ -135,13 +169,26 @@ const plugin: Deno.lint.Plugin = {
 
           VariableDeclarator(node: any) {
             recordPatternBindings(node.id);
+            if (node.id?.type === "Identifier" && isFunction(node.init)) {
+              recordFunctionBinding(node.id.name, node.init);
+            }
           },
 
           CallExpression(node: any) {
             if (!isRouterQueryCall(node)) return;
             const fetcher = node.arguments?.[0];
-            if (!isFunction(fetcher)) return;
-            if (!functionContainsRelayLoadQuery(fetcher, relayImports)) return;
+            const resolvedFetcher = isFunction(fetcher)
+              ? fetcher
+              : fetcher?.type === "Identifier"
+              ? resolveFunctionBinding(fetcher.name) ??
+                resolveFunctionBindingFromAncestors(fetcher.name, node)
+              : undefined;
+            if (!isFunction(resolvedFetcher)) return;
+            if (
+              !functionContainsRelayLoadQuery(resolvedFetcher, relayImports)
+            ) {
+              return;
+            }
 
             context.report({
               node,
@@ -158,7 +205,8 @@ export default plugin;
 
 function isFunction(node: any): boolean {
   return node?.type === "ArrowFunctionExpression" ||
-    node?.type === "FunctionExpression";
+    node?.type === "FunctionExpression" ||
+    node?.type === "FunctionDeclaration";
 }
 
 function functionContainsRelayLoadQuery(
@@ -170,15 +218,20 @@ function functionContainsRelayLoadQuery(
     }
   >,
 ): boolean {
-  const scopes: Set<string>[] = [];
-  const pushScope = () => scopes.push(new Set());
+  interface Scope {
+    bindings: Set<string>;
+  }
+
+  const scopes: Scope[] = [];
+  const currentScope = () => scopes[scopes.length - 1];
+  const pushScope = () => scopes.push({ bindings: new Set() });
   const popScope = () => scopes.pop();
   const recordBinding = (name: string) => {
-    scopes[scopes.length - 1]?.add(name);
+    currentScope()?.bindings.add(name);
   };
   const isShadowed = (name: string) => {
     for (let i = scopes.length - 1; i >= 0; i--) {
-      if (scopes[i].has(name)) return true;
+      if (scopes[i].bindings.has(name)) return true;
     }
     return false;
   };
@@ -188,6 +241,11 @@ function functionContainsRelayLoadQuery(
   };
   const recordParamBindings = (params: any[] | undefined) => {
     for (const param of params ?? []) recordPatternBindings(param);
+  };
+  const predeclareScopeBindings = (body: any) => {
+    for (const statement of body?.body ?? []) {
+      predeclareStatementBinding(statement, recordBinding);
+    }
   };
 
   const isRelayLoadQueryCall = (node: any): boolean => {
@@ -218,9 +276,9 @@ function functionContainsRelayLoadQuery(
 
     switch (node.type) {
       case "FunctionDeclaration":
-        if (node.id?.type === "Identifier") recordBinding(node.id.name);
         pushScope();
         recordParamBindings(node.params);
+        predeclareScopeBindings(node.body);
         if (visit(node.body)) return true;
         popScope();
         return false;
@@ -230,12 +288,16 @@ function functionContainsRelayLoadQuery(
         pushScope();
         if (node.id?.type === "Identifier") recordBinding(node.id.name);
         recordParamBindings(node.params);
+        if (node.body?.type === "BlockStatement") {
+          predeclareScopeBindings(node.body);
+        }
         if (visit(node.body)) return true;
         popScope();
         return false;
 
       case "BlockStatement":
         pushScope();
+        predeclareScopeBindings(node);
         for (const stmt of node.body ?? []) {
           if (visit(stmt)) return true;
         }
@@ -245,6 +307,24 @@ function functionContainsRelayLoadQuery(
       case "VariableDeclarator":
         recordPatternBindings(node.id);
         return visit(node.init);
+
+      case "ReturnStatement":
+      case "ExpressionStatement":
+        return visit(node.argument ?? node.expression);
+
+      case "CallExpression":
+        if (visit(node.callee)) return true;
+        for (const arg of node.arguments ?? []) {
+          if (visit(arg)) return true;
+        }
+        return false;
+
+      case "AwaitExpression":
+      case "ChainExpression":
+      case "TSAsExpression":
+      case "TSSatisfiesExpression":
+      case "TSNonNullExpression":
+        return visit(node.argument ?? node.expression);
 
       case "ObjectExpression":
         for (const prop of node.properties ?? []) {
@@ -277,8 +357,102 @@ function functionContainsRelayLoadQuery(
 
   pushScope();
   recordParamBindings(fn.params);
+  if (fn.body?.type === "BlockStatement") {
+    predeclareScopeBindings(fn.body);
+  }
   const found = visit(fn.body);
   popScope();
+  return found;
+}
+
+function predeclareStatementBinding(
+  statement: any,
+  recordBinding: (name: string) => void,
+  recordFunctionBinding?: (name: string, fn: any) => void,
+): void {
+  switch (statement?.type) {
+    case "FunctionDeclaration":
+      if (statement.id?.type === "Identifier") {
+        recordFunctionBinding?.(statement.id.name, statement);
+        if (recordFunctionBinding == null) recordBinding(statement.id.name);
+      }
+      return;
+    case "VariableDeclaration":
+      for (const declaration of statement.declarations ?? []) {
+        walkPatternIdentifiers(declaration.id, recordBinding);
+        if (
+          declaration.id?.type === "Identifier" &&
+          isFunction(declaration.init)
+        ) {
+          recordFunctionBinding?.(declaration.id.name, declaration.init);
+        }
+      }
+      return;
+    case "ClassDeclaration":
+      if (statement.id?.type === "Identifier") recordBinding(statement.id.name);
+      return;
+  }
+}
+
+function resolveFunctionBindingFromAncestors(
+  name: string,
+  node: any,
+): any | undefined {
+  for (let current = node?.parent; current; current = current.parent) {
+    const body = scopeStatements(current);
+    if (body == null) continue;
+    const binding = findFunctionBindingInStatements(name, body);
+    if (binding.found) return binding.fn;
+  }
+  return undefined;
+}
+
+function scopeStatements(node: any): any[] | undefined {
+  if (node?.type === "Program") return node.body;
+  if (
+    node?.type === "FunctionDeclaration" ||
+    node?.type === "FunctionExpression" ||
+    node?.type === "ArrowFunctionExpression"
+  ) {
+    return node.body?.type === "BlockStatement" ? node.body.body : undefined;
+  }
+  if (node?.type === "BlockStatement" && !isFunction(node.parent)) {
+    return node.body;
+  }
+  return undefined;
+}
+
+function findFunctionBindingInStatements(
+  name: string,
+  statements: any[],
+): { found: boolean; fn?: any } {
+  for (const statement of statements ?? []) {
+    if (
+      statement?.type === "FunctionDeclaration" &&
+      statement.id?.name === name
+    ) {
+      return { found: true, fn: statement };
+    }
+    if (statement?.type !== "VariableDeclaration") continue;
+    for (const declaration of statement.declarations ?? []) {
+      if (!patternContainsIdentifier(declaration.id, name)) continue;
+      return {
+        found: true,
+        fn:
+          declaration.id?.type === "Identifier" && isFunction(declaration.init)
+            ? declaration.init
+            : undefined,
+      };
+    }
+  }
+  return { found: false };
+}
+
+function patternContainsIdentifier(pattern: any, name: string): boolean {
+  let found = false;
+  walkPatternIdentifiers(pattern, (identifier) => {
+    if (identifier === name) found = true;
+  });
   return found;
 }
 

--- a/web-next/lint-plugins/no-load-query-in-router-query.ts
+++ b/web-next/lint-plugins/no-load-query-in-router-query.ts
@@ -220,14 +220,31 @@ function functionContainsRelayLoadQuery(
 ): boolean {
   interface Scope {
     bindings: Set<string>;
+    functions: Map<string, any>;
   }
 
   const scopes: Scope[] = [];
   const currentScope = () => scopes[scopes.length - 1];
-  const pushScope = () => scopes.push({ bindings: new Set() });
+  const pushScope = () =>
+    scopes.push({ bindings: new Set(), functions: new Map() });
   const popScope = () => scopes.pop();
   const recordBinding = (name: string) => {
     currentScope()?.bindings.add(name);
+  };
+  const recordFunctionBinding = (name: string, fn: any) => {
+    const scope = currentScope();
+    scope?.bindings.add(name);
+    scope?.functions.set(name, fn);
+  };
+  const resolveFunctionBinding = (
+    name: string,
+  ): { found: boolean; fn?: any } => {
+    for (let i = scopes.length - 1; i >= 0; i--) {
+      const fn = scopes[i].functions.get(name);
+      if (fn != null) return { found: true, fn };
+      if (scopes[i].bindings.has(name)) return { found: true };
+    }
+    return { found: false };
   };
   const isShadowed = (name: string) => {
     for (let i = scopes.length - 1; i >= 0; i--) {
@@ -244,7 +261,9 @@ function functionContainsRelayLoadQuery(
   };
   const predeclareScopeBindings = (body: any) => {
     for (const statement of body?.body ?? []) {
-      predeclareStatementBinding(statement, recordBinding);
+      predeclareStatementBinding(statement, recordBinding, (name, fn) => {
+        recordFunctionBinding(name, fn);
+      });
     }
   };
 
@@ -270,30 +289,42 @@ function functionContainsRelayLoadQuery(
     return false;
   };
 
+  const visitedFunctions = new Set<any>();
+
+  const resolveCalledFunction = (call: any): any | undefined => {
+    if (call.callee?.type !== "Identifier") return undefined;
+
+    const binding = resolveFunctionBinding(call.callee.name);
+    if (binding.found) return binding.fn;
+    return resolveFunctionBindingFromAncestors(call.callee.name, call);
+  };
+
+  const visitFunction = (node: any): boolean => {
+    if (visitedFunctions.has(node)) return false;
+    visitedFunctions.add(node);
+
+    pushScope();
+    if (node.type !== "FunctionDeclaration" && node.id?.type === "Identifier") {
+      recordBinding(node.id.name);
+    }
+    recordParamBindings(node.params);
+    if (node.body?.type === "BlockStatement") {
+      predeclareScopeBindings(node.body);
+    }
+    const found = visit(node.body);
+    popScope();
+    return found;
+  };
+
   const visit = (node: any): boolean => {
     if (!node || typeof node !== "object") return false;
     if (isRelayLoadQueryCall(node)) return true;
 
     switch (node.type) {
       case "FunctionDeclaration":
-        pushScope();
-        recordParamBindings(node.params);
-        predeclareScopeBindings(node.body);
-        if (visit(node.body)) return true;
-        popScope();
-        return false;
-
       case "FunctionExpression":
       case "ArrowFunctionExpression":
-        pushScope();
-        if (node.id?.type === "Identifier") recordBinding(node.id.name);
-        recordParamBindings(node.params);
-        if (node.body?.type === "BlockStatement") {
-          predeclareScopeBindings(node.body);
-        }
-        if (visit(node.body)) return true;
-        popScope();
-        return false;
+        return visitFunction(node);
 
       case "BlockStatement":
         pushScope();
@@ -306,6 +337,9 @@ function functionContainsRelayLoadQuery(
 
       case "VariableDeclarator":
         recordPatternBindings(node.id);
+        if (node.id?.type === "Identifier" && isFunction(node.init)) {
+          recordFunctionBinding(node.id.name, node.init);
+        }
         return visit(node.init);
 
       case "ReturnStatement":
@@ -313,6 +347,7 @@ function functionContainsRelayLoadQuery(
         return visit(node.argument ?? node.expression);
 
       case "CallExpression":
+        if (visit(resolveCalledFunction(node))) return true;
         if (visit(node.callee)) return true;
         for (const arg of node.arguments ?? []) {
           if (visit(arg)) return true;

--- a/web-next/lint-plugins/no-load-query-in-router-query.ts
+++ b/web-next/lint-plugins/no-load-query-in-router-query.ts
@@ -1,0 +1,318 @@
+// deno-lint-ignore-file no-explicit-any
+//
+// Custom Deno lint plugin: prevent returning solid-relay PreloadedQuery
+// objects from @solidjs/router query() fetchers.
+//
+// Solid Router query() caches return values for preloads, active subscribers,
+// history navigation, and hydration. solid-relay loadQuery() returns a
+// PreloadedQuery whose lifetime is tied to createPreloadedQuery(); that
+// primitive disposes the query when the component unmounts. Caching that
+// disposable object in query() lets a later navigation reuse an already
+// disposed PreloadedQuery, which trips solid-relay's invariant.
+
+const plugin: Deno.lint.Plugin = {
+  name: "hackerspub-solid-relay",
+  rules: {
+    "no-load-query-in-router-query": {
+      create(context) {
+        type ImportBinding =
+          | { kind: "named"; imported: string }
+          | { kind: "namespace" };
+
+        const routerImports = new Map<string, ImportBinding>();
+        const relayImports = new Map<string, ImportBinding>();
+        const scopes: Set<string>[] = [];
+
+        const pushScope = () => scopes.push(new Set());
+        const popScope = () => scopes.pop();
+        const recordBinding = (name: string) => {
+          scopes[scopes.length - 1]?.add(name);
+        };
+        const isShadowed = (name: string) => {
+          for (let i = scopes.length - 1; i >= 0; i--) {
+            if (scopes[i].has(name)) return true;
+          }
+          return false;
+        };
+        const recordPatternBindings = (pattern: any) => {
+          walkPatternIdentifiers(pattern, recordBinding);
+        };
+        const recordParamBindings = (params: any[] | undefined) => {
+          for (const param of params ?? []) recordPatternBindings(param);
+        };
+
+        const isRouterQueryCall = (call: any): boolean => {
+          const callee = call.callee;
+          if (callee?.type === "Identifier") {
+            if (isShadowed(callee.name)) return false;
+            const binding = routerImports.get(callee.name);
+            return binding?.kind === "named" && binding.imported === "query";
+          }
+          if (
+            callee?.type === "MemberExpression" &&
+            !callee.computed &&
+            callee.object?.type === "Identifier" &&
+            callee.property?.type === "Identifier"
+          ) {
+            if (isShadowed(callee.object.name)) return false;
+            const binding = routerImports.get(callee.object.name);
+            return binding?.kind === "namespace" &&
+              callee.property.name === "query";
+          }
+          return false;
+        };
+
+        const message =
+          "Do not call solid-relay loadQuery() inside @solidjs/router " +
+          "query() fetchers. query() caches return values, but loadQuery() " +
+          "returns a disposable PreloadedQuery that createPreloadedQuery() " +
+          "disposes on unmount; reusing the cached object can crash with " +
+          "solid-relay's disposed preloaded query invariant.";
+
+        const isFunctionParent = (parent: any): boolean =>
+          parent?.type === "ArrowFunctionExpression" ||
+          parent?.type === "FunctionExpression" ||
+          parent?.type === "FunctionDeclaration";
+
+        return {
+          Program: pushScope,
+          "Program:exit": popScope,
+
+          ImportDeclaration(node: any) {
+            const source = node.source?.value;
+            if (source !== "@solidjs/router" && source !== "solid-relay") {
+              return;
+            }
+            const imports = source === "@solidjs/router"
+              ? routerImports
+              : relayImports;
+            for (const spec of node.specifiers ?? []) {
+              if (spec.type === "ImportSpecifier") {
+                const local = spec.local?.name;
+                const imported = spec.imported?.name ?? spec.imported?.value;
+                if (typeof local === "string" && typeof imported === "string") {
+                  imports.set(local, { kind: "named", imported });
+                }
+              } else if (spec.type === "ImportNamespaceSpecifier") {
+                const local = spec.local?.name;
+                if (typeof local === "string") {
+                  imports.set(local, { kind: "namespace" });
+                }
+              }
+            }
+          },
+
+          FunctionDeclaration(node: any) {
+            if (node.id?.type === "Identifier") recordBinding(node.id.name);
+            pushScope();
+            recordParamBindings(node.params);
+          },
+          "FunctionDeclaration:exit": popScope,
+
+          FunctionExpression(node: any) {
+            pushScope();
+            if (node.id?.type === "Identifier") recordBinding(node.id.name);
+            recordParamBindings(node.params);
+          },
+          "FunctionExpression:exit": popScope,
+
+          ArrowFunctionExpression(node: any) {
+            pushScope();
+            recordParamBindings(node.params);
+          },
+          "ArrowFunctionExpression:exit": popScope,
+
+          BlockStatement(node: any) {
+            if (isFunctionParent(node.parent)) return;
+            pushScope();
+            if (node.parent?.type === "CatchClause" && node.parent.param) {
+              recordPatternBindings(node.parent.param);
+            }
+          },
+          "BlockStatement:exit"(node: any) {
+            if (!isFunctionParent(node.parent)) popScope();
+          },
+
+          VariableDeclarator(node: any) {
+            recordPatternBindings(node.id);
+          },
+
+          CallExpression(node: any) {
+            if (!isRouterQueryCall(node)) return;
+            const fetcher = node.arguments?.[0];
+            if (!isFunction(fetcher)) return;
+            if (!functionContainsRelayLoadQuery(fetcher, relayImports)) return;
+
+            context.report({
+              node,
+              message,
+            });
+          },
+        };
+      },
+    },
+  },
+};
+
+export default plugin;
+
+function isFunction(node: any): boolean {
+  return node?.type === "ArrowFunctionExpression" ||
+    node?.type === "FunctionExpression";
+}
+
+function functionContainsRelayLoadQuery(
+  fn: any,
+  relayImports: Map<
+    string,
+    { kind: "named"; imported: string } | {
+      kind: "namespace";
+    }
+  >,
+): boolean {
+  const scopes: Set<string>[] = [];
+  const pushScope = () => scopes.push(new Set());
+  const popScope = () => scopes.pop();
+  const recordBinding = (name: string) => {
+    scopes[scopes.length - 1]?.add(name);
+  };
+  const isShadowed = (name: string) => {
+    for (let i = scopes.length - 1; i >= 0; i--) {
+      if (scopes[i].has(name)) return true;
+    }
+    return false;
+  };
+
+  const recordPatternBindings = (pattern: any) => {
+    walkPatternIdentifiers(pattern, recordBinding);
+  };
+  const recordParamBindings = (params: any[] | undefined) => {
+    for (const param of params ?? []) recordPatternBindings(param);
+  };
+
+  const isRelayLoadQueryCall = (node: any): boolean => {
+    if (node?.type !== "CallExpression") return false;
+    const callee = node.callee;
+    if (callee?.type === "Identifier") {
+      if (isShadowed(callee.name)) return false;
+      const binding = relayImports.get(callee.name);
+      return binding?.kind === "named" && binding.imported === "loadQuery";
+    }
+    if (
+      callee?.type === "MemberExpression" &&
+      !callee.computed &&
+      callee.object?.type === "Identifier" &&
+      callee.property?.type === "Identifier"
+    ) {
+      if (isShadowed(callee.object.name)) return false;
+      const binding = relayImports.get(callee.object.name);
+      return binding?.kind === "namespace" &&
+        callee.property.name === "loadQuery";
+    }
+    return false;
+  };
+
+  const visit = (node: any): boolean => {
+    if (!node || typeof node !== "object") return false;
+    if (isRelayLoadQueryCall(node)) return true;
+
+    switch (node.type) {
+      case "FunctionDeclaration":
+        if (node.id?.type === "Identifier") recordBinding(node.id.name);
+        pushScope();
+        recordParamBindings(node.params);
+        if (visit(node.body)) return true;
+        popScope();
+        return false;
+
+      case "FunctionExpression":
+      case "ArrowFunctionExpression":
+        pushScope();
+        if (node.id?.type === "Identifier") recordBinding(node.id.name);
+        recordParamBindings(node.params);
+        if (visit(node.body)) return true;
+        popScope();
+        return false;
+
+      case "BlockStatement":
+        pushScope();
+        for (const stmt of node.body ?? []) {
+          if (visit(stmt)) return true;
+        }
+        popScope();
+        return false;
+
+      case "VariableDeclarator":
+        recordPatternBindings(node.id);
+        return visit(node.init);
+
+      case "ObjectExpression":
+        for (const prop of node.properties ?? []) {
+          if (prop.type === "SpreadElement" && visit(prop.argument)) {
+            return true;
+          }
+          if (visit(prop.value)) return true;
+        }
+        return false;
+    }
+
+    for (const [key, value] of Object.entries(node)) {
+      if (
+        key === "parent" ||
+        key === "range" ||
+        key === "loc" ||
+        key === "start" ||
+        key === "end"
+      ) continue;
+      if (Array.isArray(value)) {
+        for (const child of value) {
+          if (visit(child)) return true;
+        }
+      } else if (value && typeof value === "object") {
+        if (visit(value)) return true;
+      }
+    }
+    return false;
+  };
+
+  pushScope();
+  recordParamBindings(fn.params);
+  const found = visit(fn.body);
+  popScope();
+  return found;
+}
+
+function walkPatternIdentifiers(
+  pattern: any,
+  bind: (name: string) => void,
+): void {
+  if (!pattern || typeof pattern !== "object") return;
+  switch (pattern.type) {
+    case "Identifier":
+      bind(pattern.name);
+      return;
+    case "AssignmentPattern":
+      walkPatternIdentifiers(pattern.left, bind);
+      return;
+    case "RestElement":
+      walkPatternIdentifiers(pattern.argument, bind);
+      return;
+    case "ArrayPattern":
+      for (const element of pattern.elements ?? []) {
+        walkPatternIdentifiers(element, bind);
+      }
+      return;
+    case "ObjectPattern":
+      for (const prop of pattern.properties ?? []) {
+        if (prop.type === "RestElement") {
+          walkPatternIdentifiers(prop.argument, bind);
+        } else {
+          walkPatternIdentifiers(prop.value ?? prop.key, bind);
+        }
+      }
+      return;
+    case "TSParameterProperty":
+      walkPatternIdentifiers(pattern.parameter, bind);
+      return;
+  }
+}

--- a/web-next/src/app.tsx
+++ b/web-next/src/app.tsx
@@ -1,7 +1,7 @@
 import { withSentryErrorBoundary } from "@sentry/solidstart";
 import { withSentryRouterRouting } from "@sentry/solidstart/solidrouter";
 import { MetaProvider } from "@solidjs/meta";
-import { query, Router } from "@solidjs/router";
+import { Router } from "@solidjs/router";
 import { graphql } from "relay-runtime";
 import { ErrorBoundary, type ParentProps, Show, Suspense } from "solid-js";
 import {
@@ -29,6 +29,7 @@ const SentryErrorBoundary = withSentryErrorBoundary(ErrorBoundary);
 
 import "pretendard/dist/web/variable/pretendardvariable-dynamic-subset.css";
 import "~/app.css";
+import { routePreloadedQuery } from "~/lib/relayPreload.ts";
 
 const appQuery = graphql`
   query appQuery {
@@ -36,7 +37,7 @@ const appQuery = graphql`
   }
 `;
 
-const loadAppQuery = query(
+const loadAppQuery = routePreloadedQuery(
   () =>
     loadQuery<appQuery>(
       useRelayEnvironment()(),

--- a/web-next/src/lib/relayPreload.ts
+++ b/web-next/src/lib/relayPreload.ts
@@ -72,33 +72,28 @@ export function refreshRelayQuery<TQuery extends OperationType>(
 }
 
 export function routePreloadedQuery<
-  TQuery extends OperationType,
-  TArgs extends unknown[],
+  TLoader extends (...args: never[]) => PreloadedQuery<OperationType>,
 >(
-  loader: (...args: TArgs) => PreloadedQuery<TQuery>,
+  loader: TLoader,
   name: string,
-): ((...args: TArgs) => PreloadedQuery<TQuery>) & {
+): TLoader & {
   key: string;
-  keyFor: (...args: TArgs) => string;
+  keyFor: (...args: Parameters<TLoader>) => string;
 } {
-  const cached = query(loader, name) as
-    & ((...args: TArgs) => PreloadedQuery<
-      TQuery
-    >)
-    & {
-      key: string;
-      keyFor: (...args: TArgs) => string;
-    };
-  const wrapped = ((...args: TArgs) => {
+  const cached = query(loader, name) as unknown as TLoader & {
+    key: string;
+    keyFor: (...args: Parameters<TLoader>) => string;
+  };
+  const wrapped = ((...args: Parameters<TLoader>) => {
     const preloaded = cached(...args);
     if (!preloaded.controls?.value.isDisposed()) return preloaded;
 
     const fresh = loader(...args);
     query.set(cached.keyFor(...args), fresh);
     return fresh;
-  }) as ((...args: TArgs) => PreloadedQuery<TQuery>) & {
+  }) as TLoader & {
     key: string;
-    keyFor: (...args: TArgs) => string;
+    keyFor: (...args: Parameters<TLoader>) => string;
   };
   wrapped.key = cached.key;
   wrapped.keyFor = cached.keyFor;

--- a/web-next/src/lib/relayPreload.ts
+++ b/web-next/src/lib/relayPreload.ts
@@ -91,15 +91,6 @@ export function routePreloadedQuery<
   const cached = query(loader, name) as unknown as RoutePreloadedQuery<TLoader>;
   const wrapped = ((...args: Parameters<TLoader>) => {
     const key = cached.keyFor(...args);
-    const cachedValue = getCachedValue(key);
-    if (
-      cachedValue.exists &&
-      cachedValue.value != null &&
-      isDisposed(cachedValue.value)
-    ) {
-      query.delete(key);
-    }
-
     const owner = getOwner();
     const preloaded = cached(...args);
     if (isPromiseLike(preloaded)) {
@@ -128,18 +119,6 @@ function isDisposed(
 
 function isPromiseLike<T>(value: T | PromiseLike<T>): value is PromiseLike<T> {
   return typeof value === "object" && value != null && "then" in value;
-}
-
-function getCachedValue(
-  key: string,
-):
-  | { exists: true; value: PreloadedQuery<OperationType> | undefined }
-  | { exists: false } {
-  try {
-    return { exists: true, value: query.get(key) };
-  } catch {
-    return { exists: false };
-  }
 }
 
 function runCached<TLoader extends (...args: never[]) => unknown>(

--- a/web-next/src/lib/relayPreload.ts
+++ b/web-next/src/lib/relayPreload.ts
@@ -96,7 +96,8 @@ export function routePreloadedQuery<
     const cachedValue = getCachedValue(key);
     if (
       cachedValue.exists &&
-      (cachedValue.value == null || isDisposed(cachedValue.value))
+      cachedValue.value != null &&
+      isDisposed(cachedValue.value)
     ) {
       query.delete(key);
     }

--- a/web-next/src/lib/relayPreload.ts
+++ b/web-next/src/lib/relayPreload.ts
@@ -109,13 +109,13 @@ export function routePreloadedQuery<
         if (!isDisposed(resolved)) return resolved;
 
         query.delete(key);
-        return runLoader(owner, loader, args);
+        return runCached(owner, cached, args);
       });
     }
     if (!isDisposed(preloaded)) return preloaded;
 
     query.delete(key);
-    return runLoader(owner, loader, args);
+    return runCached(owner, cached, args);
   }) as
     & ((...args: Parameters<TLoader>) => MaybePromise<ReturnType<TLoader>>)
     & {
@@ -147,11 +147,11 @@ function getCachedValue(
   }
 }
 
-function runLoader<TLoader extends (...args: never[]) => unknown>(
+function runCached<TLoader extends (...args: never[]) => unknown>(
   owner: Owner | null,
-  loader: TLoader,
+  cached: TLoader,
   args: Parameters<TLoader>,
 ): ReturnType<TLoader> {
-  if (owner == null) return loader(...args) as ReturnType<TLoader>;
-  return runWithOwner(owner, () => loader(...args)) as ReturnType<TLoader>;
+  if (owner == null) return cached(...args) as ReturnType<TLoader>;
+  return runWithOwner(owner, () => cached(...args)) as ReturnType<TLoader>;
 }

--- a/web-next/src/lib/relayPreload.ts
+++ b/web-next/src/lib/relayPreload.ts
@@ -1,0 +1,70 @@
+import {
+  type CacheConfig,
+  type FetchPolicy,
+  fetchQuery,
+  type FetchQueryFetchPolicy,
+  type GraphQLTaggedNode,
+  type IEnvironment,
+  type OperationType,
+  type VariablesOf,
+} from "relay-runtime";
+
+export interface RelayPreloadOptions {
+  fetchPolicy?: FetchPolicy | null | undefined;
+  networkCacheConfig?: CacheConfig | null | undefined;
+}
+
+function toFetchQueryPolicy(
+  fetchPolicy: FetchPolicy | null | undefined,
+): FetchQueryFetchPolicy | null {
+  switch (fetchPolicy) {
+    case "store-only":
+      return null;
+    case "network-only":
+    case "store-and-network":
+      return "network-only";
+    case "store-or-network":
+    case undefined:
+    case null:
+      return "store-or-network";
+  }
+}
+
+export function preloadRelayQuery<TQuery extends OperationType>(
+  environment: IEnvironment,
+  query: GraphQLTaggedNode,
+  variables: VariablesOf<TQuery>,
+  options?: RelayPreloadOptions,
+): void {
+  const fetchPolicy = toFetchQueryPolicy(options?.fetchPolicy);
+  if (fetchPolicy == null) return;
+  fetchQuery<TQuery>(environment, query, variables, {
+    fetchPolicy,
+    networkCacheConfig: options?.networkCacheConfig,
+  }).subscribe({
+    error(error: unknown) {
+      console.error("Relay query preload failed:", error);
+    },
+  });
+}
+
+export function refreshRelayQuery<TQuery extends OperationType>(
+  environment: IEnvironment,
+  query: GraphQLTaggedNode,
+  variables: VariablesOf<TQuery>,
+  options?: Omit<RelayPreloadOptions, "fetchPolicy">,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    fetchQuery<TQuery>(environment, query, variables, {
+      fetchPolicy: "network-only",
+      networkCacheConfig: options?.networkCacheConfig,
+    }).subscribe({
+      complete() {
+        resolve();
+      },
+      error(error: unknown) {
+        reject(error);
+      },
+    });
+  });
+}

--- a/web-next/src/lib/relayPreload.ts
+++ b/web-next/src/lib/relayPreload.ts
@@ -1,3 +1,4 @@
+import { query } from "@solidjs/router";
 import {
   type CacheConfig,
   type FetchPolicy,
@@ -8,6 +9,7 @@ import {
   type OperationType,
   type VariablesOf,
 } from "relay-runtime";
+import type { PreloadedQuery } from "solid-relay";
 
 export interface RelayPreloadOptions {
   fetchPolicy?: FetchPolicy | null | undefined;
@@ -67,4 +69,38 @@ export function refreshRelayQuery<TQuery extends OperationType>(
       },
     });
   });
+}
+
+export function routePreloadedQuery<
+  TQuery extends OperationType,
+  TArgs extends unknown[],
+>(
+  loader: (...args: TArgs) => PreloadedQuery<TQuery>,
+  name: string,
+): ((...args: TArgs) => PreloadedQuery<TQuery>) & {
+  key: string;
+  keyFor: (...args: TArgs) => string;
+} {
+  const cached = query(loader, name) as
+    & ((...args: TArgs) => PreloadedQuery<
+      TQuery
+    >)
+    & {
+      key: string;
+      keyFor: (...args: TArgs) => string;
+    };
+  const wrapped = ((...args: TArgs) => {
+    const preloaded = cached(...args);
+    if (!preloaded.controls?.value.isDisposed()) return preloaded;
+
+    const fresh = loader(...args);
+    query.set(cached.keyFor(...args), fresh);
+    return fresh;
+  }) as ((...args: TArgs) => PreloadedQuery<TQuery>) & {
+    key: string;
+    keyFor: (...args: TArgs) => string;
+  };
+  wrapped.key = cached.key;
+  wrapped.keyFor = cached.keyFor;
+  return wrapped;
 }

--- a/web-next/src/lib/relayPreload.ts
+++ b/web-next/src/lib/relayPreload.ts
@@ -12,11 +12,19 @@ import {
 import { getOwner, type Owner, runWithOwner } from "solid-js";
 import type { PreloadedQuery } from "solid-relay";
 
-type MaybePromise<T> = T | Promise<T>;
+export type MaybePromise<T> = T | Promise<T>;
 
 export interface RelayPreloadOptions {
   fetchPolicy?: FetchPolicy | null | undefined;
   networkCacheConfig?: CacheConfig | null | undefined;
+}
+
+export interface RoutePreloadedQuery<
+  TLoader extends (...args: never[]) => PreloadedQuery<OperationType>,
+> {
+  (...args: Parameters<TLoader>): MaybePromise<ReturnType<TLoader>>;
+  key: string;
+  keyFor: (...args: Parameters<TLoader>) => string;
 }
 
 function toFetchQueryPolicy(
@@ -79,18 +87,8 @@ export function routePreloadedQuery<
 >(
   loader: TLoader,
   name: string,
-): ((...args: Parameters<TLoader>) => MaybePromise<ReturnType<TLoader>>) & {
-  key: string;
-  keyFor: (...args: Parameters<TLoader>) => string;
-} {
-  const cached = query(loader, name) as unknown as
-    & ((
-      ...args: Parameters<TLoader>
-    ) => MaybePromise<ReturnType<TLoader>>)
-    & {
-      key: string;
-      keyFor: (...args: Parameters<TLoader>) => string;
-    };
+): RoutePreloadedQuery<TLoader> {
+  const cached = query(loader, name) as unknown as RoutePreloadedQuery<TLoader>;
   const wrapped = ((...args: Parameters<TLoader>) => {
     const key = cached.keyFor(...args);
     const cachedValue = getCachedValue(key);
@@ -116,12 +114,7 @@ export function routePreloadedQuery<
 
     query.delete(key);
     return runCached(owner, cached, args);
-  }) as
-    & ((...args: Parameters<TLoader>) => MaybePromise<ReturnType<TLoader>>)
-    & {
-      key: string;
-      keyFor: (...args: Parameters<TLoader>) => string;
-    };
+  }) as RoutePreloadedQuery<TLoader>;
   wrapped.key = cached.key;
   wrapped.keyFor = cached.keyFor;
   return wrapped;

--- a/web-next/src/lib/relayPreload.ts
+++ b/web-next/src/lib/relayPreload.ts
@@ -9,7 +9,10 @@ import {
   type OperationType,
   type VariablesOf,
 } from "relay-runtime";
+import { getOwner, type Owner, runWithOwner } from "solid-js";
 import type { PreloadedQuery } from "solid-relay";
+
+type MaybePromise<T> = T | Promise<T>;
 
 export interface RelayPreloadOptions {
   fetchPolicy?: FetchPolicy | null | undefined;
@@ -76,26 +79,78 @@ export function routePreloadedQuery<
 >(
   loader: TLoader,
   name: string,
-): TLoader & {
+): ((...args: Parameters<TLoader>) => MaybePromise<ReturnType<TLoader>>) & {
   key: string;
   keyFor: (...args: Parameters<TLoader>) => string;
 } {
-  const cached = query(loader, name) as unknown as TLoader & {
-    key: string;
-    keyFor: (...args: Parameters<TLoader>) => string;
-  };
+  const cached = query(loader, name) as unknown as
+    & ((
+      ...args: Parameters<TLoader>
+    ) => MaybePromise<ReturnType<TLoader>>)
+    & {
+      key: string;
+      keyFor: (...args: Parameters<TLoader>) => string;
+    };
   const wrapped = ((...args: Parameters<TLoader>) => {
-    const preloaded = cached(...args);
-    if (!preloaded.controls?.value.isDisposed()) return preloaded;
+    const key = cached.keyFor(...args);
+    const cachedValue = getCachedValue(key);
+    if (
+      cachedValue.exists &&
+      (cachedValue.value == null || isDisposed(cachedValue.value))
+    ) {
+      query.delete(key);
+    }
 
-    const fresh = loader(...args);
-    query.set(cached.keyFor(...args), fresh);
-    return fresh;
-  }) as TLoader & {
-    key: string;
-    keyFor: (...args: Parameters<TLoader>) => string;
-  };
+    const owner = getOwner();
+    const preloaded = cached(...args);
+    if (isPromiseLike(preloaded)) {
+      return preloaded.then((resolved) => {
+        if (!isDisposed(resolved)) return resolved;
+
+        query.delete(key);
+        return runLoader(owner, loader, args);
+      });
+    }
+    if (!isDisposed(preloaded)) return preloaded;
+
+    query.delete(key);
+    return runLoader(owner, loader, args);
+  }) as
+    & ((...args: Parameters<TLoader>) => MaybePromise<ReturnType<TLoader>>)
+    & {
+      key: string;
+      keyFor: (...args: Parameters<TLoader>) => string;
+    };
   wrapped.key = cached.key;
   wrapped.keyFor = cached.keyFor;
   return wrapped;
+}
+
+function isDisposed(preloaded: PreloadedQuery<OperationType>): boolean {
+  return preloaded.controls?.value.isDisposed() ?? false;
+}
+
+function isPromiseLike<T>(value: T | PromiseLike<T>): value is PromiseLike<T> {
+  return typeof value === "object" && value != null && "then" in value;
+}
+
+function getCachedValue(
+  key: string,
+):
+  | { exists: true; value: PreloadedQuery<OperationType> | undefined }
+  | { exists: false } {
+  try {
+    return { exists: true, value: query.get(key) };
+  } catch {
+    return { exists: false };
+  }
+}
+
+function runLoader<TLoader extends (...args: never[]) => unknown>(
+  owner: Owner | null,
+  loader: TLoader,
+  args: Parameters<TLoader>,
+): ReturnType<TLoader> {
+  if (owner == null) return loader(...args) as ReturnType<TLoader>;
+  return runWithOwner(owner, () => loader(...args)) as ReturnType<TLoader>;
 }

--- a/web-next/src/lib/relayPreload.ts
+++ b/web-next/src/lib/relayPreload.ts
@@ -127,8 +127,10 @@ export function routePreloadedQuery<
   return wrapped;
 }
 
-function isDisposed(preloaded: PreloadedQuery<OperationType>): boolean {
-  return preloaded.controls?.value.isDisposed() ?? false;
+function isDisposed(
+  preloaded: PreloadedQuery<OperationType> | null | undefined,
+): boolean {
+  return preloaded?.controls?.value.isDisposed() ?? false;
 }
 
 function isPromiseLike<T>(value: T | PromiseLike<T>): value is PromiseLike<T> {

--- a/web-next/src/routes/(root).tsx
+++ b/web-next/src/routes/(root).tsx
@@ -1,6 +1,5 @@
 import {
   A,
-  query,
   type RouteDefinition,
   type RouteSectionProps,
   useLocation,
@@ -20,6 +19,7 @@ import { NoteComposeProvider } from "~/contexts/NoteComposeContext.tsx";
 import { ViewerProvider } from "~/contexts/ViewerContext.tsx";
 import { useLingui } from "~/lib/i18n/macro.d.ts";
 import type { RootLayoutQuery } from "./__generated__/RootLayoutQuery.graphql.ts";
+import { routePreloadedQuery } from "~/lib/relayPreload.ts";
 
 export const route = {
   preload() {
@@ -37,7 +37,7 @@ const RootLayoutQuery = graphql`
   }
 `;
 
-const loadRootLayoutQuery = query(
+const loadRootLayoutQuery = routePreloadedQuery(
   () =>
     loadQuery<RootLayoutQuery>(
       useRelayEnvironment()(),

--- a/web-next/src/routes/(root)/[handle]/(profile)/articles.tsx
+++ b/web-next/src/routes/(root)/[handle]/(profile)/articles.tsx
@@ -1,5 +1,5 @@
 import { Meta } from "@solidjs/meta";
-import { query, type RouteDefinition, useParams } from "@solidjs/router";
+import { type RouteDefinition, useParams } from "@solidjs/router";
 import { graphql } from "relay-runtime";
 import { Show } from "solid-js";
 import {
@@ -19,6 +19,7 @@ import {
   profileContentRevalidating,
 } from "~/lib/profileContentQueries.ts";
 import type { articlesPageQuery } from "./__generated__/articlesPageQuery.graphql.ts";
+import { routePreloadedQuery } from "~/lib/relayPreload.ts";
 
 export const route = {
   matchFilters: {
@@ -45,7 +46,7 @@ const articlesPageQuery = graphql`
   }
 `;
 
-const loadPageQuery = query(
+const loadPageQuery = routePreloadedQuery(
   (handle: string, locale: string) =>
     loadQuery<articlesPageQuery>(
       useRelayEnvironment()(),

--- a/web-next/src/routes/(root)/[handle]/(profile)/followers.tsx
+++ b/web-next/src/routes/(root)/[handle]/(profile)/followers.tsx
@@ -1,5 +1,5 @@
 import { Meta } from "@solidjs/meta";
-import { query, type RouteDefinition, useParams } from "@solidjs/router";
+import { type RouteDefinition, useParams } from "@solidjs/router";
 import { graphql } from "relay-runtime";
 import { Show } from "solid-js";
 import {
@@ -13,6 +13,7 @@ import { ProfileCard } from "~/components/ProfileCard.tsx";
 import { Title } from "~/components/Title.tsx";
 import { useLingui } from "~/lib/i18n/macro.d.ts";
 import type { followersPageQuery } from "./__generated__/followersPageQuery.graphql.ts";
+import { routePreloadedQuery } from "~/lib/relayPreload.ts";
 
 export const route = {
   matchFilters: {
@@ -37,7 +38,7 @@ const followersPageQuery = graphql`
   }
 `;
 
-const loadPageQuery = query(
+const loadPageQuery = routePreloadedQuery(
   (username: string) =>
     loadQuery<followersPageQuery>(
       useRelayEnvironment()(),

--- a/web-next/src/routes/(root)/[handle]/(profile)/following.tsx
+++ b/web-next/src/routes/(root)/[handle]/(profile)/following.tsx
@@ -1,5 +1,5 @@
 import { Meta } from "@solidjs/meta";
-import { query, type RouteDefinition, useParams } from "@solidjs/router";
+import { type RouteDefinition, useParams } from "@solidjs/router";
 import { graphql } from "relay-runtime";
 import { Show } from "solid-js";
 import {
@@ -13,6 +13,7 @@ import { ProfileCard } from "~/components/ProfileCard.tsx";
 import { Title } from "~/components/Title.tsx";
 import { useLingui } from "~/lib/i18n/macro.d.ts";
 import type { followingPageQuery } from "./__generated__/followingPageQuery.graphql.ts";
+import { routePreloadedQuery } from "~/lib/relayPreload.ts";
 
 export const route = {
   matchFilters: {
@@ -37,7 +38,7 @@ const followingPageQuery = graphql`
   }
 `;
 
-const loadPageQuery = query(
+const loadPageQuery = routePreloadedQuery(
   (username: string) =>
     loadQuery<followingPageQuery>(
       useRelayEnvironment()(),

--- a/web-next/src/routes/(root)/[handle]/(profile)/index.tsx
+++ b/web-next/src/routes/(root)/[handle]/(profile)/index.tsx
@@ -1,5 +1,5 @@
 import { Link, Meta } from "@solidjs/meta";
-import { query, type RouteDefinition, useParams } from "@solidjs/router";
+import { type RouteDefinition, useParams } from "@solidjs/router";
 import { graphql } from "relay-runtime";
 import { For, Show } from "solid-js";
 import {
@@ -24,6 +24,7 @@ import IconPin from "~icons/lucide/pin";
 import type { ProfilePagePinsQuery } from "./__generated__/ProfilePagePinsQuery.graphql.ts";
 import type { ProfilePagePostsQuery } from "./__generated__/ProfilePagePostsQuery.graphql.ts";
 import type { ProfilePageQuery } from "./__generated__/ProfilePageQuery.graphql.ts";
+import { routePreloadedQuery } from "~/lib/relayPreload.ts";
 
 export const route = {
   matchFilters: {
@@ -85,7 +86,7 @@ const ProfilePagePostsQuery = graphql`
   }
 `;
 
-const loadPageQuery = query(
+const loadPageQuery = routePreloadedQuery(
   (handle: string) =>
     loadQuery<ProfilePageQuery>(
       useRelayEnvironment()(),
@@ -95,7 +96,7 @@ const loadPageQuery = query(
   "loadProfilePageQuery",
 );
 
-const loadPagePinsQuery = query(
+const loadPagePinsQuery = routePreloadedQuery(
   (handle: string, locale: string) =>
     loadQuery<ProfilePagePinsQuery>(
       useRelayEnvironment()(),
@@ -106,7 +107,7 @@ const loadPagePinsQuery = query(
   PROFILE_PAGE_PINS_QUERY_KEY,
 );
 
-const loadPagePostsQuery = query(
+const loadPagePostsQuery = routePreloadedQuery(
   (handle: string, locale: string) =>
     loadQuery<ProfilePagePostsQuery>(
       useRelayEnvironment()(),

--- a/web-next/src/routes/(root)/[handle]/(profile)/notes.tsx
+++ b/web-next/src/routes/(root)/[handle]/(profile)/notes.tsx
@@ -1,5 +1,5 @@
 import { Meta } from "@solidjs/meta";
-import { query, type RouteDefinition, useParams } from "@solidjs/router";
+import { type RouteDefinition, useParams } from "@solidjs/router";
 import { graphql } from "relay-runtime";
 import { Show } from "solid-js";
 import {
@@ -19,6 +19,7 @@ import {
   profileContentRevalidating,
 } from "~/lib/profileContentQueries.ts";
 import type { notesPageQuery } from "./__generated__/notesPageQuery.graphql.ts";
+import { routePreloadedQuery } from "~/lib/relayPreload.ts";
 
 export const route = {
   matchFilters: {
@@ -44,7 +45,7 @@ const notesPageQuery = graphql`
   }
 `;
 
-const loadPageQuery = query(
+const loadPageQuery = routePreloadedQuery(
   (handle: string) =>
     loadQuery<notesPageQuery>(
       useRelayEnvironment()(),

--- a/web-next/src/routes/(root)/[handle]/(profile)/shares.tsx
+++ b/web-next/src/routes/(root)/[handle]/(profile)/shares.tsx
@@ -1,5 +1,5 @@
 import { Meta } from "@solidjs/meta";
-import { query, type RouteDefinition, useParams } from "@solidjs/router";
+import { type RouteDefinition, useParams } from "@solidjs/router";
 import { graphql } from "relay-runtime";
 import { Show } from "solid-js";
 import {
@@ -19,6 +19,7 @@ import {
   profileContentRevalidating,
 } from "~/lib/profileContentQueries.ts";
 import type { sharesPageQuery } from "./__generated__/sharesPageQuery.graphql.ts";
+import { routePreloadedQuery } from "~/lib/relayPreload.ts";
 
 export const route = {
   matchFilters: {
@@ -45,7 +46,7 @@ const sharesPageQuery = graphql`
   }
 `;
 
-const loadPageQuery = query(
+const loadPageQuery = routePreloadedQuery(
   (handle: string, locale: string) =>
     loadQuery<sharesPageQuery>(
       useRelayEnvironment()(),

--- a/web-next/src/routes/(root)/[handle]/[idOrYear]/[slug]/[lang].tsx
+++ b/web-next/src/routes/(root)/[handle]/[idOrYear]/[slug]/[lang].tsx
@@ -1,10 +1,5 @@
 import { normalizeLocale } from "@hackerspub/models/i18n";
-import {
-  Navigate,
-  query,
-  type RouteDefinition,
-  useParams,
-} from "@solidjs/router";
+import { Navigate, type RouteDefinition, useParams } from "@solidjs/router";
 import { HttpStatusCode } from "@solidjs/start";
 import {
   type Disposable,
@@ -31,6 +26,7 @@ import { showToast } from "~/components/ui/toast.tsx";
 import { useLingui } from "~/lib/i18n/macro.d.ts";
 import type { LangPageQuery } from "./__generated__/LangPageQuery.graphql.ts";
 import type { LangPage_requestArticleTranslation_Mutation } from "./__generated__/LangPage_requestArticleTranslation_Mutation.graphql.ts";
+import { routePreloadedQuery } from "~/lib/relayPreload.ts";
 import {
   ArticleBody,
   ArticleMetaHead,
@@ -158,7 +154,7 @@ const requestArticleTranslationMutation = graphql`
   }
 `;
 
-const loadLangPageQuery = query(
+const loadLangPageQuery = routePreloadedQuery(
   (handle: string, idOrYear: string, slug: string, language: string) =>
     loadQuery<LangPageQuery>(
       useRelayEnvironment()(),

--- a/web-next/src/routes/(root)/[handle]/[idOrYear]/[slug]/edit.tsx
+++ b/web-next/src/routes/(root)/[handle]/[idOrYear]/[slug]/edit.tsx
@@ -1,5 +1,4 @@
 import {
-  query,
   revalidate,
   type RouteDefinition,
   useNavigate,
@@ -29,6 +28,7 @@ import { useLingui } from "~/lib/i18n/macro.d.ts";
 import type { editPageQuery } from "./__generated__/editPageQuery.graphql.ts";
 import type { edit_article$key } from "./__generated__/edit_article.graphql.ts";
 import type { edit_updateArticle_Mutation } from "./__generated__/edit_updateArticle_Mutation.graphql.ts";
+import { routePreloadedQuery } from "~/lib/relayPreload.ts";
 
 export const route = {
   matchFilters: {
@@ -59,7 +59,7 @@ const editPageQueryDef = graphql`
   }
 `;
 
-const loadPageQuery = query(
+const loadPageQuery = routePreloadedQuery(
   (handle: string, idOrYear: string, slug: string) =>
     loadQuery<editPageQuery>(
       useRelayEnvironment()(),

--- a/web-next/src/routes/(root)/[handle]/[idOrYear]/[slug]/index.tsx
+++ b/web-next/src/routes/(root)/[handle]/[idOrYear]/[slug]/index.tsx
@@ -1,12 +1,7 @@
 import { normalizeLocale } from "@hackerspub/models/i18n";
 import type { Toc } from "@hackerspub/models/markup";
 import { Link, Meta } from "@solidjs/meta";
-import {
-  query,
-  revalidate,
-  type RouteDefinition,
-  useParams,
-} from "@solidjs/router";
+import { revalidate, type RouteDefinition, useParams } from "@solidjs/router";
 import { HttpHeader, HttpStatusCode } from "@solidjs/start";
 import { graphql } from "relay-runtime";
 import { createSignal, For, onMount, Show } from "solid-js";
@@ -46,6 +41,7 @@ import type { Slug_head$key } from "./__generated__/Slug_head.graphql.ts";
 import type { Slug_languageSwitcher$key } from "./__generated__/Slug_languageSwitcher.graphql.ts";
 import type { Slug_replies$key } from "./__generated__/Slug_replies.graphql.ts";
 import type { Slug_viewer$key } from "./__generated__/Slug_viewer.graphql.ts";
+import { routePreloadedQuery } from "~/lib/relayPreload.ts";
 
 export const route = {
   matchFilters: {
@@ -83,7 +79,7 @@ const SlugPageQueryDef = graphql`
   }
 `;
 
-const loadPageQuery = query(
+const loadPageQuery = routePreloadedQuery(
   (handle: string, idOrYear: string, slug: string) =>
     loadQuery<SlugPageQuery>(
       useRelayEnvironment()(),

--- a/web-next/src/routes/(root)/[handle]/[noteId].tsx
+++ b/web-next/src/routes/(root)/[handle]/[noteId].tsx
@@ -1,7 +1,6 @@
 import { type Uuid, validateUuid } from "@hackerspub/models/uuid";
 import { Meta } from "@solidjs/meta";
 import {
-  query,
   revalidate,
   type RouteDefinition,
   useNavigate,
@@ -55,6 +54,7 @@ import type { NoteId_noteBody$key } from "./__generated__/NoteId_noteBody.graphq
 import type { NoteId_questionBody$key } from "./__generated__/NoteId_questionBody.graphql.ts";
 import type { NoteIdThreadQuery } from "./__generated__/NoteIdThreadQuery.graphql.ts";
 import type { NoteIdThread_post$key } from "./__generated__/NoteIdThread_post.graphql.ts";
+import { routePreloadedQuery } from "~/lib/relayPreload.ts";
 
 type NoteIdPagePost = NonNullable<
   NonNullable<
@@ -108,7 +108,7 @@ const NoteIdPageQuery = graphql`
   }
 `;
 
-const loadNotePageQuery = query(
+const loadNotePageQuery = routePreloadedQuery(
   (username: string, noteId: Uuid) =>
     loadQuery<NoteIdPageQuery>(
       useRelayEnvironment()(),
@@ -128,7 +128,7 @@ const NoteIdThreadQuery = graphql`
   }
 `;
 
-const loadNoteThreadQuery = query(
+const loadNoteThreadQuery = routePreloadedQuery(
   (username: string, noteId: Uuid) =>
     loadQuery<NoteIdThreadQuery>(
       useRelayEnvironment()(),

--- a/web-next/src/routes/(root)/[handle]/bookmarks.tsx
+++ b/web-next/src/routes/(root)/[handle]/bookmarks.tsx
@@ -1,7 +1,6 @@
 import {
   A,
   Navigate,
-  query,
   revalidate,
   type RouteDefinition,
   useParams,
@@ -31,6 +30,7 @@ import { WideContainer } from "~/components/WideContainer.tsx";
 import { useViewer } from "~/contexts/ViewerContext.tsx";
 import { useLingui } from "~/lib/i18n/macro.d.ts";
 import type { bookmarksPageQuery } from "./__generated__/bookmarksPageQuery.graphql.ts";
+import { routePreloadedQuery } from "~/lib/relayPreload.ts";
 
 export const route = {
   matchFilters: {
@@ -54,7 +54,7 @@ const bookmarksPageQuery = graphql`
   }
 `;
 
-const loadBookmarksPageQuery = query(
+const loadBookmarksPageQuery = routePreloadedQuery(
   (locale: string) =>
     loadQuery<bookmarksPageQuery>(
       useRelayEnvironment()(),

--- a/web-next/src/routes/(root)/[handle]/drafts/[id].tsx
+++ b/web-next/src/routes/(root)/[handle]/drafts/[id].tsx
@@ -1,4 +1,4 @@
-import { A, query, type RouteDefinition, useParams } from "@solidjs/router";
+import { A, type RouteDefinition, useParams } from "@solidjs/router";
 import { HttpStatusCode } from "@solidjs/start";
 import { graphql } from "relay-runtime";
 import { Show } from "solid-js";
@@ -13,6 +13,7 @@ import { WideContainer } from "~/components/WideContainer.tsx";
 import { Button } from "~/components/ui/button.tsx";
 import { useLingui } from "~/lib/i18n/macro.d.ts";
 import type { IdQuery } from "./__generated__/IdQuery.graphql.ts";
+import { routePreloadedQuery } from "~/lib/relayPreload.ts";
 
 const EditDraftViewerQuery = graphql`
   query IdQuery {
@@ -23,7 +24,7 @@ const EditDraftViewerQuery = graphql`
   }
 `;
 
-const loadEditDraftViewerQuery = query(
+const loadEditDraftViewerQuery = routePreloadedQuery(
   () =>
     loadQuery<IdQuery>(
       useRelayEnvironment()(),

--- a/web-next/src/routes/(root)/[handle]/drafts/index.tsx
+++ b/web-next/src/routes/(root)/[handle]/drafts/index.tsx
@@ -1,4 +1,4 @@
-import { A, query, type RouteDefinition, useParams } from "@solidjs/router";
+import { A, type RouteDefinition, useParams } from "@solidjs/router";
 import { HttpStatusCode } from "@solidjs/start";
 import { ConnectionHandler, graphql } from "relay-runtime";
 import { createSignal, For, Match, Show, Switch } from "solid-js";
@@ -27,6 +27,7 @@ import { showToast } from "~/components/ui/toast.tsx";
 import type { draftsQuery } from "./__generated__/draftsQuery.graphql.ts";
 import type { draftsDeleteMutation } from "./__generated__/draftsDeleteMutation.graphql.ts";
 import type { draftsPaginationFragment$key } from "./__generated__/draftsPaginationFragment.graphql.ts";
+import { routePreloadedQuery } from "~/lib/relayPreload.ts";
 
 const DRAFTS_PAGE_SIZE = 50 as const;
 
@@ -86,7 +87,7 @@ const DeleteDraftMutation = graphql`
   }
 `;
 
-const loadDraftsQuery = query(
+const loadDraftsQuery = routePreloadedQuery(
   (first: number = DRAFTS_PAGE_SIZE, after: string | null = null) =>
     loadQuery<draftsQuery>(
       useRelayEnvironment()(),

--- a/web-next/src/routes/(root)/[handle]/drafts/new.tsx
+++ b/web-next/src/routes/(root)/[handle]/drafts/new.tsx
@@ -1,6 +1,5 @@
 import {
   A,
-  query,
   type RouteDefinition,
   useNavigate,
   useParams,
@@ -19,6 +18,7 @@ import { Title } from "~/components/Title.tsx";
 import { Button } from "~/components/ui/button.tsx";
 import { useLingui } from "~/lib/i18n/macro.d.ts";
 import type { newConnectionsQuery } from "./__generated__/newConnectionsQuery.graphql.ts";
+import { routePreloadedQuery } from "~/lib/relayPreload.ts";
 
 const NewDraftConnectionsQuery = graphql`
   query newConnectionsQuery {
@@ -29,7 +29,7 @@ const NewDraftConnectionsQuery = graphql`
   }
 `;
 
-const loadNewDraftConnectionsQuery = query(
+const loadNewDraftConnectionsQuery = routePreloadedQuery(
   () =>
     loadQuery<newConnectionsQuery>(
       useRelayEnvironment()(),

--- a/web-next/src/routes/(root)/[handle]/invite/[id].tsx
+++ b/web-next/src/routes/(root)/[handle]/invite/[id].tsx
@@ -1,4 +1,4 @@
-import { query, type RouteDefinition, useParams } from "@solidjs/router";
+import { type RouteDefinition, useParams } from "@solidjs/router";
 import { graphql } from "relay-runtime";
 import { createSignal, Show } from "solid-js";
 import {
@@ -31,6 +31,7 @@ import { showToast } from "~/components/ui/toast.tsx";
 import { msg, plural, useLingui } from "~/lib/i18n/macro.d.ts";
 import type { IdInvitationLinkPageQuery } from "./__generated__/IdInvitationLinkPageQuery.graphql.ts";
 import type { IdRedeemInvitationLinkMutation } from "./__generated__/IdRedeemInvitationLinkMutation.graphql.ts";
+import { routePreloadedQuery } from "~/lib/relayPreload.ts";
 
 export const route = {
   matchFilters: {
@@ -66,7 +67,7 @@ const invitationLinkPageQuery = graphql`
 
 type UUID = `${string}-${string}-${string}-${string}-${string}`;
 
-const loadInvitationLinkPageQuery = query(
+const loadInvitationLinkPageQuery = routePreloadedQuery(
   (id: string, handle: string) =>
     loadQuery<IdInvitationLinkPageQuery>(
       useRelayEnvironment()(),

--- a/web-next/src/routes/(root)/[handle]/settings/index.tsx
+++ b/web-next/src/routes/(root)/[handle]/settings/index.tsx
@@ -1,4 +1,4 @@
-import { query, type RouteDefinition, useParams } from "@solidjs/router";
+import { type RouteDefinition, useParams } from "@solidjs/router";
 import { createDropzone } from "@soorria/solid-dropzone";
 import type {
   CropperCanvas,
@@ -44,6 +44,7 @@ import { SettingsOwnerGuard } from "~/components/SettingsOwnerGuard.tsx";
 import type { settingsForm_account$key } from "./__generated__/settingsForm_account.graphql.ts";
 import type { settingsMutation } from "./__generated__/settingsMutation.graphql.ts";
 import type { settingsPageQuery } from "./__generated__/settingsPageQuery.graphql.ts";
+import { routePreloadedQuery } from "~/lib/relayPreload.ts";
 
 export const route = {
   matchFilters: {
@@ -67,7 +68,7 @@ const settingsPageQuery = graphql`
   }
 `;
 
-const loadPageQuery = query(
+const loadPageQuery = routePreloadedQuery(
   (handle: string) =>
     loadQuery<settingsPageQuery>(
       useRelayEnvironment()(),

--- a/web-next/src/routes/(root)/[handle]/settings/invite.tsx
+++ b/web-next/src/routes/(root)/[handle]/settings/invite.tsx
@@ -1,4 +1,4 @@
-import { query, type RouteDefinition, useParams } from "@solidjs/router";
+import { type RouteDefinition, useParams } from "@solidjs/router";
 import { graphql } from "relay-runtime";
 import { createSignal, For, Match, Show, Switch } from "solid-js";
 import {
@@ -44,6 +44,7 @@ import type {
   inviteMutation,
 } from "./__generated__/inviteMutation.graphql.ts";
 import type { invitePageQuery } from "./__generated__/invitePageQuery.graphql.ts";
+import { routePreloadedQuery } from "~/lib/relayPreload.ts";
 
 export const route = {
   matchFilters: {
@@ -82,7 +83,7 @@ const invitePageQuery = graphql`
   }
 `;
 
-const loadInvitePageQuery = query(
+const loadInvitePageQuery = routePreloadedQuery(
   (handle: string) =>
     loadQuery<invitePageQuery>(
       useRelayEnvironment()(),

--- a/web-next/src/routes/(root)/[handle]/settings/language.tsx
+++ b/web-next/src/routes/(root)/[handle]/settings/language.tsx
@@ -1,4 +1,4 @@
-import { query, type RouteDefinition, useParams } from "@solidjs/router";
+import { type RouteDefinition, useParams } from "@solidjs/router";
 import { graphql } from "relay-runtime";
 import { createSignal, Show } from "solid-js";
 import {
@@ -18,6 +18,7 @@ import { useLingui } from "~/lib/i18n/macro.d.ts";
 import type { languageMutation } from "./__generated__/languageMutation.graphql.ts";
 import type { languagePageQuery } from "./__generated__/languagePageQuery.graphql.ts";
 import type { languagePreferredLanguagesForm_locales$key } from "./__generated__/languagePreferredLanguagesForm_locales.graphql.ts";
+import { routePreloadedQuery } from "~/lib/relayPreload.ts";
 
 export const route = {
   matchFilters: {
@@ -42,7 +43,7 @@ const languagePageQuery = graphql`
   }
 `;
 
-const loadLanguagePageQuery = query(
+const loadLanguagePageQuery = routePreloadedQuery(
   (handle: string) =>
     loadQuery<languagePageQuery>(
       useRelayEnvironment()(),

--- a/web-next/src/routes/(root)/[handle]/settings/passkeys.tsx
+++ b/web-next/src/routes/(root)/[handle]/settings/passkeys.tsx
@@ -3,7 +3,7 @@ import {
   type RegistrationResponseJSON,
   startRegistration,
 } from "@simplewebauthn/browser";
-import { query, type RouteDefinition, useParams } from "@solidjs/router";
+import { type RouteDefinition, useParams } from "@solidjs/router";
 import { graphql } from "relay-runtime";
 import { createSignal, For, Show } from "solid-js";
 import {
@@ -49,6 +49,7 @@ import type { passkeysGetPasskeyRegistrationOptionsMutation } from "./__generate
 import type { passkeysPageQuery } from "./__generated__/passkeysPageQuery.graphql.ts";
 import type { passkeysRevokePasskeyMutation } from "./__generated__/passkeysRevokePasskeyMutation.graphql.ts";
 import type { passkeysVerifyPasskeyRegistrationMutation } from "./__generated__/passkeysVerifyPasskeyRegistrationMutation.graphql.ts";
+import { routePreloadedQuery } from "~/lib/relayPreload.ts";
 
 const PASSKEYS_PAGE_SIZE = 10 as const;
 
@@ -103,7 +104,7 @@ const passkeysFragment = graphql`
   }
 `;
 
-const loadPageQuery = query(
+const loadPageQuery = routePreloadedQuery(
   (
     handle: string,
     first: number = PASSKEYS_PAGE_SIZE,

--- a/web-next/src/routes/(root)/[handle]/settings/preferences.tsx
+++ b/web-next/src/routes/(root)/[handle]/settings/preferences.tsx
@@ -1,4 +1,4 @@
-import { query, type RouteDefinition, useParams } from "@solidjs/router";
+import { type RouteDefinition, useParams } from "@solidjs/router";
 import { graphql } from "relay-runtime";
 import { createSignal, Show } from "solid-js";
 import {
@@ -20,6 +20,7 @@ import { showToast } from "~/components/ui/toast.tsx";
 import { useLingui } from "~/lib/i18n/macro.d.ts";
 import type { preferencesMutation } from "./__generated__/preferencesMutation.graphql.ts";
 import type { preferencesPageQuery } from "./__generated__/preferencesPageQuery.graphql.ts";
+import { routePreloadedQuery } from "~/lib/relayPreload.ts";
 
 export const route = {
   matchFilters: {
@@ -46,7 +47,7 @@ const preferencesPageQuery = graphql`
   }
 `;
 
-const loadPreferencesPageQuery = query(
+const loadPreferencesPageQuery = routePreloadedQuery(
   (handle: string) =>
     loadQuery<preferencesPageQuery>(
       useRelayEnvironment()(),

--- a/web-next/src/routes/(root)/admin/index.tsx
+++ b/web-next/src/routes/(root)/admin/index.tsx
@@ -1,4 +1,4 @@
-import { Navigate, query } from "@solidjs/router";
+import { Navigate } from "@solidjs/router";
 import { graphql } from "relay-runtime";
 import { Show } from "solid-js";
 import {
@@ -11,6 +11,7 @@ import { Title } from "~/components/Title.tsx";
 import { WideContainer } from "~/components/WideContainer.tsx";
 import { useLingui } from "~/lib/i18n/macro.d.ts";
 import type { adminAccountsPageQuery } from "./__generated__/adminAccountsPageQuery.graphql.ts";
+import { routePreloadedQuery } from "~/lib/relayPreload.ts";
 
 const adminAccountsPageQuery = graphql`
   query adminAccountsPageQuery($count: Int!, $cursor: String) {
@@ -21,7 +22,7 @@ const adminAccountsPageQuery = graphql`
   }
 `;
 
-const loadAdminAccountsPageQuery = query(
+const loadAdminAccountsPageQuery = routePreloadedQuery(
   () =>
     loadQuery<adminAccountsPageQuery>(
       useRelayEnvironment()(),

--- a/web-next/src/routes/(root)/admin/invitations.tsx
+++ b/web-next/src/routes/(root)/admin/invitations.tsx
@@ -1,4 +1,4 @@
-import { Navigate, query, revalidate, useNavigate } from "@solidjs/router";
+import { Navigate, revalidate, useNavigate } from "@solidjs/router";
 import { graphql } from "relay-runtime";
 import { createSignal, Show } from "solid-js";
 import {
@@ -23,6 +23,7 @@ import { showToast } from "~/components/ui/toast.tsx";
 import { msg, plural, useLingui } from "~/lib/i18n/macro.d.ts";
 import type { invitationsPageQuery } from "./__generated__/invitationsPageQuery.graphql.ts";
 import type { invitationsRegenerateMutation } from "./__generated__/invitationsRegenerateMutation.graphql.ts";
+import { routePreloadedQuery } from "~/lib/relayPreload.ts";
 
 const invitationsPageQuery = graphql`
   query invitationsPageQuery {
@@ -38,7 +39,7 @@ const invitationsPageQuery = graphql`
   }
 `;
 
-const loadAdminInvitationsPageQuery = query(
+const loadAdminInvitationsPageQuery = routePreloadedQuery(
   () =>
     loadQuery<invitationsPageQuery>(
       useRelayEnvironment()(),

--- a/web-next/src/routes/(root)/admin/media.tsx
+++ b/web-next/src/routes/(root)/admin/media.tsx
@@ -1,4 +1,4 @@
-import { Navigate, query, revalidate, useNavigate } from "@solidjs/router";
+import { Navigate, revalidate, useNavigate } from "@solidjs/router";
 import { graphql } from "relay-runtime";
 import { createSignal, Show } from "solid-js";
 import {
@@ -23,6 +23,7 @@ import { showToast } from "~/components/ui/toast.tsx";
 import { msg, plural, useLingui } from "~/lib/i18n/macro.d.ts";
 import type { mediaDeleteOrphanMediaMutation } from "./__generated__/mediaDeleteOrphanMediaMutation.graphql.ts";
 import type { mediaPageQuery } from "./__generated__/mediaPageQuery.graphql.ts";
+import { routePreloadedQuery } from "~/lib/relayPreload.ts";
 
 const mediaPageQuery = graphql`
   query mediaPageQuery {
@@ -36,7 +37,7 @@ const mediaPageQuery = graphql`
   }
 `;
 
-const loadAdminMediaPageQuery = query(
+const loadAdminMediaPageQuery = routePreloadedQuery(
   () =>
     loadQuery<mediaPageQuery>(
       useRelayEnvironment()(),

--- a/web-next/src/routes/(root)/authorize_interaction.tsx
+++ b/web-next/src/routes/(root)/authorize_interaction.tsx
@@ -1,5 +1,4 @@
 import {
-  query,
   type RouteDefinition,
   useNavigate,
   useSearchParams,
@@ -21,6 +20,7 @@ import {
 import { Button } from "~/components/ui/button.tsx";
 import { useLingui } from "~/lib/i18n/macro.d.ts";
 import type { authorizeInteractionPageQuery } from "./__generated__/authorizeInteractionPageQuery.graphql.ts";
+import { routePreloadedQuery } from "~/lib/relayPreload.ts";
 
 function stripAcctPrefix(uri: string): string {
   return uri.replace(/^acct:/i, "");
@@ -58,7 +58,7 @@ const authorizeInteractionPageQuery = graphql`
   }
 `;
 
-const loadPageQuery = query(
+const loadPageQuery = routePreloadedQuery(
   (uri: string) =>
     loadQuery<authorizeInteractionPageQuery>(
       useRelayEnvironment()(),

--- a/web-next/src/routes/(root)/coc.tsx
+++ b/web-next/src/routes/(root)/coc.tsx
@@ -1,5 +1,5 @@
 import { Title } from "@solidjs/meta";
-import { query, type RouteDefinition } from "@solidjs/router";
+import { type RouteDefinition } from "@solidjs/router";
 import { graphql } from "relay-runtime";
 import { Show } from "solid-js";
 import {
@@ -11,6 +11,7 @@ import { DocumentView } from "~/components/DocumentView.tsx";
 import { WideContainer } from "~/components/WideContainer.tsx";
 import { useLingui } from "~/lib/i18n/macro.d.ts";
 import type { cocPageQuery } from "./__generated__/cocPageQuery.graphql.ts";
+import { routePreloadedQuery } from "~/lib/relayPreload.ts";
 
 export const route = {
   preload() {
@@ -27,7 +28,7 @@ const cocPageQuery = graphql`
   }
 `;
 
-const loadPageQuery = query(
+const loadPageQuery = routePreloadedQuery(
   (locale: Intl.Locale | string) =>
     loadQuery<cocPageQuery>(
       useRelayEnvironment()(),

--- a/web-next/src/routes/(root)/fediverse.tsx
+++ b/web-next/src/routes/(root)/fediverse.tsx
@@ -1,4 +1,4 @@
-import { query, type RouteDefinition } from "@solidjs/router";
+import { type RouteDefinition } from "@solidjs/router";
 import { graphql } from "relay-runtime";
 import { Show } from "solid-js";
 import {
@@ -11,6 +11,7 @@ import { NarrowContainer } from "~/components/NarrowContainer.tsx";
 import { PublicTimeline } from "~/components/PublicTimeline.tsx";
 import { useLingui } from "~/lib/i18n/macro.d.ts";
 import type { fediverseTimelineQuery } from "./__generated__/fediverseTimelineQuery.graphql.ts";
+import { routePreloadedQuery } from "~/lib/relayPreload.ts";
 
 export const route = {
   preload() {
@@ -37,7 +38,7 @@ const fediverseTimelineQuery = graphql`
   }
 `;
 
-const loadFediverseTimelineQuery = query(
+const loadFediverseTimelineQuery = routePreloadedQuery(
   (locale: string, languages: readonly string[]) =>
     loadQuery<fediverseTimelineQuery>(
       useRelayEnvironment()(),

--- a/web-next/src/routes/(root)/feed/articles.tsx
+++ b/web-next/src/routes/(root)/feed/articles.tsx
@@ -1,4 +1,4 @@
-import { query, type RouteDefinition } from "@solidjs/router";
+import { type RouteDefinition } from "@solidjs/router";
 import { graphql } from "relay-runtime";
 import { Show } from "solid-js";
 import {
@@ -10,6 +10,7 @@ import { NarrowContainer } from "~/components/NarrowContainer.tsx";
 import { PersonalTimeline } from "~/components/PersonalTimeline.tsx";
 import { useLingui } from "~/lib/i18n/macro.d.ts";
 import type { articlesFeedTimelineQuery } from "./__generated__/articlesFeedTimelineQuery.graphql.ts";
+import { routePreloadedQuery } from "~/lib/relayPreload.ts";
 
 export const route = {
   preload() {
@@ -24,7 +25,7 @@ const articlesFeedTimelineQuery = graphql`
   }
 `;
 
-const loadArticlesFeedTimelineQuery = query(
+const loadArticlesFeedTimelineQuery = routePreloadedQuery(
   (locale: string) =>
     loadQuery<articlesFeedTimelineQuery>(
       useRelayEnvironment()(),

--- a/web-next/src/routes/(root)/feed/index.tsx
+++ b/web-next/src/routes/(root)/feed/index.tsx
@@ -1,4 +1,4 @@
-import { query, type RouteDefinition } from "@solidjs/router";
+import { type RouteDefinition } from "@solidjs/router";
 import { graphql } from "relay-runtime";
 import { Show } from "solid-js";
 import {
@@ -10,6 +10,7 @@ import { NarrowContainer } from "~/components/NarrowContainer.tsx";
 import { PersonalTimeline } from "~/components/PersonalTimeline.tsx";
 import { useLingui } from "~/lib/i18n/macro.d.ts";
 import type { feedTimelineQuery } from "./__generated__/feedTimelineQuery.graphql.ts";
+import { routePreloadedQuery } from "~/lib/relayPreload.ts";
 
 export const route = {
   preload() {
@@ -24,7 +25,7 @@ const feedTimelineQuery = graphql`
   }
 `;
 
-const loadFeedTimelineQuery = query(
+const loadFeedTimelineQuery = routePreloadedQuery(
   (locale: string) =>
     loadQuery<feedTimelineQuery>(
       useRelayEnvironment()(),

--- a/web-next/src/routes/(root)/feed/without-shares.tsx
+++ b/web-next/src/routes/(root)/feed/without-shares.tsx
@@ -1,4 +1,4 @@
-import { query, type RouteDefinition } from "@solidjs/router";
+import { type RouteDefinition } from "@solidjs/router";
 import { graphql } from "relay-runtime";
 import { Show } from "solid-js";
 import {
@@ -10,6 +10,7 @@ import { NarrowContainer } from "~/components/NarrowContainer.tsx";
 import { PersonalTimeline } from "~/components/PersonalTimeline.tsx";
 import { useLingui } from "~/lib/i18n/macro.d.ts";
 import type { withoutSharesFeedTimelineQuery } from "./__generated__/withoutSharesFeedTimelineQuery.graphql.ts";
+import { routePreloadedQuery } from "~/lib/relayPreload.ts";
 
 export const route = {
   preload() {
@@ -24,7 +25,7 @@ const withoutSharesFeedTimelineQuery = graphql`
   }
 `;
 
-const loadWithoutSharesFeedTimelineQuery = query(
+const loadWithoutSharesFeedTimelineQuery = routePreloadedQuery(
   (locale: string) =>
     loadQuery<withoutSharesFeedTimelineQuery>(
       useRelayEnvironment()(),

--- a/web-next/src/routes/(root)/index.tsx
+++ b/web-next/src/routes/(root)/index.tsx
@@ -1,4 +1,4 @@
-import { Navigate, query, type RouteDefinition } from "@solidjs/router";
+import { Navigate, type RouteDefinition } from "@solidjs/router";
 import { graphql } from "relay-runtime";
 import { Match, Show, Switch } from "solid-js";
 import {
@@ -7,6 +7,7 @@ import {
   useRelayEnvironment,
 } from "solid-relay";
 import type { RootRoutesQuery } from "./__generated__/RootRoutesQuery.graphql.ts";
+import { routePreloadedQuery } from "~/lib/relayPreload.ts";
 
 export const route = {
   preload() {
@@ -22,7 +23,7 @@ const RootRoutesQuery = graphql`
   }
 `;
 
-const loadRoutesQuery = query(
+const loadRoutesQuery = routePreloadedQuery(
   () =>
     loadQuery<RootRoutesQuery>(useRelayEnvironment()(), RootRoutesQuery, {}),
   "loadRoutesQuery",

--- a/web-next/src/routes/(root)/local.tsx
+++ b/web-next/src/routes/(root)/local.tsx
@@ -1,4 +1,4 @@
-import { query, type RouteDefinition } from "@solidjs/router";
+import { type RouteDefinition } from "@solidjs/router";
 import { graphql } from "relay-runtime";
 import { Show } from "solid-js";
 import {
@@ -11,6 +11,7 @@ import { NarrowContainer } from "~/components/NarrowContainer.tsx";
 import { PublicTimeline } from "~/components/PublicTimeline.tsx";
 import { useLingui } from "~/lib/i18n/macro.d.ts";
 import type { localTimelineQuery } from "./__generated__/localTimelineQuery.graphql.ts";
+import { routePreloadedQuery } from "~/lib/relayPreload.ts";
 
 export const route = {
   preload() {
@@ -37,7 +38,7 @@ const localTimelineQuery = graphql`
   }
 `;
 
-const loadLocalTimelineQuery = query(
+const loadLocalTimelineQuery = routePreloadedQuery(
   (locale: string, languages: readonly string[]) =>
     loadQuery<localTimelineQuery>(useRelayEnvironment()(), localTimelineQuery, {
       locale,

--- a/web-next/src/routes/(root)/markdown.tsx
+++ b/web-next/src/routes/(root)/markdown.tsx
@@ -1,5 +1,5 @@
 import { Title } from "@solidjs/meta";
-import { query, type RouteDefinition } from "@solidjs/router";
+import { type RouteDefinition } from "@solidjs/router";
 import { graphql } from "relay-runtime";
 import { Show } from "solid-js";
 import {
@@ -11,6 +11,7 @@ import { DocumentView } from "~/components/DocumentView.tsx";
 import { WideContainer } from "~/components/WideContainer.tsx";
 import { useLingui } from "~/lib/i18n/macro.d.ts";
 import type { markdownPageQuery } from "./__generated__/markdownPageQuery.graphql.ts";
+import { routePreloadedQuery } from "~/lib/relayPreload.ts";
 
 export const route = {
   preload() {
@@ -27,7 +28,7 @@ const markdownPageQuery = graphql`
   }
 `;
 
-const loadPageQuery = query(
+const loadPageQuery = routePreloadedQuery(
   (locale: Intl.Locale | string) =>
     loadQuery<markdownPageQuery>(
       useRelayEnvironment()(),

--- a/web-next/src/routes/(root)/notifications.tsx
+++ b/web-next/src/routes/(root)/notifications.tsx
@@ -1,4 +1,4 @@
-import { Navigate, query } from "@solidjs/router";
+import { Navigate } from "@solidjs/router";
 import { graphql } from "relay-runtime";
 import { Show } from "solid-js";
 import {
@@ -11,6 +11,7 @@ import { NotificationList } from "~/components/NotificationList.tsx";
 import { Title } from "~/components/Title.tsx";
 import { useLingui } from "~/lib/i18n/macro.d.ts";
 import type { notificationsPageQuery } from "./__generated__/notificationsPageQuery.graphql.ts";
+import { routePreloadedQuery } from "~/lib/relayPreload.ts";
 
 const notificationsPageQuery = graphql`
   query notificationsPageQuery {
@@ -20,7 +21,7 @@ const notificationsPageQuery = graphql`
   }
 `;
 
-const loadPageQuery = query(
+const loadPageQuery = routePreloadedQuery(
   () =>
     loadQuery<notificationsPageQuery>(
       useRelayEnvironment()(),

--- a/web-next/src/routes/(root)/privacy.tsx
+++ b/web-next/src/routes/(root)/privacy.tsx
@@ -1,5 +1,5 @@
 import { Title } from "@solidjs/meta";
-import { query, type RouteDefinition } from "@solidjs/router";
+import { type RouteDefinition } from "@solidjs/router";
 import { graphql } from "relay-runtime";
 import { Show } from "solid-js";
 import {
@@ -11,6 +11,7 @@ import { DocumentView } from "~/components/DocumentView.tsx";
 import { WideContainer } from "~/components/WideContainer.tsx";
 import { useLingui } from "~/lib/i18n/macro.d.ts";
 import type { privacyPolicyPageQuery } from "./__generated__/privacyPolicyPageQuery.graphql.ts";
+import { routePreloadedQuery } from "~/lib/relayPreload.ts";
 
 export const route = {
   preload() {
@@ -27,7 +28,7 @@ const privacyPolicyPageQuery = graphql`
   }
 `;
 
-const loadPageQuery = query(
+const loadPageQuery = routePreloadedQuery(
   (locale: Intl.Locale | string) =>
     loadQuery<privacyPolicyPageQuery>(
       useRelayEnvironment()(),

--- a/web-next/src/routes/(root)/search.tsx
+++ b/web-next/src/routes/(root)/search.tsx
@@ -4,7 +4,6 @@ import {
 } from "@hackerspub/models/searchPatterns";
 import {
   Navigate,
-  query,
   type RouteDefinition,
   useNavigate,
   useSearchParams,
@@ -24,6 +23,7 @@ import { useLingui } from "~/lib/i18n/macro.d.ts";
 import type { searchObjectPageQuery } from "./__generated__/searchObjectPageQuery.graphql.ts";
 import type { searchObjectPageQuery$data } from "./__generated__/searchObjectPageQuery.graphql.ts";
 import type { searchPostsPageQuery } from "./__generated__/searchPostsPageQuery.graphql.ts";
+import { routePreloadedQuery } from "~/lib/relayPreload.ts";
 
 export const route = {
   preload({ location }) {
@@ -82,7 +82,7 @@ function getSearchType(searchQuery: string): "handle" | "url" | "posts" {
   return "posts";
 }
 
-const loadSearchPostsQuery = query(
+const loadSearchPostsQuery = routePreloadedQuery(
   (
     searchQuery: string,
     locale: string,
@@ -102,7 +102,7 @@ const loadSearchPostsQuery = query(
   "loadSearchPostsQuery",
 );
 
-const loadSearchObjectQuery = query(
+const loadSearchObjectQuery = routePreloadedQuery(
   (searchQuery: string) =>
     loadQuery<searchObjectPageQuery>(
       useRelayEnvironment()(),

--- a/web-next/src/routes/(root)/tags/[tag].tsx
+++ b/web-next/src/routes/(root)/tags/[tag].tsx
@@ -1,4 +1,4 @@
-import { query, type RouteDefinition, useParams } from "@solidjs/router";
+import { type RouteDefinition, useParams } from "@solidjs/router";
 import { graphql } from "relay-runtime";
 import { Show } from "solid-js";
 import {
@@ -11,6 +11,7 @@ import { SearchResults } from "~/components/SearchResults.tsx";
 import { Trans } from "~/components/Trans.tsx";
 import { useLingui } from "~/lib/i18n/macro.d.ts";
 import type { TagPageQuery } from "./__generated__/TagPageQuery.graphql.ts";
+import { routePreloadedQuery } from "~/lib/relayPreload.ts";
 
 export const route = {
   preload({ params }) {
@@ -39,7 +40,7 @@ const TagPageQuery = graphql`
   }
 `;
 
-const loadTagQuery = query(
+const loadTagQuery = routePreloadedQuery(
   (
     searchQuery: string,
     locale: string,

--- a/web-next/src/routes/(root)/tree.tsx
+++ b/web-next/src/routes/(root)/tree.tsx
@@ -1,4 +1,4 @@
-import { query, type RouteDefinition } from "@solidjs/router";
+import { type RouteDefinition } from "@solidjs/router";
 import { graphql } from "relay-runtime";
 import { Show } from "solid-js";
 import {
@@ -8,6 +8,7 @@ import {
 } from "solid-relay";
 import { ForceGraph } from "~/components/ForceGraph.tsx";
 import type { treeQuery } from "./__generated__/treeQuery.graphql.ts";
+import { routePreloadedQuery } from "~/lib/relayPreload.ts";
 
 export const route = {
   preload() {
@@ -28,7 +29,7 @@ const TreeQueryDocument = graphql`
   }
 `;
 
-const loadTreeQuery = query(
+const loadTreeQuery = routePreloadedQuery(
   () => loadQuery<treeQuery>(useRelayEnvironment()(), TreeQueryDocument, {}),
   "loadTreeQuery",
 );


### PR DESCRIPTION
This PR fixes a route-level Relay lifetime issue in *web-next* where `@solidjs/router` `query()` could cache `solid-relay` `loadQuery()` results beyond the lifetime expected by `createPreloadedQuery()`.

`loadQuery()` returns a disposable `PreloadedQuery`, and `createPreloadedQuery()` disposes it when the route component unmounts. However, Solid Router's `query()` cache can keep returning the same object for subsequent navigations to the same route key. That means navigating away from a page and then back could reuse an already-disposed `PreloadedQuery`, triggering solid-relay's disposed preloaded query invariant.

This PR adds *web-next/src/lib/relayPreload.ts* with a `routePreloadedQuery()` helper that keeps the Solid Router query behavior while guarding against disposed Relay preloads. When a cached preload has already been disposed, the helper evicts the stale router cache entry and reruns the router query wrapper so the refreshed preload is cached, tracked, and revalidated normally.

It also updates the affected route loaders across *web-next/src/app.tsx* and *web-next/src/routes/* to use `routePreloadedQuery()` instead of calling `query()` directly around `loadQuery()`.

To prevent the pattern from coming back, this PR adds and enables a custom Deno lint plugin in *web-next/lint-plugins/no-load-query-in-router-query.ts*. The rule reports `solid-relay` `loadQuery()` calls inside `@solidjs/router` `query()` fetchers, including aliased imports, namespace imports, and object-spread return patterns.

Validation performed:

- `deno task check`
- lint plugin tests for *web-next/lint-plugins/no-load-query-in-router-query.test.ts* and *web-next/lint-plugins/keyed-show.test.ts*
- `deno lint` fixture check confirming the new rule reports the unsafe pattern
- Playwright smoke testing on `http://localhost:5173`, including repeated `/feed` ↔ `/coc` navigation and `/feed/articles` round trip, with no page errors or console errors.