### PR TITLE
Prevent Relay preloads from crossing environment instances

### DIFF
--- a/web-next/src/RelayEnvironment.tsx
+++ b/web-next/src/RelayEnvironment.tsx
@@ -5,7 +5,7 @@ import type {
   IEnvironment,
 } from "relay-runtime";
 import { Environment, Network, RecordSource, Store } from "relay-runtime";
-import { getRequestEvent } from "solid-js/web";
+import { getRequestEvent, isServer } from "solid-js/web";
 import { getApiUrl } from "~/lib/env.ts";
 
 function readSessionCookie(request: Request | undefined): string | null {
@@ -80,10 +80,17 @@ const fetchFn: FetchFunction = async (
   return body;
 };
 
-export function createEnvironment(): IEnvironment {
+let clientEnvironment: IEnvironment | undefined;
+
+function createRelayEnvironment(): IEnvironment {
   const network = Network.create((params, variables, cacheConfig) => {
     return fetchFn(params, variables, cacheConfig);
   });
   const store = new Store(new RecordSource());
   return new Environment({ store, network });
+}
+
+export function createEnvironment(): IEnvironment {
+  if (isServer) return createRelayEnvironment();
+  return clientEnvironment ??= createRelayEnvironment();
 }

--- a/web-next/src/RelayEnvironment.tsx
+++ b/web-next/src/RelayEnvironment.tsx
@@ -93,7 +93,7 @@ function createRelayEnvironment(): IEnvironment {
 
 function getRequestEnvironment(): IEnvironment | undefined {
   const event = getRequestEvent();
-  if (event == null || !("locals" in event)) return undefined;
+  if (event?.locals == null) return undefined;
 
   const locals = event.locals as Record<PropertyKey, unknown>;
   const cached = locals[requestEnvironmentKey];

--- a/web-next/src/RelayEnvironment.tsx
+++ b/web-next/src/RelayEnvironment.tsx
@@ -81,6 +81,7 @@ const fetchFn: FetchFunction = async (
 };
 
 let clientEnvironment: IEnvironment | undefined;
+const requestEnvironmentKey = Symbol("relayEnvironment");
 
 function createRelayEnvironment(): IEnvironment {
   const network = Network.create((params, variables, cacheConfig) => {
@@ -90,7 +91,20 @@ function createRelayEnvironment(): IEnvironment {
   return new Environment({ store, network });
 }
 
+function getRequestEnvironment(): IEnvironment | undefined {
+  const event = getRequestEvent();
+  if (event == null || !("locals" in event)) return undefined;
+
+  const locals = event.locals as Record<PropertyKey, unknown>;
+  const cached = locals[requestEnvironmentKey];
+  if (cached != null) return cached as IEnvironment;
+
+  const environment = createRelayEnvironment();
+  locals[requestEnvironmentKey] = environment;
+  return environment;
+}
+
 export function createEnvironment(): IEnvironment {
-  if (isServer) return createRelayEnvironment();
+  if (isServer) return getRequestEnvironment() ?? createRelayEnvironment();
   return clientEnvironment ??= createRelayEnvironment();
 }

--- a/web-next/src/lib/relayPreload.ts
+++ b/web-next/src/lib/relayPreload.ts
@@ -10,7 +10,7 @@ import {
   type VariablesOf,
 } from "relay-runtime";
 import { getOwner, type Owner, runWithOwner } from "solid-js";
-import type { PreloadedQuery } from "solid-relay";
+import { type PreloadedQuery, useRelayEnvironment } from "solid-relay";
 
 export type MaybePromise<T> = T | Promise<T>;
 
@@ -92,16 +92,21 @@ export function routePreloadedQuery<
   const wrapped = ((...args: Parameters<TLoader>) => {
     const key = cached.keyFor(...args);
     const owner = getOwner();
+    const currentEnvironment = useRelayEnvironment()();
     const preloaded = cached(...args);
     if (isPromiseLike(preloaded)) {
       return preloaded.then((resolved) => {
-        if (!isDisposed(resolved)) return resolved;
+        if (!isStalePreloadedQuery(resolved, currentEnvironment)) {
+          return resolved;
+        }
 
         query.delete(key);
         return runCached(owner, cached, args);
       });
     }
-    if (!isDisposed(preloaded)) return preloaded;
+    if (!isStalePreloadedQuery(preloaded, currentEnvironment)) {
+      return preloaded;
+    }
 
     query.delete(key);
     return runCached(owner, cached, args);
@@ -111,10 +116,13 @@ export function routePreloadedQuery<
   return wrapped;
 }
 
-function isDisposed(
+function isStalePreloadedQuery(
   preloaded: PreloadedQuery<OperationType> | null | undefined,
+  environment: IEnvironment,
 ): boolean {
-  return preloaded?.controls?.value.isDisposed() ?? false;
+  const controls = preloaded?.controls?.value;
+  return controls != null &&
+    (controls.isDisposed() || controls.environment !== environment);
 }
 
 function isPromiseLike<T>(value: T | PromiseLike<T>): value is PromiseLike<T> {


### PR DESCRIPTION
This PR fixes the remaining `solid-relay` preloaded query invariant reported in Sentry after the disposed-preload cache fix.

The previous PR prevented Solid Router from reusing a disposed `PreloadedQuery`, but Sentry still showed events from release 0.2.0+6149ea5457f7af0c5908ffe8e2d593fc81e4ee76. The latest stack trace pointed at a different invariant: `createPreloadedQuery()` was receiving a `PreloadedQuery` created with a different Relay environment than the current `RelayEnvironmentProvider`.

That can happen because route preloads are cached through Solid Router, while the app root could create a new Relay environment instance. If a cached `PreloadedQuery` outlives the environment instance that created it, `solid-relay` rejects it even when it has not been disposed yet.

Changes:

- Keeps a singleton Relay environment for the browser session in *web-next/src/RelayEnvironment.tsx*
- Preserves fresh Relay environment creation on the server to avoid cross-request store sharing
- Treats cached route preloads as stale when their Relay environment differs from the current provider environment in *web-next/src/lib/relayPreload.ts*
- Keeps the existing stale handling for disposed preloaded queries

Validation:

- `deno task check`
- `git diff --check main..HEAD`
- Playwright MCP smoke test for `/` and `/coc` navigation with no console errors
