### PR TITLE
Fix bidirectional timeline pagination cursors

### DIFF
--- a/graphql/timeline.test.ts
+++ b/graphql/timeline.test.ts
@@ -1,10 +1,15 @@
 import { assertEquals } from "@std/assert/equals";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { encodeGlobalID } from "@pothos/plugin-relay";
 import { execute, parse } from "graphql";
+import { createBookmark } from "@hackerspub/models/bookmark";
 import { follow } from "@hackerspub/models/following";
 import { sharePost } from "@hackerspub/models/post";
-import { postTable } from "@hackerspub/models/schema";
+import {
+  bookmarkTable,
+  postTable,
+  timelineItemTable,
+} from "@hackerspub/models/schema";
 import { schema } from "./mod.ts";
 import {
   createFedCtx,
@@ -19,18 +24,28 @@ import {
 const publicTimelineQuery = parse(`
   query PublicTimelineTest(
     $first: Int
+    $after: String
+    $last: Int
+    $before: String
     $local: Boolean
     $withoutShares: Boolean
   ) {
     publicTimeline(
       first: $first
+      after: $after
+      last: $last
+      before: $before
       local: $local
       withoutShares: $withoutShares
     ) {
       pageInfo {
         hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
       }
       edges {
+        cursor
         node {
           id
         }
@@ -40,9 +55,28 @@ const publicTimelineQuery = parse(`
 `);
 
 const personalTimelineQuery = parse(`
-  query PersonalTimelineTest($withoutShares: Boolean) {
-    personalTimeline(first: 10, withoutShares: $withoutShares) {
+  query PersonalTimelineTest(
+    $first: Int
+    $after: String
+    $last: Int
+    $before: String
+    $withoutShares: Boolean
+  ) {
+    personalTimeline(
+      first: $first
+      after: $after
+      last: $last
+      before: $before
+      withoutShares: $withoutShares
+    ) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
       edges {
+        cursor
         node {
           id
         }
@@ -50,6 +84,30 @@ const personalTimelineQuery = parse(`
           id
         }
         sharersCount
+      }
+    }
+  }
+`);
+
+const bookmarksQuery = parse(`
+  query BookmarksTest(
+    $first: Int
+    $after: String
+    $last: Int
+    $before: String
+  ) {
+    bookmarks(first: $first, after: $after, last: $last, before: $before) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      edges {
+        cursor
+        node {
+          id
+        }
       }
     }
   }
@@ -113,6 +171,109 @@ Deno.test({
       assertEquals(connection.pageInfo.hasNextPage, true);
       assertEquals(connection.edges.map((edge) => edge.node.id), [
         encodeGlobalID("Note", remotePost.id),
+      ]);
+    });
+  },
+});
+
+Deno.test({
+  name: "publicTimeline supports forward and backward cursor pagination",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  async fn() {
+    await withRollback(async (tx) => {
+      const author = await insertAccountWithActor(tx, {
+        username: "graphqlpublicpaginationauthor",
+        name: "GraphQL Public Pagination Author",
+        email: "graphqlpublicpaginationauthor@example.com",
+      });
+      const posts = [];
+      const timestamp = new Date("2026-04-15T00:00:01.000Z");
+      for (let i = 1; i <= 4; i++) {
+        const { post } = await insertNotePost(tx, {
+          account: author.account,
+          content: `Public pagination post ${i}`,
+          published: timestamp,
+        });
+        posts.push(post);
+      }
+      const orderedPosts = [...posts].sort((a, b) => b.id.localeCompare(a.id));
+
+      const firstPage = await execute({
+        schema,
+        document: publicTimelineQuery,
+        variableValues: { first: 2 },
+        contextValue: makeUserContext(tx, author.account),
+        onError: "NO_PROPAGATE",
+      });
+      assertEquals(firstPage.errors, undefined);
+      const firstConnection = (firstPage.data as {
+        publicTimeline: {
+          pageInfo: {
+            hasNextPage: boolean;
+            hasPreviousPage: boolean;
+            endCursor: string;
+          };
+          edges: { cursor: string; node: { id: string } }[];
+        };
+      }).publicTimeline;
+      assertEquals(firstConnection.pageInfo.hasNextPage, true);
+      assertEquals(firstConnection.pageInfo.hasPreviousPage, false);
+      assertEquals(firstConnection.edges.map((edge) => edge.node.id), [
+        encodeGlobalID("Note", orderedPosts[0].id),
+        encodeGlobalID("Note", orderedPosts[1].id),
+      ]);
+
+      const secondPage = await execute({
+        schema,
+        document: publicTimelineQuery,
+        variableValues: {
+          first: 2,
+          after: firstConnection.pageInfo.endCursor,
+        },
+        contextValue: makeUserContext(tx, author.account),
+        onError: "NO_PROPAGATE",
+      });
+      assertEquals(secondPage.errors, undefined);
+      const secondConnection = (secondPage.data as {
+        publicTimeline: {
+          pageInfo: {
+            hasNextPage: boolean;
+            hasPreviousPage: boolean;
+            endCursor: string;
+          };
+          edges: { cursor: string; node: { id: string } }[];
+        };
+      }).publicTimeline;
+      assertEquals(secondConnection.pageInfo.hasNextPage, false);
+      assertEquals(secondConnection.pageInfo.hasPreviousPage, true);
+      assertEquals(secondConnection.edges.map((edge) => edge.node.id), [
+        encodeGlobalID("Note", orderedPosts[2].id),
+        encodeGlobalID("Note", orderedPosts[3].id),
+      ]);
+
+      const backwardPage = await execute({
+        schema,
+        document: publicTimelineQuery,
+        variableValues: {
+          last: 2,
+          before: secondConnection.pageInfo.endCursor,
+        },
+        contextValue: makeUserContext(tx, author.account),
+        onError: "NO_PROPAGATE",
+      });
+      assertEquals(backwardPage.errors, undefined);
+      const backwardConnection = (backwardPage.data as {
+        publicTimeline: {
+          pageInfo: { hasNextPage: boolean; hasPreviousPage: boolean };
+          edges: { node: { id: string } }[];
+        };
+      }).publicTimeline;
+      assertEquals(backwardConnection.pageInfo.hasNextPage, true);
+      assertEquals(backwardConnection.pageInfo.hasPreviousPage, true);
+      assertEquals(backwardConnection.edges.map((edge) => edge.node.id), [
+        encodeGlobalID("Note", orderedPosts[1].id),
+        encodeGlobalID("Note", orderedPosts[2].id),
       ]);
     });
   },
@@ -244,6 +405,244 @@ Deno.test({
         }).personalTimeline.edges,
         [],
       );
+    });
+  },
+});
+
+Deno.test({
+  name: "personalTimeline supports forward and backward cursor pagination",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  async fn() {
+    await withRollback(async (tx) => {
+      const fedCtx = createFedCtx(tx);
+      const viewer = await insertAccountWithActor(tx, {
+        username: "graphqlpersonalpaginationviewer",
+        name: "GraphQL Personal Pagination Viewer",
+        email: "graphqlpersonalpaginationviewer@example.com",
+      });
+      const sharer = await insertAccountWithActor(tx, {
+        username: "graphqlpersonalpaginationsharer",
+        name: "GraphQL Personal Pagination Sharer",
+        email: "graphqlpersonalpaginationsharer@example.com",
+      });
+      const remoteActor = await insertRemoteActor(tx, {
+        username: "graphqlpersonalpaginationremote",
+        name: "GraphQL Personal Pagination Remote",
+        host: "personal-pagination.example",
+      });
+
+      await follow(fedCtx, viewer.account, sharer.actor);
+
+      const posts = [];
+      const timestamp = new Date("2026-04-15T00:01:00.000Z");
+      for (let i = 1; i <= 4; i++) {
+        const remotePost = await insertRemotePost(tx, {
+          actorId: remoteActor.id,
+          contentHtml: `<p>Personal pagination post ${i}</p>`,
+          published: timestamp,
+        });
+        const share = await sharePost(fedCtx, sharer.account, {
+          ...remotePost,
+          actor: remoteActor,
+        });
+        await tx.update(postTable)
+          .set({ published: timestamp, updated: timestamp })
+          .where(eq(postTable.id, share.id));
+        await tx.update(timelineItemTable)
+          .set({ appended: timestamp })
+          .where(
+            and(
+              eq(timelineItemTable.accountId, viewer.account.id),
+              eq(timelineItemTable.postId, remotePost.id),
+            ),
+          );
+        posts.push(remotePost);
+      }
+      const orderedPosts = [...posts].sort((a, b) => b.id.localeCompare(a.id));
+
+      const firstPage = await execute({
+        schema,
+        document: personalTimelineQuery,
+        variableValues: { first: 2 },
+        contextValue: makeUserContext(tx, viewer.account),
+        onError: "NO_PROPAGATE",
+      });
+      assertEquals(firstPage.errors, undefined);
+      const firstConnection = (firstPage.data as {
+        personalTimeline: {
+          pageInfo: { hasNextPage: boolean; endCursor: string };
+          edges: { node: { id: string } }[];
+        };
+      }).personalTimeline;
+      assertEquals(firstConnection.pageInfo.hasNextPage, true);
+      assertEquals(firstConnection.edges.map((edge) => edge.node.id), [
+        encodeGlobalID("Note", orderedPosts[0].id),
+        encodeGlobalID("Note", orderedPosts[1].id),
+      ]);
+
+      const secondPage = await execute({
+        schema,
+        document: personalTimelineQuery,
+        variableValues: {
+          first: 2,
+          after: firstConnection.pageInfo.endCursor,
+        },
+        contextValue: makeUserContext(tx, viewer.account),
+        onError: "NO_PROPAGATE",
+      });
+      assertEquals(secondPage.errors, undefined);
+      const secondConnection = (secondPage.data as {
+        personalTimeline: {
+          pageInfo: {
+            hasNextPage: boolean;
+            hasPreviousPage: boolean;
+            endCursor: string;
+          };
+          edges: { node: { id: string } }[];
+        };
+      }).personalTimeline;
+      assertEquals(secondConnection.pageInfo.hasNextPage, false);
+      assertEquals(secondConnection.pageInfo.hasPreviousPage, true);
+      assertEquals(secondConnection.edges.map((edge) => edge.node.id), [
+        encodeGlobalID("Note", orderedPosts[2].id),
+        encodeGlobalID("Note", orderedPosts[3].id),
+      ]);
+
+      const backwardPage = await execute({
+        schema,
+        document: personalTimelineQuery,
+        variableValues: {
+          last: 2,
+          before: secondConnection.pageInfo.endCursor,
+        },
+        contextValue: makeUserContext(tx, viewer.account),
+        onError: "NO_PROPAGATE",
+      });
+      assertEquals(backwardPage.errors, undefined);
+      const backwardConnection = (backwardPage.data as {
+        personalTimeline: {
+          pageInfo: { hasNextPage: boolean; hasPreviousPage: boolean };
+          edges: { node: { id: string } }[];
+        };
+      }).personalTimeline;
+      assertEquals(backwardConnection.pageInfo.hasNextPage, true);
+      assertEquals(backwardConnection.pageInfo.hasPreviousPage, true);
+      assertEquals(backwardConnection.edges.map((edge) => edge.node.id), [
+        encodeGlobalID("Note", orderedPosts[1].id),
+        encodeGlobalID("Note", orderedPosts[2].id),
+      ]);
+    });
+  },
+});
+
+Deno.test({
+  name: "bookmarks supports forward and backward cursor pagination",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  async fn() {
+    await withRollback(async (tx) => {
+      const viewer = await insertAccountWithActor(tx, {
+        username: "graphqlbookmarkpaginationviewer",
+        name: "GraphQL Bookmark Pagination Viewer",
+        email: "graphqlbookmarkpaginationviewer@example.com",
+      });
+      const author = await insertAccountWithActor(tx, {
+        username: "graphqlbookmarkpaginationauthor",
+        name: "GraphQL Bookmark Pagination Author",
+        email: "graphqlbookmarkpaginationauthor@example.com",
+      });
+
+      const posts = [];
+      for (let i = 1; i <= 4; i++) {
+        const { post } = await insertNotePost(tx, {
+          account: author.account,
+          content: `Bookmark pagination post ${i}`,
+          published: new Date(`2026-04-15T00:00:0${i}.000Z`),
+        });
+        await createBookmark(tx, viewer.account, post);
+        await tx.update(bookmarkTable)
+          .set({ created: new Date(`2026-04-15T00:02:0${i}.000Z`) })
+          .where(
+            and(
+              eq(bookmarkTable.accountId, viewer.account.id),
+              eq(bookmarkTable.postId, post.id),
+            ),
+          );
+        posts.push(post);
+      }
+
+      const firstPage = await execute({
+        schema,
+        document: bookmarksQuery,
+        variableValues: { first: 2 },
+        contextValue: makeUserContext(tx, viewer.account),
+        onError: "NO_PROPAGATE",
+      });
+      assertEquals(firstPage.errors, undefined);
+      const firstConnection = (firstPage.data as {
+        bookmarks: {
+          pageInfo: { hasNextPage: boolean; endCursor: string };
+          edges: { node: { id: string } }[];
+        };
+      }).bookmarks;
+      assertEquals(firstConnection.pageInfo.hasNextPage, true);
+      assertEquals(firstConnection.edges.map((edge) => edge.node.id), [
+        encodeGlobalID("Note", posts[3].id),
+        encodeGlobalID("Note", posts[2].id),
+      ]);
+
+      const secondPage = await execute({
+        schema,
+        document: bookmarksQuery,
+        variableValues: {
+          first: 2,
+          after: firstConnection.pageInfo.endCursor,
+        },
+        contextValue: makeUserContext(tx, viewer.account),
+        onError: "NO_PROPAGATE",
+      });
+      assertEquals(secondPage.errors, undefined);
+      const secondConnection = (secondPage.data as {
+        bookmarks: {
+          pageInfo: {
+            hasNextPage: boolean;
+            hasPreviousPage: boolean;
+            endCursor: string;
+          };
+          edges: { node: { id: string } }[];
+        };
+      }).bookmarks;
+      assertEquals(secondConnection.pageInfo.hasNextPage, false);
+      assertEquals(secondConnection.pageInfo.hasPreviousPage, true);
+      assertEquals(secondConnection.edges.map((edge) => edge.node.id), [
+        encodeGlobalID("Note", posts[1].id),
+        encodeGlobalID("Note", posts[0].id),
+      ]);
+
+      const backwardPage = await execute({
+        schema,
+        document: bookmarksQuery,
+        variableValues: {
+          last: 2,
+          before: secondConnection.pageInfo.endCursor,
+        },
+        contextValue: makeUserContext(tx, viewer.account),
+        onError: "NO_PROPAGATE",
+      });
+      assertEquals(backwardPage.errors, undefined);
+      const backwardConnection = (backwardPage.data as {
+        bookmarks: {
+          pageInfo: { hasNextPage: boolean; hasPreviousPage: boolean };
+          edges: { node: { id: string } }[];
+        };
+      }).bookmarks;
+      assertEquals(backwardConnection.pageInfo.hasNextPage, true);
+      assertEquals(backwardConnection.pageInfo.hasPreviousPage, true);
+      assertEquals(backwardConnection.edges.map((edge) => edge.node.id), [
+        encodeGlobalID("Note", posts[2].id),
+        encodeGlobalID("Note", posts[1].id),
+      ]);
     });
   },
 });

--- a/graphql/timeline.ts
+++ b/graphql/timeline.ts
@@ -4,8 +4,11 @@ import {
   getBookmarks,
 } from "@hackerspub/models/bookmark";
 import {
+  formatTimelineCursor,
   getPersonalTimeline,
   getPublicTimeline,
+  parseTimelineCursor,
+  type TimelineCursor,
 } from "@hackerspub/models/timeline";
 import { type Uuid, validateUuid } from "@hackerspub/models/uuid";
 import { assertNever } from "@std/assert/unstable-never";
@@ -39,8 +42,54 @@ function parseBookmarkCursor(raw: string): BookmarkCursor | undefined {
   return { created, postId: postId as Uuid };
 }
 
+function parseRequiredBookmarkCursor(raw: string): BookmarkCursor {
+  const cursor = parseBookmarkCursor(raw);
+  if (cursor == null) {
+    throw createGraphQLError("Invalid bookmark cursor.", {
+      extensions: { code: "INVALID_CURSOR" },
+    });
+  }
+  return cursor;
+}
+
+function parseRequiredTimelineCursor(raw: string): TimelineCursor {
+  const cursor = parseTimelineCursor(raw);
+  if (cursor == null) {
+    throw createGraphQLError("Invalid timeline cursor.", {
+      extensions: { code: "INVALID_CURSOR" },
+    });
+  }
+  return cursor;
+}
+
 function formatBookmarkCursor(entry: BookmarkEntry): string {
   return `${entry.bookmarked.toISOString()}|${entry.post.id}`;
+}
+
+function getTimelineWindow(
+  args: { first?: number | null; last?: number | null },
+): number {
+  if (args.first != null && args.last != null) {
+    throw createGraphQLError("Cannot paginate with both first and last.", {
+      extensions: { code: "PAGINATION_ERROR" },
+    });
+  }
+  return args.last ?? args.first ?? 25;
+}
+
+function conflictingCursors(): never {
+  throw createGraphQLError("Cannot paginate with both after and before.", {
+    extensions: { code: "PAGINATION_ERROR" },
+  });
+}
+
+function getConnectionPage<T>(
+  entries: readonly T[],
+  window: number,
+  backwards: boolean,
+): T[] {
+  const page = entries.slice(0, window);
+  return backwards ? [...page].reverse() : page;
 }
 
 builder.queryFields((t) => ({
@@ -60,13 +109,20 @@ builder.queryFields((t) => ({
         }),
       },
       async resolve(_, args, ctx) {
-        if (args.last != null || args.before != null) {
-          throw new Error("Backward pagination is not supported.");
+        if (args.after != null && args.before != null) {
+          conflictingCursors();
         }
-        const window = args.first ?? 25;
-        const until = args.after == null ? undefined : new Date(args.after);
+        const backwards = args.last != null;
+        const window = getTimelineWindow(args);
+        const since = args.before == null
+          ? undefined
+          : parseRequiredTimelineCursor(args.before);
+        const until = args.after == null
+          ? undefined
+          : parseRequiredTimelineCursor(args.after);
         const timeline = await getPublicTimeline(ctx.db, {
           currentAccount: ctx.account,
+          direction: backwards ? "backward" : "forward",
           languages: new Set(
             (args.languages ?? []).flatMap((l) =>
               l.language !== l.baseName
@@ -86,25 +142,30 @@ builder.queryFields((t) => ({
             ? "Question"
             : assertNever(args.postType),
           window: window + 1,
+          since,
           until,
         });
+        const pageEntries = getConnectionPage(timeline, window, backwards);
         return {
           pageInfo: {
-            hasNextPage: timeline.length > window,
-            hasPreviousPage: false,
-            startCursor: timeline.length < 2
+            hasNextPage: backwards
+              ? args.before != null && timeline.length > window
+              : timeline.length > window,
+            hasPreviousPage: backwards
+              ? timeline.length > window
+              : args.after != null,
+            startCursor: pageEntries.length < 1
               ? null
-              : timeline[1].added.toISOString(),
-            endCursor: timeline.length < 2
+              : formatTimelineCursor(pageEntries[0]),
+            endCursor: pageEntries.length < 1
               ? null
-              : timeline.at(-1)!.added.toISOString(),
+              : formatTimelineCursor(pageEntries[pageEntries.length - 1]),
           },
-          edges: timeline.slice(0, window).map((
-            { post, lastSharer, sharersCount, added },
-            i,
+          edges: pageEntries.map((
+            { post, lastSharer, sharersCount, added, cursor },
           ) => ({
             node: post,
-            cursor: timeline[i + 1]?.added?.toISOString() ?? "",
+            cursor: formatTimelineCursor({ post, cursor }),
             lastSharer,
             sharersCount,
             added,
@@ -133,15 +194,20 @@ builder.queryFields((t) => ({
     async resolve(_, args, ctx) {
       if (ctx.account == null) {
         authenticationRequired();
-      } else if (args.last != null || args.before != null) {
-        throw new Error("Backward pagination is not supported.");
+      } else if (args.after != null && args.before != null) {
+        conflictingCursors();
       }
-      const window = args.first ?? 25;
+      const backwards = args.last != null;
+      const window = getTimelineWindow(args);
+      const since = args.before == null
+        ? undefined
+        : parseRequiredBookmarkCursor(args.before);
       const until = args.after == null
         ? undefined
-        : parseBookmarkCursor(args.after);
+        : parseRequiredBookmarkCursor(args.after);
       const bookmarks = await getBookmarks(ctx.db, {
         account: ctx.account,
+        direction: backwards ? "backward" : "forward",
         postType: args.postType == null
           ? undefined
           : args.postType === "ARTICLE"
@@ -152,13 +218,18 @@ builder.queryFields((t) => ({
           ? "Question"
           : assertNever(args.postType),
         window: window + 1,
+        since,
         until,
       });
-      const pageEntries = bookmarks.slice(0, window);
+      const pageEntries = getConnectionPage(bookmarks, window, backwards);
       return {
         pageInfo: {
-          hasNextPage: bookmarks.length > window,
-          hasPreviousPage: false,
+          hasNextPage: backwards
+            ? args.before != null && bookmarks.length > window
+            : bookmarks.length > window,
+          hasPreviousPage: backwards
+            ? bookmarks.length > window
+            : args.after != null,
           startCursor: pageEntries.length < 1
             ? null
             : formatBookmarkCursor(pageEntries[0]),
@@ -188,13 +259,20 @@ builder.queryFields((t) => ({
       async resolve(_, args, ctx) {
         if (ctx.account == null) {
           authenticationRequired();
-        } else if (args.last != null || args.before != null) {
-          throw new Error("Backward pagination is not supported.");
+        } else if (args.after != null && args.before != null) {
+          conflictingCursors();
         }
-        const window = args.first ?? 25;
-        const until = args.after == null ? undefined : new Date(args.after);
+        const backwards = args.last != null;
+        const window = getTimelineWindow(args);
+        const since = args.before == null
+          ? undefined
+          : parseRequiredTimelineCursor(args.before);
+        const until = args.after == null
+          ? undefined
+          : parseRequiredTimelineCursor(args.after);
         const timeline = await getPersonalTimeline(ctx.db, {
           currentAccount: ctx.account,
+          direction: backwards ? "backward" : "forward",
           local: args.local ?? false,
           withoutShares: args.withoutShares ?? false,
           postType: args.postType == null
@@ -207,25 +285,30 @@ builder.queryFields((t) => ({
             ? "Question"
             : assertNever(args.postType),
           window: window + 1,
+          since,
           until,
         });
+        const pageEntries = getConnectionPage(timeline, window, backwards);
         return {
           pageInfo: {
-            hasNextPage: timeline.length > window,
-            hasPreviousPage: false,
-            startCursor: timeline.length < 2
+            hasNextPage: backwards
+              ? args.before != null && timeline.length > window
+              : timeline.length > window,
+            hasPreviousPage: backwards
+              ? timeline.length > window
+              : args.after != null,
+            startCursor: pageEntries.length < 1
               ? null
-              : timeline[1].added.toISOString(),
-            endCursor: timeline.length < 2
+              : formatTimelineCursor(pageEntries[0]),
+            endCursor: pageEntries.length < 1
               ? null
-              : timeline.at(-1)!.added.toISOString(),
+              : formatTimelineCursor(pageEntries[pageEntries.length - 1]),
           },
-          edges: timeline.slice(0, window).map((
-            { post, lastSharer, sharersCount, added },
-            i,
+          edges: pageEntries.map((
+            { post, lastSharer, sharersCount, added, cursor },
           ) => ({
             node: post,
-            cursor: timeline[i + 1]?.added?.toISOString() ?? "",
+            cursor: formatTimelineCursor({ post, cursor }),
             lastSharer,
             sharersCount,
             added,

--- a/models/bookmark.ts
+++ b/models/bookmark.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, inArray, lt, or } from "drizzle-orm";
+import { and, asc, desc, eq, gt, inArray, lt, or } from "drizzle-orm";
 import type { Database } from "./db.ts";
 import {
   type Account,
@@ -68,7 +68,9 @@ export interface BookmarkCursor {
 
 export interface BookmarkListOptions {
   readonly account: Account;
+  readonly direction?: "backward" | "forward";
   readonly postType?: PostType;
+  readonly since?: BookmarkCursor;
   readonly until?: BookmarkCursor;
   readonly window: number;
 }
@@ -80,7 +82,14 @@ export interface BookmarkEntry {
 
 export async function getBookmarks(
   db: Database,
-  { account, postType, until, window }: BookmarkListOptions,
+  {
+    account,
+    direction = "forward",
+    postType,
+    since,
+    until,
+    window,
+  }: BookmarkListOptions,
 ): Promise<BookmarkEntry[]> {
   const rows = await db
     .select({
@@ -93,6 +102,13 @@ export async function getBookmarks(
       and(
         eq(bookmarkTable.accountId, account.id),
         postType == null ? undefined : eq(postTable.type, postType),
+        since == null ? undefined : or(
+          gt(bookmarkTable.created, since.created),
+          and(
+            eq(bookmarkTable.created, since.created),
+            gt(bookmarkTable.postId, since.postId),
+          ),
+        ),
         until == null ? undefined : or(
           lt(bookmarkTable.created, until.created),
           and(
@@ -102,7 +118,14 @@ export async function getBookmarks(
         ),
       ),
     )
-    .orderBy(desc(bookmarkTable.created), desc(bookmarkTable.postId))
+    .orderBy(
+      direction === "backward"
+        ? asc(bookmarkTable.created)
+        : desc(bookmarkTable.created),
+      direction === "backward"
+        ? asc(bookmarkTable.postId)
+        : desc(bookmarkTable.postId),
+    )
     .limit(window);
   return rows.map((row) => ({
     post: row.post,

--- a/models/timeline.query.test.ts
+++ b/models/timeline.query.test.ts
@@ -1,9 +1,9 @@
 import { assertEquals } from "@std/assert/equals";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { follow } from "./following.ts";
 import { sharePost } from "./post.ts";
 import { getPersonalTimeline, getPublicTimeline } from "./timeline.ts";
-import { postTable } from "./schema.ts";
+import { postTable, timelineItemTable } from "./schema.ts";
 import {
   createFedCtx,
   insertAccountWithActor,
@@ -96,6 +96,52 @@ Deno.test({
 });
 
 Deno.test({
+  name: "getPublicTimeline() uses exclusive cursors without gaps",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  async fn() {
+    await withRollback(async (tx) => {
+      const author = await insertAccountWithActor(tx, {
+        username: "publiccursorauthor",
+        name: "Public Cursor Author",
+        email: "publiccursorauthor@example.com",
+      });
+      const posts = [];
+      const timestamp = new Date("2026-04-15T00:00:01.000Z");
+      for (let i = 1; i <= 4; i++) {
+        const { post } = await insertNotePost(tx, {
+          account: author.account,
+          content: `Public cursor post ${i}`,
+          published: timestamp,
+        });
+        posts.push(post);
+      }
+      const orderedPosts = [...posts].sort((a, b) => b.id.localeCompare(a.id));
+
+      const firstPage = await getPublicTimeline(tx, { window: 3 });
+      assertEquals(firstPage.map((entry) => entry.post.id), [
+        orderedPosts[0].id,
+        orderedPosts[1].id,
+        orderedPosts[2].id,
+      ]);
+
+      const nextCursor = {
+        timestamp: firstPage[1].cursor,
+        postId: firstPage[1].post.id,
+      };
+      const secondPage = await getPublicTimeline(tx, {
+        until: nextCursor,
+        window: 2,
+      });
+      assertEquals(secondPage.map((entry) => entry.post.id), [
+        orderedPosts[2].id,
+        orderedPosts[3].id,
+      ]);
+    });
+  },
+});
+
+Deno.test({
   name: "getPersonalTimeline() hides pure shares when withoutShares is enabled",
   sanitizeOps: false,
   sanitizeResources: false,
@@ -150,6 +196,85 @@ Deno.test({
         window: 10,
       });
       assertEquals(withoutShares, []);
+    });
+  },
+});
+
+Deno.test({
+  name: "getPersonalTimeline() uses appended cursors without gaps",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  async fn() {
+    await withRollback(async (tx) => {
+      const fedCtx = createFedCtx(tx);
+      const viewer = await insertAccountWithActor(tx, {
+        username: "personalcursorviewer",
+        name: "Personal Cursor Viewer",
+        email: "personalcursorviewer@example.com",
+      });
+      const sharer = await insertAccountWithActor(tx, {
+        username: "personalcursorsharer",
+        name: "Personal Cursor Sharer",
+        email: "personalcursorsharer@example.com",
+      });
+      const remoteActor = await insertRemoteActor(tx, {
+        username: "personalcursorremote",
+        name: "Personal Cursor Remote",
+        host: "personal-cursor.example",
+      });
+
+      await follow(fedCtx, viewer.account, sharer.actor);
+
+      const posts = [];
+      const timestamp = new Date("2026-04-15T00:01:00.000Z");
+      for (let i = 1; i <= 4; i++) {
+        const remotePost = await insertRemotePost(tx, {
+          actorId: remoteActor.id,
+          contentHtml: `<p>Personal cursor post ${i}</p>`,
+          published: timestamp,
+        });
+        const share = await sharePost(fedCtx, sharer.account, {
+          ...remotePost,
+          actor: remoteActor,
+        });
+        await tx.update(postTable)
+          .set({ published: timestamp, updated: timestamp })
+          .where(eq(postTable.id, share.id));
+        await tx.update(timelineItemTable)
+          .set({ appended: timestamp })
+          .where(
+            and(
+              eq(timelineItemTable.accountId, viewer.account.id),
+              eq(timelineItemTable.postId, remotePost.id),
+            ),
+          );
+        posts.push(remotePost);
+      }
+      const orderedPosts = [...posts].sort((a, b) => b.id.localeCompare(a.id));
+
+      const firstPage = await getPersonalTimeline(tx, {
+        currentAccount: viewer.account,
+        window: 3,
+      });
+      assertEquals(firstPage.map((entry) => entry.post.id), [
+        orderedPosts[0].id,
+        orderedPosts[1].id,
+        orderedPosts[2].id,
+      ]);
+
+      const nextCursor = {
+        timestamp: firstPage[1].cursor,
+        postId: firstPage[1].post.id,
+      };
+      const secondPage = await getPersonalTimeline(tx, {
+        currentAccount: viewer.account,
+        until: nextCursor,
+        window: 2,
+      });
+      assertEquals(secondPage.map((entry) => entry.post.id), [
+        orderedPosts[2].id,
+        orderedPosts[3].id,
+      ]);
     });
   },
 });

--- a/models/timeline.ts
+++ b/models/timeline.ts
@@ -23,6 +23,7 @@ import {
   type Reaction,
   timelineItemTable,
 } from "./schema.ts";
+import { type Uuid, validateUuid } from "./uuid.ts";
 
 export const FUTURE_TIMESTAMP_TOLERANCE = (() => {
   const envValue = process.env.FUTURE_TIMESTAMP_TOLERANCE;
@@ -268,13 +269,43 @@ export interface TimelineEntry {
   lastSharer: Actor | null;
   sharersCount: number;
   added: Date;
+  cursor: Date;
+}
+
+export interface TimelineCursor {
+  readonly timestamp: Date;
+  readonly postId?: Uuid;
+}
+
+export function parseTimelineCursor(raw: string): TimelineCursor | undefined {
+  const separatorIndex = raw.indexOf("|");
+  if (separatorIndex < 0) {
+    const timestamp = raw.match(/^\d+(\.\d+)?$/)
+      ? new Date(parseInt(raw, 10))
+      : new Date(raw);
+    return isNaN(timestamp.getTime()) ? undefined : { timestamp };
+  }
+
+  const timestamp = new Date(raw.slice(0, separatorIndex));
+  const postId = raw.slice(separatorIndex + 1);
+  if (isNaN(timestamp.getTime())) return undefined;
+  if (!validateUuid(postId)) return undefined;
+  return { timestamp, postId };
+}
+
+export function formatTimelineCursor(
+  entry: Pick<TimelineEntry, "cursor" | "post">,
+): string {
+  return `${entry.cursor.toISOString()}|${entry.post.id}`;
 }
 
 export interface TimelineOptions {
+  readonly direction?: "backward" | "forward";
   readonly local?: boolean;
   readonly withoutShares?: boolean;
   readonly postType?: PostType;
-  readonly until?: Date;
+  readonly since?: TimelineCursor;
+  readonly until?: TimelineCursor;
   readonly window?: number;
 }
 
@@ -283,19 +314,80 @@ export interface PublicTimelineOptions extends TimelineOptions {
   readonly languages?: Set<string>;
 }
 
+function getPostCursorFilter(
+  cursor: TimelineCursor,
+  boundary: "newer" | "older",
+) {
+  const timestamp = cursor.timestamp.toISOString();
+  if (cursor.postId == null) {
+    return {
+      RAW: (post: typeof postTable) =>
+        boundary === "newer"
+          ? sql`${post.published}::timestamptz(3) > ${timestamp}::timestamptz(3)`
+          : sql`${post.published}::timestamptz(3) < ${timestamp}::timestamptz(3)`,
+    };
+  }
+
+  const postId = cursor.postId;
+  return {
+    RAW: (post: typeof postTable) =>
+      boundary === "newer"
+        ? sql`(${post.published}::timestamptz(3) > ${timestamp}::timestamptz(3) OR (${post.published}::timestamptz(3) = ${timestamp}::timestamptz(3) AND ${post.id} > ${postId}::uuid))`
+        : sql`(${post.published}::timestamptz(3) < ${timestamp}::timestamptz(3) OR (${post.published}::timestamptz(3) = ${timestamp}::timestamptz(3) AND ${post.id} < ${postId}::uuid))`,
+  };
+}
+
+function getTimelineItemCursorFilter(
+  cursor: TimelineCursor,
+  useAddedColumn: boolean,
+  boundary: "newer" | "older",
+) {
+  const timestamp = cursor.timestamp.toISOString();
+  if (cursor.postId == null) {
+    return {
+      RAW: (timelineItem: typeof timelineItemTable) => {
+        const cursorColumn = useAddedColumn
+          ? timelineItem.added
+          : timelineItem.appended;
+        return boundary === "newer"
+          ? sql`${cursorColumn}::timestamptz(3) > ${timestamp}::timestamptz(3)`
+          : sql`${cursorColumn}::timestamptz(3) < ${timestamp}::timestamptz(3)`;
+      },
+    };
+  }
+
+  const postId = cursor.postId;
+  return {
+    RAW: (timelineItem: typeof timelineItemTable) => {
+      const cursorColumn = useAddedColumn
+        ? timelineItem.added
+        : timelineItem.appended;
+      return boundary === "newer"
+        ? sql`(${cursorColumn}::timestamptz(3) > ${timestamp}::timestamptz(3) OR (${cursorColumn}::timestamptz(3) = ${timestamp}::timestamptz(3) AND ${timelineItem.postId} > ${postId}::uuid))`
+        : sql`(${cursorColumn}::timestamptz(3) < ${timestamp}::timestamptz(3) OR (${cursorColumn}::timestamptz(3) = ${timestamp}::timestamptz(3) AND ${timelineItem.postId} < ${postId}::uuid))`;
+    },
+  };
+}
+
 export async function getPublicTimeline(
   db: Database,
   {
     currentAccount,
+    direction = "forward",
     languages = new Set(),
     local = false,
     withoutShares = false,
     postType,
+    since,
     until,
     window,
   }: PublicTimelineOptions,
 ): Promise<TimelineEntry[]> {
   const futureTimestampLimit = getFutureTimestampLimit();
+  const cursorFilters = [
+    since == null ? undefined : getPostCursorFilter(since, "newer"),
+    until == null ? undefined : getPostCursorFilter(until, "older"),
+  ].filter((filter) => filter != null);
   const posts = await db.query.postTable.findMany({
     with: {
       actor: {
@@ -492,6 +584,7 @@ export async function getPublicTimeline(
     where: {
       AND: [
         getPublicTimelineVisibilityFilter(currentAccount?.actor ?? null),
+        ...cursorFilters,
         {
           ...(
             languages.size < 1
@@ -520,11 +613,17 @@ export async function getPublicTimeline(
           ),
           ...(withoutShares ? { sharedPostId: { isNull: true } } : undefined),
           ...(postType == null ? undefined : { type: postType }),
-          published: { lte: until == null ? futureTimestampLimit : until },
+          published: { lte: futureTimestampLimit },
         },
       ],
     },
-    orderBy: { published: "desc" },
+    orderBy: (post, { asc, desc }) => {
+      const cursorTimestamp = sql<Date>`${post.published}::timestamptz(3)`;
+      return [
+        direction === "backward" ? asc(cursorTimestamp) : desc(cursorTimestamp),
+        direction === "backward" ? asc(post.id) : desc(post.id),
+      ];
+    },
     limit: window,
   });
   return posts.map((post) => ({
@@ -532,6 +631,7 @@ export async function getPublicTimeline(
     lastSharer: null,
     sharersCount: 0,
     added: post.published,
+    cursor: post.published,
   }));
 }
 
@@ -543,14 +643,24 @@ export async function getPersonalTimeline(
   db: Database,
   {
     currentAccount,
+    direction = "forward",
     local = false,
     withoutShares = false,
     postType,
+    since,
     until,
     window,
   }: PersonalTimelineOptions,
 ): Promise<TimelineEntry[]> {
   const futureTimestampLimit = getFutureTimestampLimit();
+  const cursorFilters = [
+    since == null
+      ? undefined
+      : getTimelineItemCursorFilter(since, withoutShares, "newer"),
+    until == null
+      ? undefined
+      : getTimelineItemCursorFilter(until, withoutShares, "older"),
+  ].filter((filter) => filter != null);
   const timeline = await db.query.timelineItemTable.findMany({
     with: {
       post: {
@@ -713,6 +823,7 @@ export async function getPersonalTimeline(
     },
     where: {
       accountId: currentAccount.id,
+      ...(cursorFilters.length < 1 ? {} : { AND: cursorFilters }),
       post: {
         AND: [
           getPostVisibilityFilter(currentAccount.actor),
@@ -736,15 +847,24 @@ export async function getPersonalTimeline(
         ],
       },
       ...(withoutShares ? { originalAuthorId: { isNotNull: true } } : {}),
-      ...(until == null ? undefined : { added: { lte: until } }),
     },
-    orderBy: withoutShares ? { added: "desc" } : { appended: "desc" },
+    orderBy: (timelineItem, { asc, desc }) => {
+      const cursorTimestamp = withoutShares
+        ? sql<Date>`${timelineItem.added}::timestamptz(3)`
+        : sql<Date>`${timelineItem.appended}::timestamptz(3)`;
+      return [
+        direction === "backward" ? asc(cursorTimestamp) : desc(cursorTimestamp),
+        direction === "backward"
+          ? asc(timelineItem.postId)
+          : desc(timelineItem.postId),
+      ];
+    },
     limit: window,
   });
-  if (!withoutShares) return timeline;
   return timeline.map((item) => ({
     ...item,
-    lastSharer: null,
-    lastSharerId: null,
+    cursor: withoutShares ? item.added : item.appended,
+    lastSharer: withoutShares ? null : item.lastSharer,
+    lastSharerId: withoutShares ? null : item.lastSharerId,
   }));
 }

--- a/web/routes/index.tsx
+++ b/web/routes/index.tsx
@@ -14,8 +14,10 @@ import type {
   Reaction,
 } from "@hackerspub/models/schema";
 import {
+  formatTimelineCursor,
   getPersonalTimeline,
   getPublicTimeline,
+  parseTimelineCursor,
   type TimelineEntry,
 } from "@hackerspub/models/timeline";
 import { getLogger } from "@logtape/logtape";
@@ -58,13 +60,15 @@ export const handler = define.handlers({
       filter = ctx.state.account == null ? "fediverse" : "feed";
     }
     const untilString = ctx.url.searchParams.get("until");
-    const until = untilString == null || !untilString.match(/^\d+(\.\d+)?$/)
+    const until = untilString == null
       ? undefined
-      : new Date(parseInt(untilString));
+      : parseTimelineCursor(untilString);
     const windowString = ctx.url.searchParams.get("window");
-    const window = windowString == null || !windowString.match(/^\d+$/)
+    const requestedWindow = windowString == null ||
+        !windowString.match(/^\d+$/)
       ? defaultWindow
       : parseInt(windowString);
+    const window = requestedWindow < 1 ? defaultWindow : requestedWindow;
     let timeline: TimelineEntry[];
     const languages = new Set<string>(
       acceptsLanguages(ctx.req)
@@ -100,9 +104,9 @@ export const handler = define.handlers({
           window: window + 1,
         });
     }
-    let next: Date | undefined = undefined;
+    let next: string | undefined = undefined;
     if (timeline.length > window) {
-      next = timeline[window].added;
+      next = formatTimelineCursor(timeline[window - 1]);
       timeline = timeline.slice(0, window);
     }
     const recommendedActors = next == null || filter === "recommendations"
@@ -229,8 +233,9 @@ interface HomeProps {
     lastSharer: Actor | null;
     sharersCount: number;
     added: Date;
+    cursor: Date;
   })[];
-  next?: Date;
+  next?: string;
   window: number;
   defaultWindow: number;
   recommendedActors: (Actor & { account?: Account | null })[];
@@ -242,8 +247,10 @@ export default define.page<typeof handler, HomeProps>(
     const nextHref = data.next == null
       ? undefined
       : data.window === data.defaultWindow
-      ? `?filter=${data.filter}&until=${+data.next}`
-      : `?filter=${data.filter}&until=${+data.next}&window=${data.window}`;
+      ? `?filter=${data.filter}&until=${encodeURIComponent(data.next)}`
+      : `?filter=${data.filter}&until=${
+        encodeURIComponent(data.next)
+      }&window=${data.window}`;
     return (
       <>
         {data.composer && (


### PR DESCRIPTION
This PR add bidirectional cursor pagination for public timeline, personal timeline, and bookmarks GraphQL connections. Also update the legacy web home timeline “next page” link to use the same stable cursor format., and add tests for forward and backward pagination across public, personal, and bookmark timelines.

This PR was assisted by Codex(GPT-5.5).