### PR TITLE
web-next: Sort, search, and header improvements for admin accounts table

### DIFF
--- a/graphql/admin.ts
+++ b/graphql/admin.ts
@@ -506,19 +506,17 @@ builder.queryField("adminAccounts", (t) =>
             )
             .leftJoin(
               inviteesSubq,
-              sql`${inviteesSubq.inviterId} = ${accountTable.id}`,
+              eq(inviteesSubq.inviterId, accountTable.id),
             )
             .where(and(beforeFilter, afterFilter, searchFilter))
             .orderBy(...orderByClause)
             .limit(limit);
 
           return rows.map((r) => {
-            // The COALESCE expression comes through as a raw string from
-            // postgres-js (no column type annotation on the expression).
-            const rawStr = r.lastActivityRaw as unknown;
-            const lastActivityRaw = rawStr instanceof Date
-              ? rawStr.toISOString()
-              : String(rawStr);
+            // lastActivityRaw and createdRaw are already formatted as UTC
+            // strings by the to_char() expressions in the SELECT above, so
+            // they are always strings, never Date objects.
+            const lastActivityRaw = String(r.lastActivityRaw);
             const rawAct = r.lastActivity as unknown;
             const lastActivity = rawAct instanceof Date
               ? rawAct
@@ -527,9 +525,7 @@ builder.queryField("adminAccounts", (t) =>
             const sortValRaw: string = orderBy === "LAST_ACTIVITY"
               ? lastActivityRaw
               : orderBy === "CREATED"
-              ? ((r.createdRaw as unknown) instanceof Date
-                ? (r.createdRaw as unknown as Date).toISOString()
-                : String(r.createdRaw))
+              ? String(r.createdRaw)
               : orderBy === "INVITATIONS_LEFT"
               ? String(r.account.leftInvitations)
               : orderBy === "FOLLOWING"

--- a/graphql/admin.ts
+++ b/graphql/admin.ts
@@ -375,25 +375,62 @@ builder.queryField("adminAccounts", (t) =>
         Date
       >`COALESCE(${postsSubq.maxPublished}, ${accountTable.updated})`;
 
-      // --- Sort expression for the chosen field ---
-      const sortExpr: SQL = orderBy === "FOLLOWING"
-        ? sql<number>`COALESCE(${followingSubq.count}, 0)`
-        : orderBy === "FOLLOWERS"
-        ? sql<number>`COALESCE(${followersSubq.count}, 0)`
-        : orderBy === "POSTS"
-        ? sql<number>`COALESCE(${postsSubq.count}, 0)`
-        : orderBy === "INVITATIONS_LEFT"
-        ? sql`${accountTable.leftInvitations}`
-        : orderBy === "INVITED"
-        ? sql<number>`COALESCE(${inviteesSubq.count}, 0)`
-        : orderBy === "CREATED"
-        ? sql`${accountTable.created}`
-        : lastActivityExpr; // LAST_ACTIVITY (default)
+      // --- Per-field sort definitions ---
+      // Each entry pairs the SQL expression used for ORDER BY / cursor filters
+      // with a function that extracts the raw cursor value from a result row.
+      // Keeping both together means adding a new sort field only requires one
+      // change here rather than two separate switch-like blocks.
+      interface SortRow {
+        lastActivityRaw: string;
+        createdRaw: unknown;
+        followingCount: number;
+        followersCount: number;
+        postsCount: number;
+        inviteesCount: number;
+        account: typeof accountTable.$inferSelect;
+      }
+      const sortFieldDefs: Record<
+        AdminOrderBy,
+        { expr: SQL; isTimestamp: boolean; extractVal: (r: SortRow) => string }
+      > = {
+        FOLLOWING: {
+          expr: sql<number>`COALESCE(${followingSubq.count}, 0)`,
+          isTimestamp: false,
+          extractVal: (r) => String(r.followingCount),
+        },
+        FOLLOWERS: {
+          expr: sql<number>`COALESCE(${followersSubq.count}, 0)`,
+          isTimestamp: false,
+          extractVal: (r) => String(r.followersCount),
+        },
+        POSTS: {
+          expr: sql<number>`COALESCE(${postsSubq.count}, 0)`,
+          isTimestamp: false,
+          extractVal: (r) => String(r.postsCount),
+        },
+        INVITATIONS_LEFT: {
+          expr: sql`${accountTable.leftInvitations}`,
+          isTimestamp: false,
+          extractVal: (r) => String(r.account.leftInvitations),
+        },
+        INVITED: {
+          expr: sql<number>`COALESCE(${inviteesSubq.count}, 0)`,
+          isTimestamp: false,
+          extractVal: (r) => String(r.inviteesCount),
+        },
+        LAST_ACTIVITY: {
+          expr: lastActivityExpr,
+          isTimestamp: true,
+          extractVal: (r) => r.lastActivityRaw,
+        },
+        CREATED: {
+          expr: sql`${accountTable.created}`,
+          isTimestamp: true,
+          extractVal: (r) => String(r.createdRaw),
+        },
+      };
 
-      // Timestamps need `::timestamptz` casts in cursor comparisons;
-      // integer fields use `::bigint`.
-      const isTimestamp = orderBy === "LAST_ACTIVITY" ||
-        orderBy === "CREATED";
+      const { expr: sortExpr, isTimestamp } = sortFieldDefs[orderBy];
 
       const [{ totalCount }] = await ctx.db
         .select({ totalCount: sql<number>`COUNT(*)::int` })
@@ -519,19 +556,15 @@ builder.queryField("adminAccounts", (t) =>
               ? rawAct
               : new Date(rawAct as string);
 
-            const sortValRaw: string = orderBy === "LAST_ACTIVITY"
-              ? lastActivityRaw
-              : orderBy === "CREATED"
-              ? String(r.createdRaw)
-              : orderBy === "INVITATIONS_LEFT"
-              ? String(r.account.leftInvitations)
-              : orderBy === "FOLLOWING"
-              ? String(r.followingCount)
-              : orderBy === "FOLLOWERS"
-              ? String(r.followersCount)
-              : orderBy === "POSTS"
-              ? String(r.postsCount)
-              : String(r.inviteesCount); // INVITED
+            const sortValRaw = sortFieldDefs[orderBy].extractVal({
+              lastActivityRaw,
+              createdRaw: r.createdRaw,
+              followingCount: r.followingCount,
+              followersCount: r.followersCount,
+              postsCount: r.postsCount,
+              inviteesCount: r.inviteesCount,
+              account: r.account,
+            });
 
             return { account: r.account, lastActivity, sortValRaw };
           });

--- a/graphql/admin.ts
+++ b/graphql/admin.ts
@@ -191,6 +191,29 @@ function decodeAdminCursor(encoded: string): AdminCursorData | null {
     if (!validFields.includes(field)) return null;
     if (dir !== "ASC" && dir !== "DESC") return null;
     if (!validateUuid(id as Uuid)) return null;
+    // Validate the sort-key value to prevent SQL cast errors.
+    const isTimestampField = field === "LAST_ACTIVITY" || field === "CREATED";
+    if (isTimestampField) {
+      // Validate the PostgreSQL timestamptz text format emitted by ::text
+      // (e.g. "2024-01-15 10:30:00.123456+00") by checking each calendar
+      // and time component directly.  Avoids relying on JS Date parsing,
+      // which normalises invalid dates and shifts local dates to UTC.
+      // Cursors are always emitted in UTC ("+00"); reject any other offset.
+      const pgTsPattern =
+        /^(\d{4})-(\d{2})-(\d{2}) (\d{2}):(\d{2}):(\d{2})(\.\d{1,6})?\+00$/;
+      const pgMatch = pgTsPattern.exec(val);
+      if (!pgMatch) return null;
+      const [, yr, mo, dy, hh, mm, ss] = pgMatch.map(Number);
+      if (yr < 1 || mo < 1 || mo > 12) return null;
+      // Last day of the month (new Date(yr, mo, 0) = day 0 of next month).
+      const maxDay = new Date(yr, mo, 0).getDate();
+      if (dy < 1 || dy > maxDay) return null;
+      if (hh > 23 || mm > 59 || ss > 59) return null;
+    } else {
+      // Decimal digits only, within PostgreSQL bigint range.
+      if (!/^\d+$/.test(val)) return null;
+      if (BigInt(val) > 9223372036854775807n) return null;
+    }
     return { field, dir, val, id };
   } catch {
     return null;
@@ -303,6 +326,7 @@ builder.queryField("adminAccounts", (t) =>
         .as("posts_agg");
 
       // Followers per account (actors whose followeeId maps to this account).
+      // Only count accepted follows so the sort order matches the displayed totals.
       const followersSubq = ctx.db
         .select({
           accountId: actorTable.accountId,
@@ -310,11 +334,17 @@ builder.queryField("adminAccounts", (t) =>
         })
         .from(followingTable)
         .innerJoin(actorTable, eq(actorTable.id, followingTable.followeeId))
-        .where(isNotNull(actorTable.accountId))
+        .where(
+          and(
+            isNotNull(actorTable.accountId),
+            isNotNull(followingTable.accepted),
+          ),
+        )
         .groupBy(actorTable.accountId)
         .as("followers_agg");
 
       // Following per account (actors whose followerId maps to this account).
+      // Only count accepted follows so the sort order matches the displayed totals.
       const followingSubq = ctx.db
         .select({
           accountId: actorTable.accountId,
@@ -322,7 +352,12 @@ builder.queryField("adminAccounts", (t) =>
         })
         .from(followingTable)
         .innerJoin(actorTable, eq(actorTable.id, followingTable.followerId))
-        .where(isNotNull(actorTable.accountId))
+        .where(
+          and(
+            isNotNull(actorTable.accountId),
+            isNotNull(followingTable.accepted),
+          ),
+        )
         .groupBy(actorTable.accountId)
         .as("following_agg");
 
@@ -408,12 +443,25 @@ builder.queryField("adminAccounts", (t) =>
             : decodeAdminCursor(before);
           const afterCursor = after == null ? null : decodeAdminCursor(after);
 
-          const afterFilter = afterCursor == null
+          // Reject cursors that don't match the current sort to prevent
+          // wrong pagination or SQL cast errors when the sort changes.
+          const validAfter = afterCursor != null &&
+              afterCursor.field === orderBy &&
+              afterCursor.dir === orderDir
+            ? afterCursor
+            : null;
+          const validBefore = beforeCursor != null &&
+              beforeCursor.field === orderBy &&
+              beforeCursor.dir === orderDir
+            ? beforeCursor
+            : null;
+
+          const afterFilter = validAfter == null
             ? undefined
-            : buildAfterFilter(afterCursor);
-          const beforeFilter = beforeCursor == null
+            : buildAfterFilter(validAfter);
+          const beforeFilter = validBefore == null
             ? undefined
-            : buildBeforeFilter(beforeCursor);
+            : buildBeforeFilter(validBefore);
 
           // `inverted` flips ORDER BY so resolveCursorConnection can fetch
           // the LAST N items closest to the cursor and then reverse them.
@@ -426,9 +474,15 @@ builder.queryField("adminAccounts", (t) =>
             .select({
               account: accountTable,
               lastActivity: lastActivityExpr,
-              // Cast the COALESCE expression to text so postgres-js gives us
-              // the raw microsecond-precision string needed for the cursor.
-              lastActivityRaw: sql<string>`${lastActivityExpr}::text`,
+              // Format timestamps as UTC text for cursor encoding.  Using
+              // AT TIME ZONE 'UTC' before to_char ensures the cursor value
+              // is always "+00", regardless of the PostgreSQL session timezone.
+              lastActivityRaw: sql<
+                string
+              >`to_char(${lastActivityExpr} AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS.US') || '+00'`,
+              createdRaw: sql<
+                string
+              >`to_char(${accountTable.created} AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS.US') || '+00'`,
               followingCount: sql<
                 number
               >`COALESCE(${followingSubq.count}, 0)::int`,
@@ -473,9 +527,9 @@ builder.queryField("adminAccounts", (t) =>
             const sortValRaw: string = orderBy === "LAST_ACTIVITY"
               ? lastActivityRaw
               : orderBy === "CREATED"
-              ? (r.account.created instanceof Date
-                ? r.account.created.toISOString()
-                : String(r.account.created))
+              ? ((r.createdRaw as unknown) instanceof Date
+                ? (r.createdRaw as unknown as Date).toISOString()
+                : String(r.createdRaw))
               : orderBy === "INVITATIONS_LEFT"
               ? String(r.account.leftInvitations)
               : orderBy === "FOLLOWING"

--- a/graphql/admin.ts
+++ b/graphql/admin.ts
@@ -202,9 +202,12 @@ function decodeAdminCursor(encoded: string): AdminCursorData | null {
       if (dy < 1 || dy > maxDay) return null;
       if (hh > 23 || mm > 59 || ss > 59) return null;
     } else {
-      // Decimal digits only, within PostgreSQL bigint range.
-      if (!/^\d+$/.test(val)) return null;
-      if (BigInt(val) > 9223372036854775807n) return null;
+      // Signed decimal integer, within PostgreSQL bigint range.
+      // INVITATIONS_LEFT is a signed smallint so negative cursor values
+      // are possible; the leading "-" must be accepted here.
+      if (!/^-?\d+$/.test(val)) return null;
+      const n = BigInt(val);
+      if (n < -9223372036854775808n || n > 9223372036854775807n) return null;
     }
     return { field, dir, val, id };
   } catch {

--- a/graphql/admin.ts
+++ b/graphql/admin.ts
@@ -22,8 +22,10 @@ import {
   asc,
   desc,
   eq,
+  ilike,
   inArray,
   isNotNull,
+  or,
   type SQL,
   sql,
 } from "drizzle-orm";
@@ -254,6 +256,7 @@ builder.queryField("adminAccounts", (t) =>
       before: t.arg.string(),
       orderBy: t.arg({ type: AdminAccountOrderBy }),
       orderDirection: t.arg({ type: OrderDirection }),
+      search: t.arg.string(),
     },
     async resolve(
       _root,
@@ -265,6 +268,21 @@ builder.queryField("adminAccounts", (t) =>
 
       const orderBy: AdminOrderBy = args.orderBy ?? "LAST_ACTIVITY";
       const orderDir: AdminOrderDir = args.orderDirection ?? "DESC";
+
+      // Split the search string into words; each word must appear in either
+      // the display name or the username (case-insensitive substring match).
+      const searchWords = (args.search ?? "")
+        .trim()
+        .split(/\s+/)
+        .filter(Boolean);
+      const searchFilter = searchWords.length === 0 ? undefined : and(
+        ...searchWords.map((w) =>
+          or(
+            ilike(accountTable.name, `%${w}%`),
+            ilike(accountTable.username, `%${w}%`),
+          )!
+        ),
+      );
 
       // --- Subqueries ---
 
@@ -345,7 +363,10 @@ builder.queryField("adminAccounts", (t) =>
       const isTimestamp = orderBy === "LAST_ACTIVITY" ||
         orderBy === "CREATED";
 
-      const totalCount = await ctx.db.$count(accountTable);
+      const [{ totalCount }] = await ctx.db
+        .select({ totalCount: sql<number>`COUNT(*)::int` })
+        .from(accountTable)
+        .where(searchFilter);
 
       // --- Cursor filter helpers ---
       // For DESC natural order: "after" a cursor means a smaller value;
@@ -433,7 +454,7 @@ builder.queryField("adminAccounts", (t) =>
               inviteesSubq,
               sql`${inviteesSubq.inviterId} = ${accountTable.id}`,
             )
-            .where(and(beforeFilter, afterFilter))
+            .where(and(beforeFilter, afterFilter, searchFilter))
             .orderBy(...orderByClause)
             .limit(limit);
 

--- a/graphql/admin.ts
+++ b/graphql/admin.ts
@@ -22,7 +22,6 @@ import {
   asc,
   desc,
   eq,
-  ilike,
   inArray,
   isNotNull,
   or,
@@ -123,16 +122,18 @@ builder.drizzleObjectField(Account, "lastPostPublished", (t) =>
     },
   }));
 
+const ADMIN_SORT_FIELDS = [
+  "FOLLOWING",
+  "FOLLOWERS",
+  "POSTS",
+  "INVITATIONS_LEFT",
+  "INVITED",
+  "LAST_ACTIVITY",
+  "CREATED",
+] as const;
+
 const AdminAccountOrderBy = builder.enumType("AdminAccountOrderBy", {
-  values: [
-    "FOLLOWING",
-    "FOLLOWERS",
-    "POSTS",
-    "INVITATIONS_LEFT",
-    "INVITED",
-    "LAST_ACTIVITY",
-    "CREATED",
-  ] as const,
+  values: ADMIN_SORT_FIELDS,
 });
 
 const OrderDirection = builder.enumType("OrderDirection", {
@@ -179,16 +180,7 @@ function decodeAdminCursor(encoded: string): AdminCursorData | null {
     const dir = decoded.slice(first + 1, second) as AdminOrderDir;
     const val = decoded.slice(second + 1, last);
     const id = decoded.slice(last + 1);
-    const validFields: AdminOrderBy[] = [
-      "FOLLOWING",
-      "FOLLOWERS",
-      "POSTS",
-      "INVITATIONS_LEFT",
-      "INVITED",
-      "LAST_ACTIVITY",
-      "CREATED",
-    ];
-    if (!validFields.includes(field)) return null;
+    if (!(ADMIN_SORT_FIELDS as readonly string[]).includes(field)) return null;
     if (dir !== "ASC" && dir !== "DESC") return null;
     if (!validateUuid(id as Uuid)) return null;
     // Validate the sort-key value to prevent SQL cast errors.
@@ -294,17 +286,22 @@ builder.queryField("adminAccounts", (t) =>
 
       // Split the search string into words; each word must appear in either
       // the display name or the username (case-insensitive substring match).
+      // "!" is used as the ILIKE escape character so "%" and "_" in the
+      // search term are treated as literals rather than SQL wildcards.
       const searchWords = (args.search ?? "")
         .trim()
         .split(/\s+/)
         .filter(Boolean);
       const searchFilter = searchWords.length === 0 ? undefined : and(
-        ...searchWords.map((w) =>
-          or(
-            ilike(accountTable.name, `%${w}%`),
-            ilike(accountTable.username, `%${w}%`),
-          )!
-        ),
+        ...searchWords.map((w) => {
+          const p = `%${
+            w.replace(/!/g, "!!").replace(/%/g, "!%").replace(/_/g, "!_")
+          }%`;
+          return or(
+            sql`${accountTable.name} ILIKE ${p} ESCAPE '!'`,
+            sql`${accountTable.username} ILIKE ${p} ESCAPE '!'`,
+          )!;
+        }),
       );
 
       // --- Subqueries ---

--- a/graphql/admin.ts
+++ b/graphql/admin.ts
@@ -5,7 +5,12 @@ import {
   type InvitationRegenerationStatus as ModelInvitationRegenerationStatus,
   regenerateInvitations,
 } from "@hackerspub/models/admin";
-import { accountTable, actorTable, postTable } from "@hackerspub/models/schema";
+import {
+  accountTable,
+  actorTable,
+  followingTable,
+  postTable,
+} from "@hackerspub/models/schema";
 import { type Uuid, validateUuid } from "@hackerspub/models/uuid";
 import {
   resolveCursorConnection,
@@ -116,34 +121,78 @@ builder.drizzleObjectField(Account, "lastPostPublished", (t) =>
     },
   }));
 
+const AdminAccountOrderBy = builder.enumType("AdminAccountOrderBy", {
+  values: [
+    "FOLLOWING",
+    "FOLLOWERS",
+    "POSTS",
+    "INVITATIONS_LEFT",
+    "INVITED",
+    "LAST_ACTIVITY",
+    "CREATED",
+  ] as const,
+});
+
+const OrderDirection = builder.enumType("OrderDirection", {
+  values: ["ASC", "DESC"] as const,
+});
+
+type AdminOrderBy = typeof AdminAccountOrderBy.$inferType;
+type AdminOrderDir = typeof OrderDirection.$inferType;
+
 interface AdminAccountRow {
   account: typeof accountTable.$inferSelect;
   lastActivity: Date;
-  // The raw `timestamptz` text from PostgreSQL, preserving microsecond
-  // precision.  We carry it alongside the JS Date so the cursor round-
-  // trips bit-for-bit; a JS Date only keeps milliseconds and would
-  // truncate the boundary timestamp, causing rows in the rounded
-  // microsecond window to be skipped on the next page.
-  lastActivityRaw: string;
+  // Raw string representation of the sort key value, used to encode the
+  // cursor without precision loss.  For timestamp sorts this is the raw
+  // PostgreSQL `timestamptz` text; for integer sorts it is the decimal
+  // string representation of the count.
+  sortValRaw: string;
 }
 
-function encodeAdminCursor(row: AdminAccountRow): string {
-  return `${row.lastActivityRaw}|${row.account.id}`;
+interface AdminCursorData {
+  field: AdminOrderBy;
+  dir: AdminOrderDir;
+  val: string; // raw sort-key value
+  id: string; // account UUID
 }
 
-function decodeAdminCursor(
-  cursor: string,
-): { lastActivityRaw: string; accountId: Uuid } | null {
-  const sep = cursor.indexOf("|");
-  if (sep < 0) return null;
-  const lastActivityRaw = cursor.slice(0, sep);
-  const rawId = cursor.slice(sep + 1);
-  // Validate by attempting to parse to a Date.  Microsecond precision
-  // is lost in JS but the raw string is what gets passed back to
-  // PostgreSQL via `::timestamptz`, where full precision is preserved.
-  if (Number.isNaN(new Date(lastActivityRaw).getTime())) return null;
-  if (!validateUuid(rawId)) return null;
-  return { lastActivityRaw, accountId: rawId };
+// Encoded as base64(field|dir|val|id).  None of the constituent values
+// contain "|" (enum names use only [A-Z_], directions are "ASC"/"DESC",
+// PostgreSQL timestamps use ":", "-", ".", "+" and spaces, integers use
+// only digits, and UUIDs use hex digits and "-"), so a single "|"
+// delimiter is safe.
+function encodeAdminCursor(data: AdminCursorData): string {
+  return btoa(`${data.field}|${data.dir}|${data.val}|${data.id}`);
+}
+
+function decodeAdminCursor(encoded: string): AdminCursorData | null {
+  try {
+    const decoded = atob(encoded);
+    const first = decoded.indexOf("|");
+    const second = decoded.indexOf("|", first + 1);
+    const last = decoded.lastIndexOf("|");
+    if (first < 0 || second < 0 || last <= second) return null;
+    const field = decoded.slice(0, first) as AdminOrderBy;
+    const dir = decoded.slice(first + 1, second) as AdminOrderDir;
+    const val = decoded.slice(second + 1, last);
+    const id = decoded.slice(last + 1);
+    const validFields: AdminOrderBy[] = [
+      "FOLLOWING",
+      "FOLLOWERS",
+      "POSTS",
+      "INVITATIONS_LEFT",
+      "INVITED",
+      "LAST_ACTIVITY",
+      "CREATED",
+    ];
+    if (!validFields.includes(field)) return null;
+    if (dir !== "ASC" && dir !== "DESC") return null;
+    if (!validateUuid(id as Uuid)) return null;
+    return { field, dir, val, id };
+  } catch {
+    return null;
+  }
 }
 
 const AdminAccountEdge = builder.simpleObject("AdminAccountEdge", {
@@ -195,15 +244,16 @@ builder.queryField("adminAccounts", (t) =>
     type: AdminAccountConnection,
     nullable: true,
     description:
-      "Moderator-only connection of every account, ordered by latest " +
-      "post `published` falling back to `account.updated`.  Returns " +
-      "null when the viewer is not a moderator; routes should guard " +
-      "with `viewer.moderator` and redirect non-moderators.",
+      "Moderator-only connection of every account.  Returns null when " +
+      "the viewer is not a moderator; routes should guard with " +
+      "`viewer.moderator` and redirect non-moderators.",
     args: {
       first: t.arg.int(),
       after: t.arg.string(),
       last: t.arg.int(),
       before: t.arg.string(),
+      orderBy: t.arg({ type: AdminAccountOrderBy }),
+      orderDirection: t.arg({ type: OrderDirection }),
     },
     async resolve(
       _root,
@@ -213,11 +263,17 @@ builder.queryField("adminAccounts", (t) =>
       if (ctx.session == null) return null;
       if (!ctx.account?.moderator) return null;
 
-      // Aggregate the latest published timestamp per account so the
-      // outer query can sort by COALESCE(MAX(published), updated).
-      const lastPublishedSubquery = ctx.db
+      const orderBy: AdminOrderBy = args.orderBy ?? "LAST_ACTIVITY";
+      const orderDir: AdminOrderDir = args.orderDirection ?? "DESC";
+
+      // --- Subqueries ---
+
+      // Post count + latest published timestamp per account, used for
+      // LAST_ACTIVITY sort and POSTS sort.
+      const postsSubq = ctx.db
         .select({
           accountId: actorTable.accountId,
+          count: sql<number>`COUNT(*)::int`.as("count"),
           maxPublished: sql<Date | null>`MAX(${postTable.published})`.as(
             "max_published",
           ),
@@ -226,40 +282,102 @@ builder.queryField("adminAccounts", (t) =>
         .innerJoin(actorTable, eq(actorTable.id, postTable.actorId))
         .where(isNotNull(actorTable.accountId))
         .groupBy(actorTable.accountId)
-        .as("last_published");
+        .as("posts_agg");
 
+      // Followers per account (actors whose followeeId maps to this account).
+      const followersSubq = ctx.db
+        .select({
+          accountId: actorTable.accountId,
+          count: sql<number>`COUNT(*)::int`.as("count"),
+        })
+        .from(followingTable)
+        .innerJoin(actorTable, eq(actorTable.id, followingTable.followeeId))
+        .where(isNotNull(actorTable.accountId))
+        .groupBy(actorTable.accountId)
+        .as("followers_agg");
+
+      // Following per account (actors whose followerId maps to this account).
+      const followingSubq = ctx.db
+        .select({
+          accountId: actorTable.accountId,
+          count: sql<number>`COUNT(*)::int`.as("count"),
+        })
+        .from(followingTable)
+        .innerJoin(actorTable, eq(actorTable.id, followingTable.followerId))
+        .where(isNotNull(actorTable.accountId))
+        .groupBy(actorTable.accountId)
+        .as("following_agg");
+
+      // Invitees per account (accounts whose inviterId is this account).
+      const inviteesSubq = ctx.db
+        .select({
+          inviterId: accountTable.inviterId,
+          count: sql<number>`COUNT(*)::int`.as("count"),
+        })
+        .from(accountTable)
+        .where(isNotNull(accountTable.inviterId))
+        .groupBy(accountTable.inviterId)
+        .as("invitees_agg");
+
+      // COALESCE(MAX(post.published), account.updated) — the "last activity"
+      // value used for display and for the LAST_ACTIVITY sort.
       const lastActivityExpr = sql<
         Date
-      >`COALESCE(${lastPublishedSubquery.maxPublished}, ${accountTable.updated})`;
+      >`COALESCE(${postsSubq.maxPublished}, ${accountTable.updated})`;
+
+      // --- Sort expression for the chosen field ---
+      const sortExpr: SQL = orderBy === "FOLLOWING"
+        ? sql<number>`COALESCE(${followingSubq.count}, 0)`
+        : orderBy === "FOLLOWERS"
+        ? sql<number>`COALESCE(${followersSubq.count}, 0)`
+        : orderBy === "POSTS"
+        ? sql<number>`COALESCE(${postsSubq.count}, 0)`
+        : orderBy === "INVITATIONS_LEFT"
+        ? sql`${accountTable.leftInvitations}`
+        : orderBy === "INVITED"
+        ? sql<number>`COALESCE(${inviteesSubq.count}, 0)`
+        : orderBy === "CREATED"
+        ? sql`${accountTable.created}`
+        : lastActivityExpr; // LAST_ACTIVITY (default)
+
+      // Timestamps need `::timestamptz` casts in cursor comparisons;
+      // integer fields use `::bigint`.
+      const isTimestamp = orderBy === "LAST_ACTIVITY" ||
+        orderBy === "CREATED";
 
       const totalCount = await ctx.db.$count(accountTable);
 
-      // For the natural ordering `lastActivity DESC, accountId DESC`,
-      // the cursor filters depend only on the cursor side, never on
-      // `inverted`: rows BEFORE the cursor in natural order have a
-      // strictly larger (lastActivity, id) tuple, and rows AFTER have a
-      // strictly smaller one.  The `inverted` flag only flips the
-      // ORDER BY direction so the framework can take the LAST N nodes
-      // closest to the cursor and reverse them back into natural order.
-      // The cursor timestamp and id are bound as text and cast inside
-      // the SQL so postgres-js can serialise them (it has no parameter
-      // type for the COALESCE expression).
-      function tupleLessThan(tsRaw: string, id: string): SQL {
-        const tsLit = sql`${tsRaw}::timestamptz`;
-        const idLit = sql`${id}::uuid`;
-        return sql`(${lastActivityExpr} < ${tsLit}) OR (${lastActivityExpr} = ${tsLit} AND ${accountTable.id} < ${idLit})`;
+      // --- Cursor filter helpers ---
+      // For DESC natural order: "after" a cursor means a smaller value;
+      // for ASC natural order: "after" means a larger value.
+      function buildAfterFilter(c: AdminCursorData): SQL {
+        const cast = isTimestamp ? "timestamptz" : "bigint";
+        const v = sql`${c.val}::${sql.raw(cast)}`;
+        const id = sql`${c.id}::uuid`;
+        return c.dir === "DESC"
+          ? sql`(${sortExpr} < ${v}) OR (${sortExpr} = ${v} AND ${accountTable.id} < ${id})`
+          : sql`(${sortExpr} > ${v}) OR (${sortExpr} = ${v} AND ${accountTable.id} > ${id})`;
       }
 
-      function tupleGreaterThan(tsRaw: string, id: string): SQL {
-        const tsLit = sql`${tsRaw}::timestamptz`;
-        const idLit = sql`${id}::uuid`;
-        return sql`(${lastActivityExpr} > ${tsLit}) OR (${lastActivityExpr} = ${tsLit} AND ${accountTable.id} > ${idLit})`;
+      function buildBeforeFilter(c: AdminCursorData): SQL {
+        const cast = isTimestamp ? "timestamptz" : "bigint";
+        const v = sql`${c.val}::${sql.raw(cast)}`;
+        const id = sql`${c.id}::uuid`;
+        return c.dir === "DESC"
+          ? sql`(${sortExpr} > ${v}) OR (${sortExpr} = ${v} AND ${accountTable.id} > ${id})`
+          : sql`(${sortExpr} < ${v}) OR (${sortExpr} = ${v} AND ${accountTable.id} < ${id})`;
       }
 
       const connection = await resolveCursorConnection(
         {
           args,
-          toCursor: (row: AdminAccountRow) => encodeAdminCursor(row),
+          toCursor: (row: AdminAccountRow) =>
+            encodeAdminCursor({
+              field: orderBy,
+              dir: orderDir,
+              val: row.sortValRaw,
+              id: row.account.id,
+            }),
         },
         async (
           { before, after, limit, inverted }: ResolveCursorConnectionArgs,
@@ -269,54 +387,85 @@ builder.queryField("adminAccounts", (t) =>
             : decodeAdminCursor(before);
           const afterCursor = after == null ? null : decodeAdminCursor(after);
 
+          const afterFilter = afterCursor == null
+            ? undefined
+            : buildAfterFilter(afterCursor);
           const beforeFilter = beforeCursor == null
             ? undefined
-            : tupleGreaterThan(
-              beforeCursor.lastActivityRaw,
-              beforeCursor.accountId,
-            );
-          const afterFilter = afterCursor == null ? undefined : tupleLessThan(
-            afterCursor.lastActivityRaw,
-            afterCursor.accountId,
-          );
+            : buildBeforeFilter(beforeCursor);
+
+          // `inverted` flips ORDER BY so resolveCursorConnection can fetch
+          // the LAST N items closest to the cursor and then reverse them.
+          const descending = (orderDir === "DESC") !== inverted;
+          const orderByClause = descending
+            ? [desc(sortExpr), desc(accountTable.id)]
+            : [asc(sortExpr), asc(accountTable.id)];
 
           const rows = await ctx.db
             .select({
               account: accountTable,
-              lastActivity: lastActivityExpr.as("last_activity"),
+              lastActivity: lastActivityExpr,
+              // Cast the COALESCE expression to text so postgres-js gives us
+              // the raw microsecond-precision string needed for the cursor.
+              lastActivityRaw: sql<string>`${lastActivityExpr}::text`,
+              followingCount: sql<
+                number
+              >`COALESCE(${followingSubq.count}, 0)::int`,
+              followersCount: sql<
+                number
+              >`COALESCE(${followersSubq.count}, 0)::int`,
+              postsCount: sql<number>`COALESCE(${postsSubq.count}, 0)::int`,
+              inviteesCount: sql<
+                number
+              >`COALESCE(${inviteesSubq.count}, 0)::int`,
             })
             .from(accountTable)
+            .leftJoin(postsSubq, eq(postsSubq.accountId, accountTable.id))
             .leftJoin(
-              lastPublishedSubquery,
-              eq(lastPublishedSubquery.accountId, accountTable.id),
+              followersSubq,
+              eq(followersSubq.accountId, accountTable.id),
+            )
+            .leftJoin(
+              followingSubq,
+              eq(followingSubq.accountId, accountTable.id),
+            )
+            .leftJoin(
+              inviteesSubq,
+              sql`${inviteesSubq.inviterId} = ${accountTable.id}`,
             )
             .where(and(beforeFilter, afterFilter))
-            .orderBy(
-              inverted ? asc(lastActivityExpr) : desc(lastActivityExpr),
-              inverted ? asc(accountTable.id) : desc(accountTable.id),
-            )
+            .orderBy(...orderByClause)
             .limit(limit);
 
           return rows.map((r) => {
-            const raw = r.lastActivity as unknown as Date | string;
-            // postgres-js parses `timestamptz` columns to JS Dates by
-            // default (millisecond precision), but the bare COALESCE
-            // expression doesn't carry a column type, so it comes
-            // through as the raw `YYYY-MM-DD HH:MM:SS.UUUUUU+00`
-            // string (microsecond precision).  Keep both: the string
-            // for the cursor (so boundaries round-trip exactly) and a
-            // Date for the GraphQL output.
-            const lastActivityRaw = raw instanceof Date
-              ? raw.toISOString()
-              : raw;
-            const lastActivity = raw instanceof Date
-              ? raw
-              : new Date(raw as string);
-            return {
-              account: r.account,
-              lastActivity,
-              lastActivityRaw,
-            };
+            // The COALESCE expression comes through as a raw string from
+            // postgres-js (no column type annotation on the expression).
+            const rawStr = r.lastActivityRaw as unknown;
+            const lastActivityRaw = rawStr instanceof Date
+              ? rawStr.toISOString()
+              : String(rawStr);
+            const rawAct = r.lastActivity as unknown;
+            const lastActivity = rawAct instanceof Date
+              ? rawAct
+              : new Date(rawAct as string);
+
+            const sortValRaw: string = orderBy === "LAST_ACTIVITY"
+              ? lastActivityRaw
+              : orderBy === "CREATED"
+              ? (r.account.created instanceof Date
+                ? r.account.created.toISOString()
+                : String(r.account.created))
+              : orderBy === "INVITATIONS_LEFT"
+              ? String(r.account.leftInvitations)
+              : orderBy === "FOLLOWING"
+              ? String(r.followingCount)
+              : orderBy === "FOLLOWERS"
+              ? String(r.followersCount)
+              : orderBy === "POSTS"
+              ? String(r.postsCount)
+              : String(r.inviteesCount); // INVITED
+
+            return { account: r.account, lastActivity, sortValRaw };
           });
         },
       );

--- a/graphql/admin.ts
+++ b/graphql/admin.ts
@@ -322,9 +322,10 @@ builder.queryField("adminAccounts", (t) =>
         .groupBy(actorTable.accountId)
         .as("posts_agg");
 
-      // Followers per account (actors whose followeeId maps to this account).
-      // Only count accepted follows so the sort order matches the displayed totals.
-      const followersSubq = ctx.db
+      // Build only the aggregate subquery needed for the current sort field.
+      // Follower / following / invitee counts are expensive GROUP BY aggregates;
+      // joining all three on every request is wasteful when only one is used.
+      const followersSubq = orderBy !== "FOLLOWERS" ? null : ctx.db
         .select({
           accountId: actorTable.accountId,
           count: sql<number>`COUNT(*)::int`.as("count"),
@@ -340,9 +341,7 @@ builder.queryField("adminAccounts", (t) =>
         .groupBy(actorTable.accountId)
         .as("followers_agg");
 
-      // Following per account (actors whose followerId maps to this account).
-      // Only count accepted follows so the sort order matches the displayed totals.
-      const followingSubq = ctx.db
+      const followingSubq = orderBy !== "FOLLOWING" ? null : ctx.db
         .select({
           accountId: actorTable.accountId,
           count: sql<number>`COUNT(*)::int`.as("count"),
@@ -358,8 +357,7 @@ builder.queryField("adminAccounts", (t) =>
         .groupBy(actorTable.accountId)
         .as("following_agg");
 
-      // Invitees per account (accounts whose inviterId is this account).
-      const inviteesSubq = ctx.db
+      const inviteesSubq = orderBy !== "INVITED" ? null : ctx.db
         .select({
           inviterId: accountTable.inviterId,
           count: sql<number>`COUNT(*)::int`.as("count"),
@@ -375,62 +373,56 @@ builder.queryField("adminAccounts", (t) =>
         Date
       >`COALESCE(${postsSubq.maxPublished}, ${accountTable.updated})`;
 
-      // --- Per-field sort definitions ---
-      // Each entry pairs the SQL expression used for ORDER BY / cursor filters
-      // with a function that extracts the raw cursor value from a result row.
-      // Keeping both together means adding a new sort field only requires one
-      // change here rather than two separate switch-like blocks.
+      // Sort expression and cursor value extractor for the active sort field.
+      // Built with a switch so references to conditional subqueries are only
+      // evaluated when those subqueries are actually constructed (non-null).
       interface SortRow {
         lastActivityRaw: string;
-        createdRaw: unknown;
-        followingCount: number;
-        followersCount: number;
-        postsCount: number;
-        inviteesCount: number;
+        createdRaw: string;
+        sortCount: number;
         account: typeof accountTable.$inferSelect;
       }
-      const sortFieldDefs: Record<
-        AdminOrderBy,
-        { expr: SQL; isTimestamp: boolean; extractVal: (r: SortRow) => string }
-      > = {
-        FOLLOWING: {
-          expr: sql<number>`COALESCE(${followingSubq.count}, 0)`,
-          isTimestamp: false,
-          extractVal: (r) => String(r.followingCount),
-        },
-        FOLLOWERS: {
-          expr: sql<number>`COALESCE(${followersSubq.count}, 0)`,
-          isTimestamp: false,
-          extractVal: (r) => String(r.followersCount),
-        },
-        POSTS: {
-          expr: sql<number>`COALESCE(${postsSubq.count}, 0)`,
-          isTimestamp: false,
-          extractVal: (r) => String(r.postsCount),
-        },
-        INVITATIONS_LEFT: {
-          expr: sql`${accountTable.leftInvitations}`,
-          isTimestamp: false,
-          extractVal: (r) => String(r.account.leftInvitations),
-        },
-        INVITED: {
-          expr: sql<number>`COALESCE(${inviteesSubq.count}, 0)`,
-          isTimestamp: false,
-          extractVal: (r) => String(r.inviteesCount),
-        },
-        LAST_ACTIVITY: {
-          expr: lastActivityExpr,
-          isTimestamp: true,
-          extractVal: (r) => r.lastActivityRaw,
-        },
-        CREATED: {
-          expr: sql`${accountTable.created}`,
-          isTimestamp: true,
-          extractVal: (r) => String(r.createdRaw),
-        },
-      };
 
-      const { expr: sortExpr, isTimestamp } = sortFieldDefs[orderBy];
+      let sortExpr: SQL;
+      let isTimestamp: boolean;
+      let extractSortVal: (r: SortRow) => string;
+      switch (orderBy) {
+        case "FOLLOWING":
+          sortExpr = sql<number>`COALESCE(${followingSubq!.count}, 0)`;
+          isTimestamp = false;
+          extractSortVal = (r) => String(r.sortCount);
+          break;
+        case "FOLLOWERS":
+          sortExpr = sql<number>`COALESCE(${followersSubq!.count}, 0)`;
+          isTimestamp = false;
+          extractSortVal = (r) => String(r.sortCount);
+          break;
+        case "POSTS":
+          sortExpr = sql<number>`COALESCE(${postsSubq.count}, 0)`;
+          isTimestamp = false;
+          extractSortVal = (r) => String(r.sortCount);
+          break;
+        case "INVITATIONS_LEFT":
+          sortExpr = sql`${accountTable.leftInvitations}`;
+          isTimestamp = false;
+          extractSortVal = (r) => String(r.account.leftInvitations);
+          break;
+        case "INVITED":
+          sortExpr = sql<number>`COALESCE(${inviteesSubq!.count}, 0)`;
+          isTimestamp = false;
+          extractSortVal = (r) => String(r.sortCount);
+          break;
+        case "LAST_ACTIVITY":
+          sortExpr = lastActivityExpr;
+          isTimestamp = true;
+          extractSortVal = (r) => r.lastActivityRaw;
+          break;
+        case "CREATED":
+          sortExpr = sql`${accountTable.created}`;
+          isTimestamp = true;
+          extractSortVal = (r) => r.createdRaw;
+          break;
+      }
 
       const [{ totalCount }] = await ctx.db
         .select({ totalCount: sql<number>`COUNT(*)::int` })
@@ -504,7 +496,16 @@ builder.queryField("adminAccounts", (t) =>
             ? [desc(sortExpr), desc(accountTable.id)]
             : [asc(sortExpr), asc(accountTable.id)];
 
-          const rows = await ctx.db
+          // sortCount carries the active sort field's count expression.
+          // For timestamp and INVITATIONS_LEFT sorts it is unused (set to 0).
+          const sortCountExpr: SQL<number> = isTimestamp
+            ? sql<number>`0`
+            : sql<number>`(${sortExpr})::int`;
+
+          // Build the base query with postsSubq always joined (needed for
+          // lastActivityExpr), then conditionally join the one optional
+          // subquery the current sort field requires.
+          const baseQ = ctx.db
             .select({
               account: accountTable,
               lastActivity: lastActivityExpr,
@@ -517,52 +518,52 @@ builder.queryField("adminAccounts", (t) =>
               createdRaw: sql<
                 string
               >`to_char(${accountTable.created} AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS.US') || '+00'`,
-              followingCount: sql<
-                number
-              >`COALESCE(${followingSubq.count}, 0)::int`,
-              followersCount: sql<
-                number
-              >`COALESCE(${followersSubq.count}, 0)::int`,
-              postsCount: sql<number>`COALESCE(${postsSubq.count}, 0)::int`,
-              inviteesCount: sql<
-                number
-              >`COALESCE(${inviteesSubq.count}, 0)::int`,
+              sortCount: sortCountExpr,
             })
             .from(accountTable)
             .leftJoin(postsSubq, eq(postsSubq.accountId, accountTable.id))
-            .leftJoin(
+            .$dynamic();
+
+          // $dynamic() allows conditional leftJoin calls at the cost of a
+          // type assertion: each leftJoin changes the nullabilityMap in the
+          // return type, so we cast back to the base dynamic type.
+          type DynQ = typeof baseQ;
+          let q: DynQ = baseQ;
+          if (followersSubq != null) {
+            q = q.leftJoin(
               followersSubq,
               eq(followersSubq.accountId, accountTable.id),
-            )
-            .leftJoin(
+            ) as unknown as DynQ;
+          }
+          if (followingSubq != null) {
+            q = q.leftJoin(
               followingSubq,
               eq(followingSubq.accountId, accountTable.id),
-            )
-            .leftJoin(
+            ) as unknown as DynQ;
+          }
+          if (inviteesSubq != null) {
+            q = q.leftJoin(
               inviteesSubq,
               eq(inviteesSubq.inviterId, accountTable.id),
-            )
+            ) as unknown as DynQ;
+          }
+
+          const rows = await q
             .where(and(beforeFilter, afterFilter, searchFilter))
             .orderBy(...orderByClause)
             .limit(limit);
 
           return rows.map((r) => {
-            // lastActivityRaw and createdRaw are already formatted as UTC
-            // strings by the to_char() expressions in the SELECT above, so
-            // they are always strings, never Date objects.
             const lastActivityRaw = String(r.lastActivityRaw);
             const rawAct = r.lastActivity as unknown;
             const lastActivity = rawAct instanceof Date
               ? rawAct
               : new Date(rawAct as string);
 
-            const sortValRaw = sortFieldDefs[orderBy].extractVal({
+            const sortValRaw = extractSortVal({
               lastActivityRaw,
-              createdRaw: r.createdRaw,
-              followingCount: r.followingCount,
-              followersCount: r.followersCount,
-              postsCount: r.postsCount,
-              inviteesCount: r.inviteesCount,
+              createdRaw: String(r.createdRaw),
+              sortCount: r.sortCount,
               account: r.account,
             });
 

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -318,6 +318,16 @@ type AdminAccountEdge {
   node: Account!
 }
 
+enum AdminAccountOrderBy {
+  CREATED
+  FOLLOWERS
+  FOLLOWING
+  INVITATIONS_LEFT
+  INVITED
+  LAST_ACTIVITY
+  POSTS
+}
+
 type AdminAccountPageInfo {
   endCursor: String
   hasNextPage: Boolean!
@@ -1022,6 +1032,11 @@ enum NotificationType {
   SHARE
 }
 
+enum OrderDirection {
+  ASC
+  DESC
+}
+
 """
 A snapshot of media objects old enough to delete and not referenced by accounts, notes, article drafts, or article sources.
 """
@@ -1291,9 +1306,9 @@ type Query {
   actorByUuid(uuid: UUID!): Actor
 
   """
-  Moderator-only connection of every account, ordered by latest post `published` falling back to `account.updated`.  Returns null when the viewer is not a moderator; routes should guard with `viewer.moderator` and redirect non-moderators.
+  Moderator-only connection of every account.  Returns null when the viewer is not a moderator; routes should guard with `viewer.moderator` and redirect non-moderators.
   """
-  adminAccounts(after: String, before: String, first: Int, last: Int): AdminAccountConnection
+  adminAccounts(after: String, before: String, first: Int, last: Int, orderBy: AdminAccountOrderBy, orderDirection: OrderDirection): AdminAccountConnection
   articleByYearAndSlug(handle: String!, idOrYear: String!, slug: String!): Article
   articleDraft(id: ID, uuid: UUID): ArticleDraft
   availableLocales: [Locale!]!

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -1308,7 +1308,7 @@ type Query {
   """
   Moderator-only connection of every account.  Returns null when the viewer is not a moderator; routes should guard with `viewer.moderator` and redirect non-moderators.
   """
-  adminAccounts(after: String, before: String, first: Int, last: Int, orderBy: AdminAccountOrderBy, orderDirection: OrderDirection): AdminAccountConnection
+  adminAccounts(after: String, before: String, first: Int, last: Int, orderBy: AdminAccountOrderBy, orderDirection: OrderDirection, search: String): AdminAccountConnection
   articleByYearAndSlug(handle: String!, idOrYear: String!, slug: String!): Article
   articleDraft(id: ID, uuid: UUID): ArticleDraft
   availableLocales: [Locale!]!

--- a/web-next/src/components/Timestamp.tsx
+++ b/web-next/src/components/Timestamp.tsx
@@ -5,6 +5,7 @@ export interface TimestampProps {
   value: Date | string;
   capitalizeFirstLetter?: boolean;
   allowFuture?: boolean;
+  relativeStyle?: Intl.RelativeTimeFormatStyle;
 }
 
 export function Timestamp(props: TimestampProps) {
@@ -25,6 +26,7 @@ export function Timestamp(props: TimestampProps) {
       {formatRelativeTime(targetDate(), date, i18n.locale, {
         capitalizeFirstLetter: props.capitalizeFirstLetter,
         allowFuture: props.allowFuture,
+        style: props.relativeStyle,
       })}
     </time>
   );

--- a/web-next/src/components/admin/AdminAccountsTable.tsx
+++ b/web-next/src/components/admin/AdminAccountsTable.tsx
@@ -28,7 +28,7 @@ export function AdminAccountsTable(props: AdminAccountsTableProps) {
         @refetchable(queryName: "AdminAccountsTablePaginationQuery")
         @argumentDefinitions(
           cursor: { type: "String" }
-          count: { type: "Int", defaultValue: 50 }
+          count: { type: "Int", defaultValue: 100 }
         )
       {
         adminAccounts(after: $cursor, first: $count)
@@ -81,7 +81,7 @@ export function AdminAccountsTable(props: AdminAccountsTableProps) {
 
   function onLoadMore() {
     setLoadingState("loading");
-    data.loadNext(50, {
+    data.loadNext(100, {
       onComplete(error) {
         setLoadingState(error == null ? "loaded" : "errored");
       },

--- a/web-next/src/components/admin/AdminAccountsTable.tsx
+++ b/web-next/src/components/admin/AdminAccountsTable.tsx
@@ -65,7 +65,6 @@ export function AdminAccountsTable(props: AdminAccountsTableProps) {
       params.set("sort", field);
       params.delete("dir");
     }
-    params.delete("cursor");
     return `${location.pathname}?${params.toString()}`;
   }
 
@@ -76,8 +75,6 @@ export function AdminAccountsTable(props: AdminAccountsTableProps) {
     } else {
       params.delete("q");
     }
-    // Reset to first page when search changes
-    params.delete("cursor");
     return `${location.pathname}?${params.toString()}`;
   }
 

--- a/web-next/src/components/admin/AdminAccountsTable.tsx
+++ b/web-next/src/components/admin/AdminAccountsTable.tsx
@@ -5,6 +5,7 @@ import IconChevronsUpDown from "~icons/lucide/chevrons-up-down";
 import IconSearch from "~icons/lucide/search";
 import IconX from "~icons/lucide/x";
 import { graphql } from "relay-runtime";
+import { ADMIN_SORT_FIELDS } from "~/lib/adminSort.ts";
 import {
   createEffect,
   createMemo,
@@ -41,18 +42,9 @@ export function AdminAccountsTable(props: AdminAccountsTableProps) {
   // Parse once per URL change so all three derived signals share the object.
   const searchParams = createMemo(() => new URLSearchParams(location.search));
 
-  const validSortFields = new Set([
-    "FOLLOWING",
-    "FOLLOWERS",
-    "POSTS",
-    "INVITATIONS_LEFT",
-    "INVITED",
-    "LAST_ACTIVITY",
-    "CREATED",
-  ]);
   const currentSort = () => {
     const raw = searchParams().get("sort")?.toUpperCase() ?? "";
-    return validSortFields.has(raw) ? raw : "LAST_ACTIVITY";
+    return ADMIN_SORT_FIELDS.has(raw) ? raw : "LAST_ACTIVITY";
   };
   const currentDir = () => {
     const raw = searchParams().get("dir")?.toUpperCase() ?? "";
@@ -73,7 +65,7 @@ export function AdminAccountsTable(props: AdminAccountsTableProps) {
       params.set("sort", field);
       params.delete("dir");
     }
-    return `/admin?${params.toString()}`;
+    return `${location.pathname}?${params.toString()}`;
   }
 
   function searchHref(q: string): string {
@@ -85,7 +77,7 @@ export function AdminAccountsTable(props: AdminAccountsTableProps) {
     }
     // Reset to first page when search changes
     params.delete("cursor");
-    return `/admin?${params.toString()}`;
+    return `${location.pathname}?${params.toString()}`;
   }
 
   function onSearchSubmit(e: SubmitEvent) {

--- a/web-next/src/components/admin/AdminAccountsTable.tsx
+++ b/web-next/src/components/admin/AdminAccountsTable.tsx
@@ -1,4 +1,7 @@
-import { A } from "@solidjs/router";
+import { A, useLocation } from "@solidjs/router";
+import IconChevronDown from "~icons/lucide/chevron-down";
+import IconChevronUp from "~icons/lucide/chevron-up";
+import IconChevronsUpDown from "~icons/lucide/chevrons-up-down";
 import { graphql } from "relay-runtime";
 import { createSignal, For, Match, Show, Switch } from "solid-js";
 import { createPaginationFragment } from "solid-relay";
@@ -22,6 +25,44 @@ export interface AdminAccountsTableProps {
 
 export function AdminAccountsTable(props: AdminAccountsTableProps) {
   const { i18n, t } = useLingui();
+  const location = useLocation();
+
+  const currentSort = () =>
+    new URLSearchParams(location.search).get("sort") ?? "LAST_ACTIVITY";
+  const currentDir = () =>
+    new URLSearchParams(location.search).get("dir") ?? "DESC";
+
+  function sortHref(field: string): string {
+    const params = new URLSearchParams(location.search);
+    if (currentSort() === field) {
+      params.set("dir", currentDir() === "DESC" ? "ASC" : "DESC");
+    } else {
+      params.set("sort", field);
+      params.delete("dir");
+    }
+    return `/admin?${params.toString()}`;
+  }
+
+  function SortIcon(props: { field: string }) {
+    return (
+      <span class="ml-1 inline-flex size-3 shrink-0 items-center">
+        <Show
+          when={currentSort() === props.field}
+          fallback={
+            <IconChevronsUpDown class="size-3 text-muted-foreground/50" />
+          }
+        >
+          <Show
+            when={currentDir() === "ASC"}
+            fallback={<IconChevronDown class="size-3" />}
+          >
+            <IconChevronUp class="size-3" />
+          </Show>
+        </Show>
+      </span>
+    );
+  }
+
   const data = createPaginationFragment(
     graphql`
       fragment AdminAccountsTable_query on Query
@@ -29,10 +70,20 @@ export function AdminAccountsTable(props: AdminAccountsTableProps) {
         @argumentDefinitions(
           cursor: { type: "String" }
           count: { type: "Int", defaultValue: 100 }
+          orderBy: { type: "AdminAccountOrderBy" }
+          orderDirection: { type: "OrderDirection" }
         )
       {
-        adminAccounts(after: $cursor, first: $count)
-          @connection(key: "AdminAccountsTable_adminAccounts")
+        adminAccounts(
+          after: $cursor
+          first: $count
+          orderBy: $orderBy
+          orderDirection: $orderDirection
+        )
+          @connection(
+            key: "AdminAccountsTable_adminAccounts"
+            filters: ["orderBy", "orderDirection"]
+          )
         {
           totalCount
           edges {
@@ -103,27 +154,71 @@ export function AdminAccountsTable(props: AdminAccountsTableProps) {
                 <TableRow>
                   <TableHead>{t`Account`}</TableHead>
                   <TableHead class="text-right">
-                    {t`Following`}
+                    <A
+                      href={sortHref("FOLLOWING")}
+                      class="inline-flex items-center justify-end hover:text-foreground transition-colors"
+                    >
+                      {t`Following`}
+                      <SortIcon field="FOLLOWING" />
+                    </A>
                   </TableHead>
                   <TableHead class="text-right">
-                    {t`Followers`}
+                    <A
+                      href={sortHref("FOLLOWERS")}
+                      class="inline-flex items-center justify-end hover:text-foreground transition-colors"
+                    >
+                      {t`Followers`}
+                      <SortIcon field="FOLLOWERS" />
+                    </A>
                   </TableHead>
                   <TableHead class="text-right">
-                    {t`Posts`}
+                    <A
+                      href={sortHref("POSTS")}
+                      class="inline-flex items-center justify-end hover:text-foreground transition-colors"
+                    >
+                      {t`Posts`}
+                      <SortIcon field="POSTS" />
+                    </A>
                   </TableHead>
                   <TableHead class="text-right whitespace-nowrap">
-                    {t`Invitations left`}
+                    <A
+                      href={sortHref("INVITATIONS_LEFT")}
+                      class="inline-flex items-center justify-end hover:text-foreground transition-colors"
+                    >
+                      {t`Invitations left`}
+                      <SortIcon field="INVITATIONS_LEFT" />
+                    </A>
                   </TableHead>
                   <TableHead class="whitespace-nowrap">
                     {t`Invited by`}
                   </TableHead>
                   <TableHead class="text-right">
-                    {t`Invited`}
+                    <A
+                      href={sortHref("INVITED")}
+                      class="inline-flex items-center justify-end hover:text-foreground transition-colors"
+                    >
+                      {t`Invited`}
+                      <SortIcon field="INVITED" />
+                    </A>
                   </TableHead>
                   <TableHead class="whitespace-nowrap">
-                    {t`Last activity`}
+                    <A
+                      href={sortHref("LAST_ACTIVITY")}
+                      class="inline-flex items-center hover:text-foreground transition-colors"
+                    >
+                      {t`Last activity`}
+                      <SortIcon field="LAST_ACTIVITY" />
+                    </A>
                   </TableHead>
-                  <TableHead>{t`Created`}</TableHead>
+                  <TableHead>
+                    <A
+                      href={sortHref("CREATED")}
+                      class="inline-flex items-center hover:text-foreground transition-colors"
+                    >
+                      {t`Created`}
+                      <SortIcon field="CREATED" />
+                    </A>
+                  </TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>

--- a/web-next/src/components/admin/AdminAccountsTable.tsx
+++ b/web-next/src/components/admin/AdminAccountsTable.tsx
@@ -1,9 +1,11 @@
-import { A, useLocation } from "@solidjs/router";
+import { A, useLocation, useNavigate } from "@solidjs/router";
 import IconChevronDown from "~icons/lucide/chevron-down";
 import IconChevronUp from "~icons/lucide/chevron-up";
 import IconChevronsUpDown from "~icons/lucide/chevrons-up-down";
+import IconSearch from "~icons/lucide/search";
+import IconX from "~icons/lucide/x";
 import { graphql } from "relay-runtime";
-import { createSignal, For, Match, Show, Switch } from "solid-js";
+import { createEffect, createSignal, For, Match, Show, Switch } from "solid-js";
 import { createPaginationFragment } from "solid-relay";
 import { Avatar, AvatarImage } from "~/components/ui/avatar.tsx";
 import { Button } from "~/components/ui/button.tsx";
@@ -26,11 +28,19 @@ export interface AdminAccountsTableProps {
 export function AdminAccountsTable(props: AdminAccountsTableProps) {
   const { i18n, t } = useLingui();
   const location = useLocation();
+  const navigate = useNavigate();
 
   const currentSort = () =>
     new URLSearchParams(location.search).get("sort") ?? "LAST_ACTIVITY";
   const currentDir = () =>
     new URLSearchParams(location.search).get("dir") ?? "DESC";
+  const currentSearch = () =>
+    new URLSearchParams(location.search).get("q") ?? "";
+
+  // Sync the text input with the URL whenever the URL's ?q param changes
+  // (e.g. after navigating via a sort-column link).
+  const [searchInput, setSearchInput] = createSignal(currentSearch());
+  createEffect(() => setSearchInput(currentSearch()));
 
   function sortHref(field: string): string {
     const params = new URLSearchParams(location.search);
@@ -41,6 +51,23 @@ export function AdminAccountsTable(props: AdminAccountsTableProps) {
       params.delete("dir");
     }
     return `/admin?${params.toString()}`;
+  }
+
+  function searchHref(q: string): string {
+    const params = new URLSearchParams(location.search);
+    if (q.trim()) {
+      params.set("q", q.trim());
+    } else {
+      params.delete("q");
+    }
+    // Reset to first page when search changes
+    params.delete("cursor");
+    return `/admin?${params.toString()}`;
+  }
+
+  function onSearchSubmit(e: SubmitEvent) {
+    e.preventDefault();
+    navigate(searchHref(searchInput()));
   }
 
   function SortIcon(props: { field: string }) {
@@ -72,6 +99,7 @@ export function AdminAccountsTable(props: AdminAccountsTableProps) {
           count: { type: "Int", defaultValue: 100 }
           orderBy: { type: "AdminAccountOrderBy" }
           orderDirection: { type: "OrderDirection" }
+          search: { type: "String" }
         )
       {
         adminAccounts(
@@ -79,10 +107,11 @@ export function AdminAccountsTable(props: AdminAccountsTableProps) {
           first: $count
           orderBy: $orderBy
           orderDirection: $orderDirection
+          search: $search
         )
           @connection(
             key: "AdminAccountsTable_adminAccounts"
-            filters: ["orderBy", "orderDirection"]
+            filters: ["orderBy", "orderDirection", "search"]
           )
         {
           totalCount
@@ -145,6 +174,33 @@ export function AdminAccountsTable(props: AdminAccountsTableProps) {
     <Show keyed when={data()?.adminAccounts}>
       {(conn) => (
         <>
+          <form onSubmit={onSearchSubmit} class="mb-4 flex gap-2">
+            <div class="relative flex-1">
+              <IconSearch class="absolute left-2.5 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+              <input
+                type="search"
+                value={searchInput()}
+                onInput={(e) => setSearchInput(e.currentTarget.value)}
+                placeholder={t`Search by name or username…`}
+                class="h-9 w-full rounded-md border border-input bg-transparent pl-8 pr-3 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+              />
+            </div>
+            <Button type="submit" variant="outline" size="sm">
+              {t`Search`}
+            </Button>
+            <Show when={currentSearch()}>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                class="gap-1"
+                onClick={() => navigate(searchHref(""))}
+              >
+                <IconX class="size-3" />
+                {t`Clear`}
+              </Button>
+            </Show>
+          </form>
           <p class="mb-4 text-sm text-muted-foreground">
             {t`Total: ${formatNumber(conn.totalCount)}`}
           </p>

--- a/web-next/src/components/admin/AdminAccountsTable.tsx
+++ b/web-next/src/components/admin/AdminAccountsTable.tsx
@@ -65,6 +65,7 @@ export function AdminAccountsTable(props: AdminAccountsTableProps) {
       params.set("sort", field);
       params.delete("dir");
     }
+    params.delete("cursor");
     return `${location.pathname}?${params.toString()}`;
   }
 

--- a/web-next/src/components/admin/AdminAccountsTable.tsx
+++ b/web-next/src/components/admin/AdminAccountsTable.tsx
@@ -5,7 +5,15 @@ import IconChevronsUpDown from "~icons/lucide/chevrons-up-down";
 import IconSearch from "~icons/lucide/search";
 import IconX from "~icons/lucide/x";
 import { graphql } from "relay-runtime";
-import { createEffect, createSignal, For, Match, Show, Switch } from "solid-js";
+import {
+  createEffect,
+  createMemo,
+  createSignal,
+  For,
+  Match,
+  Show,
+  Switch,
+} from "solid-js";
 import { createPaginationFragment } from "solid-relay";
 import { Avatar, AvatarImage } from "~/components/ui/avatar.tsx";
 import { Button } from "~/components/ui/button.tsx";
@@ -30,12 +38,27 @@ export function AdminAccountsTable(props: AdminAccountsTableProps) {
   const location = useLocation();
   const navigate = useNavigate();
 
-  const currentSort = () =>
-    new URLSearchParams(location.search).get("sort") ?? "LAST_ACTIVITY";
-  const currentDir = () =>
-    new URLSearchParams(location.search).get("dir") ?? "DESC";
-  const currentSearch = () =>
-    new URLSearchParams(location.search).get("q") ?? "";
+  // Parse once per URL change so all three derived signals share the object.
+  const searchParams = createMemo(() => new URLSearchParams(location.search));
+
+  const validSortFields = new Set([
+    "FOLLOWING",
+    "FOLLOWERS",
+    "POSTS",
+    "INVITATIONS_LEFT",
+    "INVITED",
+    "LAST_ACTIVITY",
+    "CREATED",
+  ]);
+  const currentSort = () => {
+    const raw = searchParams().get("sort")?.toUpperCase() ?? "";
+    return validSortFields.has(raw) ? raw : "LAST_ACTIVITY";
+  };
+  const currentDir = () => {
+    const raw = searchParams().get("dir")?.toUpperCase() ?? "";
+    return raw === "ASC" || raw === "DESC" ? raw : "DESC";
+  };
+  const currentSearch = () => searchParams().get("q") ?? "";
 
   // Sync the text input with the URL whenever the URL's ?q param changes
   // (e.g. after navigating via a sort-column link).

--- a/web-next/src/components/admin/AdminAccountsTable.tsx
+++ b/web-next/src/components/admin/AdminAccountsTable.tsx
@@ -111,14 +111,18 @@ export function AdminAccountsTable(props: AdminAccountsTableProps) {
                   <TableHead class="text-right">
                     {t`Posts`}
                   </TableHead>
-                  <TableHead class="text-right">
-                    {t`Invitations`}
+                  <TableHead class="text-right whitespace-nowrap">
+                    {t`Invitations left`}
                   </TableHead>
-                  <TableHead>{t`Invited by`}</TableHead>
+                  <TableHead class="whitespace-nowrap">
+                    {t`Invited by`}
+                  </TableHead>
                   <TableHead class="text-right">
                     {t`Invited`}
                   </TableHead>
-                  <TableHead>{t`Last activity`}</TableHead>
+                  <TableHead class="whitespace-nowrap">
+                    {t`Last activity`}
+                  </TableHead>
                   <TableHead>{t`Created`}</TableHead>
                 </TableRow>
               </TableHeader>
@@ -198,7 +202,7 @@ export function AdminAccountsTable(props: AdminAccountsTableProps) {
                                   {inviter.name}
                                 </span>
                                 <span class="text-xs text-muted-foreground/70">
-                                  {inviter.handle}
+                                  @{inviter.username}
                                 </span>
                               </span>
                             </A>
@@ -209,10 +213,16 @@ export function AdminAccountsTable(props: AdminAccountsTableProps) {
                         {formatNumber(edge.node.invitees.totalCount)}
                       </TableCell>
                       <TableCell>
-                        <Timestamp value={edge.lastActivity} />
+                        <Timestamp
+                          value={edge.lastActivity}
+                          relativeStyle="narrow"
+                        />
                       </TableCell>
                       <TableCell>
-                        <Timestamp value={edge.node.created} />
+                        <Timestamp
+                          value={edge.node.created}
+                          relativeStyle="narrow"
+                        />
                       </TableCell>
                     </TableRow>
                   )}

--- a/web-next/src/lib/adminSort.ts
+++ b/web-next/src/lib/adminSort.ts
@@ -1,0 +1,13 @@
+// Valid values for the AdminAccountOrderBy GraphQL enum.  Kept here so both
+// the route preload (admin/index.tsx) and the table component
+// (admin/AdminAccountsTable.tsx) can share the same validation set without
+// duplicating the list.
+export const ADMIN_SORT_FIELDS = new Set([
+  "FOLLOWING",
+  "FOLLOWERS",
+  "POSTS",
+  "INVITATIONS_LEFT",
+  "INVITED",
+  "LAST_ACTIVITY",
+  "CREATED",
+]);

--- a/web-next/src/locales/en-US/messages.po
+++ b/web-next/src/locales/en-US/messages.po
@@ -2021,6 +2021,14 @@ msgstr "Save draft to see preview"
 msgid "Saving…"
 msgstr "Saving…"
 
+#: src/components/admin/AdminAccountsTable.tsx
+msgid "Search by name or username…"
+msgstr "Search by name or username…"
+
+#: src/components/admin/AdminAccountsTable.tsx
+msgid "Clear"
+msgstr "Clear"
+
 #: src/components/AppSidebar.tsx:356
 #: src/routes/(root)/search.tsx:180
 #: src/routes/(root)/search.tsx:197

--- a/web-next/src/locales/en-US/messages.po
+++ b/web-next/src/locales/en-US/messages.po
@@ -1204,6 +1204,9 @@ msgid "Invitation sent"
 msgstr "Invitation sent"
 
 #: src/components/admin/AdminAccountsTable.tsx:115
+msgid "Invitations left"
+msgstr "Invitations left"
+
 #: src/components/AppSidebar.tsx:676
 #: src/routes/(root)/admin/invitations.tsx:156
 msgid "Invitations"

--- a/web-next/src/locales/ja-JP/messages.po
+++ b/web-next/src/locales/ja-JP/messages.po
@@ -1200,6 +1200,9 @@ msgid "Invitation sent"
 msgstr "招待状を送信しました"
 
 #: src/components/admin/AdminAccountsTable.tsx:115
+msgid "Invitations left"
+msgstr "残り招待数"
+
 #: src/components/AppSidebar.tsx:676
 #: src/routes/(root)/admin/invitations.tsx:156
 msgid "Invitations"

--- a/web-next/src/locales/ja-JP/messages.po
+++ b/web-next/src/locales/ja-JP/messages.po
@@ -2017,6 +2017,14 @@ msgstr "下書きを保存するとプレビューが表示されます"
 msgid "Saving…"
 msgstr "保存中…"
 
+#: src/components/admin/AdminAccountsTable.tsx
+msgid "Search by name or username…"
+msgstr "名前またはユーザー名で検索…"
+
+#: src/components/admin/AdminAccountsTable.tsx
+msgid "Clear"
+msgstr "クリア"
+
 #: src/components/AppSidebar.tsx:356
 #: src/routes/(root)/search.tsx:180
 #: src/routes/(root)/search.tsx:197

--- a/web-next/src/locales/ko-KR/messages.po
+++ b/web-next/src/locales/ko-KR/messages.po
@@ -1200,6 +1200,9 @@ msgid "Invitation sent"
 msgstr "초대장이 발송되었습니다"
 
 #: src/components/admin/AdminAccountsTable.tsx:115
+msgid "Invitations left"
+msgstr "남은 초대장"
+
 #: src/components/AppSidebar.tsx:676
 #: src/routes/(root)/admin/invitations.tsx:156
 msgid "Invitations"

--- a/web-next/src/locales/ko-KR/messages.po
+++ b/web-next/src/locales/ko-KR/messages.po
@@ -2017,6 +2017,14 @@ msgstr "미리보기를 보려면 초고로 저장하세요"
 msgid "Saving…"
 msgstr "저장 중…"
 
+#: src/components/admin/AdminAccountsTable.tsx
+msgid "Search by name or username…"
+msgstr "이름 또는 아이디로 검색…"
+
+#: src/components/admin/AdminAccountsTable.tsx
+msgid "Clear"
+msgstr "지우기"
+
 #: src/components/AppSidebar.tsx:356
 #: src/routes/(root)/search.tsx:180
 #: src/routes/(root)/search.tsx:197

--- a/web-next/src/locales/zh-CN/messages.po
+++ b/web-next/src/locales/zh-CN/messages.po
@@ -1200,6 +1200,9 @@ msgid "Invitation sent"
 msgstr "邀请已发送"
 
 #: src/components/admin/AdminAccountsTable.tsx:115
+msgid "Invitations left"
+msgstr "剩余邀请"
+
 #: src/components/AppSidebar.tsx:676
 #: src/routes/(root)/admin/invitations.tsx:156
 msgid "Invitations"

--- a/web-next/src/locales/zh-CN/messages.po
+++ b/web-next/src/locales/zh-CN/messages.po
@@ -2017,6 +2017,14 @@ msgstr "保存草稿以查看预览"
 msgid "Saving…"
 msgstr "保存中…"
 
+#: src/components/admin/AdminAccountsTable.tsx
+msgid "Search by name or username…"
+msgstr "按名称或用户名搜索…"
+
+#: src/components/admin/AdminAccountsTable.tsx
+msgid "Clear"
+msgstr "清除"
+
 #: src/components/AppSidebar.tsx:356
 #: src/routes/(root)/search.tsx:180
 #: src/routes/(root)/search.tsx:197

--- a/web-next/src/locales/zh-TW/messages.po
+++ b/web-next/src/locales/zh-TW/messages.po
@@ -2017,6 +2017,14 @@ msgstr "儲存草稿以查看預覽"
 msgid "Saving…"
 msgstr "儲存中…"
 
+#: src/components/admin/AdminAccountsTable.tsx
+msgid "Search by name or username…"
+msgstr "按名稱或用戶名搜尋…"
+
+#: src/components/admin/AdminAccountsTable.tsx
+msgid "Clear"
+msgstr "清除"
+
 #: src/components/AppSidebar.tsx:356
 #: src/routes/(root)/search.tsx:180
 #: src/routes/(root)/search.tsx:197

--- a/web-next/src/locales/zh-TW/messages.po
+++ b/web-next/src/locales/zh-TW/messages.po
@@ -1200,6 +1200,9 @@ msgid "Invitation sent"
 msgstr "邀請已發送"
 
 #: src/components/admin/AdminAccountsTable.tsx:115
+msgid "Invitations left"
+msgstr "剩餘邀請"
+
 #: src/components/AppSidebar.tsx:676
 #: src/routes/(root)/admin/invitations.tsx:156
 msgid "Invitations"

--- a/web-next/src/locales/zh-TW/messages.po
+++ b/web-next/src/locales/zh-TW/messages.po
@@ -2019,7 +2019,7 @@ msgstr "儲存中…"
 
 #: src/components/admin/AdminAccountsTable.tsx
 msgid "Search by name or username…"
-msgstr "按名稱或用戶名搜尋…"
+msgstr "按名稱或使用者名稱搜尋…"
 
 #: src/components/admin/AdminAccountsTable.tsx
 msgid "Clear"

--- a/web-next/src/routes/(root)/admin/index.tsx
+++ b/web-next/src/routes/(root)/admin/index.tsx
@@ -27,7 +27,7 @@ const loadAdminAccountsPageQuery = routePreloadedQuery(
     loadQuery<adminAccountsPageQuery>(
       useRelayEnvironment()(),
       adminAccountsPageQuery,
-      { count: 50 },
+      { count: 100 },
     ),
   "loadAdminAccountsPageQuery",
 );

--- a/web-next/src/routes/(root)/admin/index.tsx
+++ b/web-next/src/routes/(root)/admin/index.tsx
@@ -45,11 +45,23 @@ function parseQueryParams(search: string): {
   search: string | undefined;
 } {
   const params = new URLSearchParams(search);
-  const orderBy =
-    (params.get("sort")?.toUpperCase() as AdminAccountOrderBy | null) ??
-      "LAST_ACTIVITY";
-  const orderDirection =
-    (params.get("dir")?.toUpperCase() as OrderDirection | null) ?? "DESC";
+  const validOrderBy = new Set<string>([
+    "FOLLOWING",
+    "FOLLOWERS",
+    "POSTS",
+    "INVITATIONS_LEFT",
+    "INVITED",
+    "LAST_ACTIVITY",
+    "CREATED",
+  ]);
+  const rawSort = params.get("sort")?.toUpperCase() ?? "";
+  const orderBy: AdminAccountOrderBy = validOrderBy.has(rawSort)
+    ? (rawSort as AdminAccountOrderBy)
+    : "LAST_ACTIVITY";
+  const rawDir = params.get("dir")?.toUpperCase() ?? "";
+  const orderDirection: OrderDirection = rawDir === "ASC" || rawDir === "DESC"
+    ? rawDir
+    : "DESC";
   const q = params.get("q") ?? undefined;
   return { orderBy, orderDirection, search: q };
 }

--- a/web-next/src/routes/(root)/admin/index.tsx
+++ b/web-next/src/routes/(root)/admin/index.tsx
@@ -1,4 +1,4 @@
-import { Navigate } from "@solidjs/router";
+import { Navigate, useLocation } from "@solidjs/router";
 import { graphql } from "relay-runtime";
 import { Show } from "solid-js";
 import {
@@ -10,39 +10,74 @@ import { AdminAccountsTable } from "~/components/admin/AdminAccountsTable.tsx";
 import { Title } from "~/components/Title.tsx";
 import { WideContainer } from "~/components/WideContainer.tsx";
 import { useLingui } from "~/lib/i18n/macro.d.ts";
-import type { adminAccountsPageQuery } from "./__generated__/adminAccountsPageQuery.graphql.ts";
+import type {
+  AdminAccountOrderBy,
+  adminAccountsPageQuery,
+  OrderDirection,
+} from "./__generated__/adminAccountsPageQuery.graphql.ts";
 import { routePreloadedQuery } from "~/lib/relayPreload.ts";
 
 const adminAccountsPageQuery = graphql`
-  query adminAccountsPageQuery($count: Int!, $cursor: String) {
+  query adminAccountsPageQuery(
+    $count: Int!
+    $cursor: String
+    $orderBy: AdminAccountOrderBy
+    $orderDirection: OrderDirection
+  ) {
     viewer {
       moderator
     }
-    ...AdminAccountsTable_query @arguments(count: $count, cursor: $cursor)
+    ...AdminAccountsTable_query
+      @arguments(
+        count: $count
+        cursor: $cursor
+        orderBy: $orderBy
+        orderDirection: $orderDirection
+      )
   }
 `;
 
+function parseSortParams(search: string): {
+  orderBy: AdminAccountOrderBy;
+  orderDirection: OrderDirection;
+} {
+  const params = new URLSearchParams(search);
+  const orderBy =
+    (params.get("sort")?.toUpperCase() as AdminAccountOrderBy | null) ??
+      "LAST_ACTIVITY";
+  const orderDirection =
+    (params.get("dir")?.toUpperCase() as OrderDirection | null) ?? "DESC";
+  return { orderBy, orderDirection };
+}
+
 const loadAdminAccountsPageQuery = routePreloadedQuery(
-  () =>
+  (orderBy: AdminAccountOrderBy, orderDirection: OrderDirection) =>
     loadQuery<adminAccountsPageQuery>(
       useRelayEnvironment()(),
       adminAccountsPageQuery,
-      { count: 100 },
+      { count: 100, orderBy, orderDirection },
     ),
   "loadAdminAccountsPageQuery",
 );
 
 export const route = {
-  preload() {
-    void loadAdminAccountsPageQuery();
+  preload({ location }: { location: { search: string } }) {
+    const { orderBy, orderDirection } = parseSortParams(location.search);
+    void loadAdminAccountsPageQuery(orderBy, orderDirection);
   },
 };
 
 export default function AdminAccountsPage() {
   const { t } = useLingui();
+  const location = useLocation();
+  const sortParams = () => parseSortParams(location.search);
   const data = createPreloadedQuery<adminAccountsPageQuery>(
     adminAccountsPageQuery,
-    () => loadAdminAccountsPageQuery(),
+    () =>
+      loadAdminAccountsPageQuery(
+        sortParams().orderBy,
+        sortParams().orderDirection,
+      ),
   );
   return (
     <WideContainer class="p-4">

--- a/web-next/src/routes/(root)/admin/index.tsx
+++ b/web-next/src/routes/(root)/admin/index.tsx
@@ -23,6 +23,7 @@ const adminAccountsPageQuery = graphql`
     $cursor: String
     $orderBy: AdminAccountOrderBy
     $orderDirection: OrderDirection
+    $search: String
   ) {
     viewer {
       moderator
@@ -33,13 +34,15 @@ const adminAccountsPageQuery = graphql`
         cursor: $cursor
         orderBy: $orderBy
         orderDirection: $orderDirection
+        search: $search
       )
   }
 `;
 
-function parseSortParams(search: string): {
+function parseQueryParams(search: string): {
   orderBy: AdminAccountOrderBy;
   orderDirection: OrderDirection;
+  search: string | undefined;
 } {
   const params = new URLSearchParams(search);
   const orderBy =
@@ -47,37 +50,43 @@ function parseSortParams(search: string): {
       "LAST_ACTIVITY";
   const orderDirection =
     (params.get("dir")?.toUpperCase() as OrderDirection | null) ?? "DESC";
-  return { orderBy, orderDirection };
+  const q = params.get("q") ?? undefined;
+  return { orderBy, orderDirection, search: q };
 }
 
 const loadAdminAccountsPageQuery = routePreloadedQuery(
-  (orderBy: AdminAccountOrderBy, orderDirection: OrderDirection) =>
+  (
+    orderBy: AdminAccountOrderBy,
+    orderDirection: OrderDirection,
+    search: string | undefined,
+  ) =>
     loadQuery<adminAccountsPageQuery>(
       useRelayEnvironment()(),
       adminAccountsPageQuery,
-      { count: 100, orderBy, orderDirection },
+      { count: 100, orderBy, orderDirection, search },
     ),
   "loadAdminAccountsPageQuery",
 );
 
 export const route = {
   preload({ location }: { location: { search: string } }) {
-    const { orderBy, orderDirection } = parseSortParams(location.search);
-    void loadAdminAccountsPageQuery(orderBy, orderDirection);
+    const { orderBy, orderDirection, search } = parseQueryParams(
+      location.search,
+    );
+    void loadAdminAccountsPageQuery(orderBy, orderDirection, search);
   },
 };
 
 export default function AdminAccountsPage() {
   const { t } = useLingui();
   const location = useLocation();
-  const sortParams = () => parseSortParams(location.search);
+  const queryParams = () => parseQueryParams(location.search);
   const data = createPreloadedQuery<adminAccountsPageQuery>(
     adminAccountsPageQuery,
-    () =>
-      loadAdminAccountsPageQuery(
-        sortParams().orderBy,
-        sortParams().orderDirection,
-      ),
+    () => {
+      const { orderBy, orderDirection, search } = queryParams();
+      return loadAdminAccountsPageQuery(orderBy, orderDirection, search);
+    },
   );
   return (
     <WideContainer class="p-4">

--- a/web-next/src/routes/(root)/admin/index.tsx
+++ b/web-next/src/routes/(root)/admin/index.tsx
@@ -16,6 +16,7 @@ import type {
   OrderDirection,
 } from "./__generated__/adminAccountsPageQuery.graphql.ts";
 import { routePreloadedQuery } from "~/lib/relayPreload.ts";
+import { ADMIN_SORT_FIELDS } from "~/lib/adminSort.ts";
 
 const adminAccountsPageQuery = graphql`
   query adminAccountsPageQuery(
@@ -45,17 +46,8 @@ function parseQueryParams(search: string): {
   search: string | undefined;
 } {
   const params = new URLSearchParams(search);
-  const validOrderBy = new Set<string>([
-    "FOLLOWING",
-    "FOLLOWERS",
-    "POSTS",
-    "INVITATIONS_LEFT",
-    "INVITED",
-    "LAST_ACTIVITY",
-    "CREATED",
-  ]);
   const rawSort = params.get("sort")?.toUpperCase() ?? "";
-  const orderBy: AdminAccountOrderBy = validOrderBy.has(rawSort)
+  const orderBy: AdminAccountOrderBy = ADMIN_SORT_FIELDS.has(rawSort)
     ? (rawSort as AdminAccountOrderBy)
     : "LAST_ACTIVITY";
   const rawDir = params.get("dir")?.toUpperCase() ?? "";


### PR DESCRIPTION
<img width="2141" height="418" alt="Admin accounts page in Korean showing a search box (“이름 또는 아이디로 검색…”), total account count (814), and a sortable table with columns for 팔로잉, 팔로워, 콘텐츠, 남은 초대장, 초대한 사람, 초대한 수, 마지막 활동, and 가입일" src="https://github.com/user-attachments/assets/69770793-0678-4ab3-98b2-b66522f0956d" />

The admin accounts table was showing 50 accounts per page, had a column header (“Invitations”) that shared a translation key with the sidebar navigation item, and had no way to sort or search. This PR adds those things.

### Column headers

The “Invitations” column uses a dedicated `msgid` (“Invitations left”), with translations specific to the table header: Korean 남은 초대장, Japanese 残り招待数, Simplified Chinese 剩余邀请, and Traditional Chinese 剩餘邀請. They no longer have to match the sidebar label. Multi-word headers (Invitations left, Invited by, Last activity) get `whitespace-nowrap` so they don't break across lines in narrower viewports. The "Invited by" column now shows `@username` without the domain, since every account on this page is on Hackers' Pub. The Last activity and Created columns use the `narrow` relative-time style for more compact display.

### Page size

Bumped to 100. The change touches three places: the fragment argument `defaultValue` in *AdminAccountsTable.tsx*, the initial `loadQuery` variables in *admin/index.tsx*, and the `loadNext` call.

### Sorting

Clicking any of these seven column headers sorts by that field descending: Following, Followers, Posts, Invitations left, Invited, Last activity, and Created. Clicking again reverses it. The active column shows a chevron (↓ or ↑); inactive columns show ↕. Sort state lives in `?sort=FIELD&dir=DIR` URL parameters, so a sorted view can be shared or bookmarked.

On the backend, *graphql/admin.ts* gains two new GraphQL enums (`AdminAccountOrderBy`, `OrderDirection`) and four aggregate subqueries: follower count, following count, post count, and invitee count. The cursor is generalized from a hardcoded `lastActivity|id` pair to `base64(field|dir|val|id)`. Timestamp cursors are formatted as UTC using `to_char(... AT TIME ZONE 'UTC', ...)` so the encoded value is session-timezone–independent, and validated against a strict format regex with component-level calendar checks before reaching SQL. Integer cursors are validated to decimal digits within PostgreSQL bigint range. Stale cursors (wrong sort field or direction) are silently dropped rather than producing wrong results. Follower and following subqueries filter to `accepted IS NOT NULL` so sort order matches the displayed totals.

### Search

A search box above the table filters by display name and username via case-insensitive substring matching. Space-separated words are `AND`ed, so “hong minhee” matches “Hong Minhee”, but not an account that only matches one of the two words. The “Total:” count reflects the active filter. The search state lives in `?q=...` and is preserved when changing the sort; the sort state is likewise preserved when submitting a search.