### PR TITLE
web-next: fix some hydration mismatches

### DIFF
--- a/web-next/src/components/AppSidebar.tsx
+++ b/web-next/src/components/AppSidebar.tsx
@@ -83,7 +83,6 @@ function removeWebNextCookie(): void {
 
 export interface AppSidebarProps {
   $signedAccount?: AppSidebar_signedAccount$key | null;
-  signedAccountLoaded?: boolean;
 }
 
 export function AppSidebar(props: AppSidebarProps) {
@@ -128,11 +127,11 @@ export function AppSidebar(props: AppSidebarProps) {
   );
 
   createEffect(() => {
-    setUnreadNotificationsCount(signedAccount()?.unreadNotificationsCount);
+    setUnreadNotificationsCount(signedAccount.latest?.unreadNotificationsCount);
   });
 
   createEffect(() => {
-    if (!props.signedAccountLoaded || signedAccount()?.username == null) {
+    if (signedAccount.latest?.username == null) {
       return;
     }
 
@@ -198,7 +197,7 @@ export function AppSidebar(props: AppSidebarProps) {
             {t`Timeline`}
           </SidebarGroupLabel>
           <SidebarGroupContent>
-            <Show when={props.signedAccountLoaded && signedAccount()}>
+            <Show when={signedAccount()}>
               <SidebarMenuItem class="list-none">
                 <SidebarMenuButton
                   as={A}
@@ -361,18 +360,18 @@ export function AppSidebar(props: AppSidebarProps) {
         <AdminSection signedAccount={signedAccount()} />
         <ComposeSection
           signedAccount={signedAccount()}
-          visible={props.signedAccountLoaded && !!signedAccount() &&
+          visible={!!signedAccount() &&
             !isMobile() && state() !== "collapsed"}
           onComposeNote={openNoteCompose}
         />
         <RecentDraftsSection
           signedAccount={signedAccount()}
-          visible={props.signedAccountLoaded && !!signedAccount() &&
+          visible={!!signedAccount() &&
             !isMobile() && state() !== "collapsed"}
         />
         <AccountSection
           signedAccount={signedAccount()}
-          signedAccountLoaded={props.signedAccountLoaded}
+          signedAccountLoaded={!!signedAccount()}
           unreadNotificationsCount={unreadNotificationsCount()}
           onSignOut={onSignOut}
         />

--- a/web-next/src/components/PostEngagementBar.tsx
+++ b/web-next/src/components/PostEngagementBar.tsx
@@ -644,7 +644,7 @@ function CountAffordance(props: {
   segment: string;
   label: string;
 }) {
-  const text = (
+  const text = () => (
     <span class="inline-flex items-center px-1 text-xs">{props.count}</span>
   );
   // Distinct affordance from the neighbouring icon button so the count
@@ -657,7 +657,7 @@ function CountAffordance(props: {
   //     mouse users get a clear "two zones" read when they pass between
   //     the icon and the count.
   return (
-    <Show when={props.engagementBase} fallback={text}>
+    <Show when={props.engagementBase} fallback={text()}>
       <A
         href={`${props.engagementBase}/${props.segment}`}
         class="inline-flex items-center px-1 text-xs rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground hover:underline hover:shadow-[inset_1px_0_0_0_var(--border)] focus-visible:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"

--- a/web-next/src/components/PostVisibilitySelect.tsx
+++ b/web-next/src/components/PostVisibilitySelect.tsx
@@ -21,7 +21,7 @@ export function PostVisibilitySelect(props: PostVisibilitySelectProps) {
     {
       value: "PUBLIC" as const,
       label: t`Public`,
-      icon: (
+      icon: () => (
         <svg
           xmlns="http://www.w3.org/2000/svg"
           fill="none"
@@ -41,7 +41,7 @@ export function PostVisibilitySelect(props: PostVisibilitySelectProps) {
     {
       value: "UNLISTED" as const,
       label: t`Quiet public`,
-      icon: (
+      icon: () => (
         <svg
           xmlns="http://www.w3.org/2000/svg"
           fill="none"
@@ -61,7 +61,7 @@ export function PostVisibilitySelect(props: PostVisibilitySelectProps) {
     {
       value: "FOLLOWERS" as const,
       label: t`Followers only`,
-      icon: (
+      icon: () => (
         <svg
           xmlns="http://www.w3.org/2000/svg"
           fill="none"
@@ -81,7 +81,7 @@ export function PostVisibilitySelect(props: PostVisibilitySelectProps) {
     {
       value: "DIRECT" as const,
       label: t`Mentioned only`,
-      icon: (
+      icon: () => (
         <svg
           xmlns="http://www.w3.org/2000/svg"
           fill="none"
@@ -109,7 +109,7 @@ export function PostVisibilitySelect(props: PostVisibilitySelectProps) {
       itemComponent={(props) => (
         <SelectItem item={props.item}>
           <div class="flex flex-row gap-1 items-center">
-            {props.item.rawValue.icon}
+            {props.item.rawValue.icon()}
             <span>{props.item.rawValue.label}</span>
           </div>
         </SelectItem>
@@ -117,11 +117,11 @@ export function PostVisibilitySelect(props: PostVisibilitySelectProps) {
     >
       <SelectTrigger class="w-[180px]">
         <SelectValue<
-          { value: PostVisibility; label: string; icon: JSX.Element }
+          { value: PostVisibility; label: string; icon: () => JSX.Element }
         >>
           {(state) => (
             <div class="flex flex-row gap-1 items-center">
-              {state.selectedOption().icon}
+              {state.selectedOption().icon()}
               <span>{state.selectedOption().label}</span>
             </div>
           )}

--- a/web-next/src/routes/(root).tsx
+++ b/web-next/src/routes/(root).tsx
@@ -100,10 +100,7 @@ export default function RootLayout(props: RouteSectionProps) {
     >
       <NoteComposeProvider>
         <SidebarProvider>
-          <AppSidebar
-            $signedAccount={signedAccount()?.viewer}
-            signedAccountLoaded={!signedAccount.pending}
-          />
+          <AppSidebar $signedAccount={signedAccount()?.viewer} />
           <header class="fixed inset-x-0 top-0 z-40 border-b bg-background/80 backdrop-blur md:hidden">
             <div class="flex h-14 items-center justify-between px-4">
               <SidebarTrigger


### PR DESCRIPTION
- It is better to render JSX on demand, rather than pre-rendering it, to prevent hydration mismatches
- It is better to directly rely on data proxy accessors, rather than deriving separate flags