### PR TITLE
Redact auth token secrets from debug logs

### DIFF
--- a/models/signin.test.ts
+++ b/models/signin.test.ts
@@ -1,6 +1,6 @@
+import { configure, type LogRecord, reset } from "@logtape/logtape";
 import { assert } from "@std/assert/assert";
 import { assertEquals } from "@std/assert/equals";
-import { configure, type LogRecord, reset } from "@logtape/logtape";
 import {
   createSigninToken,
   deleteSigninToken,

--- a/models/signin.test.ts
+++ b/models/signin.test.ts
@@ -1,5 +1,6 @@
 import { assert } from "@std/assert/assert";
 import { assertEquals } from "@std/assert/equals";
+import { configure, type LogRecord, reset } from "@logtape/logtape";
 import {
   createSigninToken,
   deleteSigninToken,
@@ -29,5 +30,47 @@ Deno.test({
 
     const deleted = await getSigninToken(kv, token.token);
     assertEquals(deleted, undefined);
+  },
+});
+
+Deno.test({
+  name: "signin token debug log omits replay secrets",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  async fn() {
+    const { kv } = createTestKv();
+    const records: LogRecord[] = [];
+    const accountId = "019d9162-ffff-7fff-8fff-ffffffffffff";
+
+    await configure({
+      reset: true,
+      sinks: { capture: (record) => records.push(record) },
+      loggers: [
+        {
+          category: ["hackerspub", "models", "signin"],
+          lowestLevel: "debug",
+          sinks: ["capture"],
+        },
+      ],
+    });
+
+    try {
+      const token = await createSigninToken(kv, accountId);
+      const record = records.find((record) =>
+        record.rawMessage ===
+          "Created sign-in token for {accountId} (expires in {expires})"
+      );
+
+      assert(record != null);
+      assertEquals(record.properties.accountId, accountId);
+      assertEquals(record.properties.token, undefined);
+      assertEquals(record.properties.code, undefined);
+
+      const serializedProperties = JSON.stringify(record.properties);
+      assertEquals(serializedProperties.includes(token.token), false);
+      assertEquals(serializedProperties.includes(token.code), false);
+    } finally {
+      await reset();
+    }
   },
 });

--- a/models/signin.ts
+++ b/models/signin.ts
@@ -36,9 +36,9 @@ export async function createSigninToken(
     tokenData,
     EXPIRATION.total("millisecond"),
   );
-  logger.debug("Created sign-in token (expires in {expires}): {token}", {
+  logger.debug("Created sign-in token for {accountId} (expires in {expires})", {
     expires: EXPIRATION,
-    token: tokenData,
+    accountId: tokenData.accountId,
   });
   return tokenData;
 }

--- a/models/signup.test.ts
+++ b/models/signup.test.ts
@@ -1,6 +1,6 @@
+import { configure, type LogRecord, reset } from "@logtape/logtape";
 import { assert } from "@std/assert/assert";
 import { assertEquals } from "@std/assert/equals";
-import { configure, type LogRecord, reset } from "@logtape/logtape";
 import {
   createAccount,
   createSignupToken,

--- a/models/signup.test.ts
+++ b/models/signup.test.ts
@@ -1,5 +1,6 @@
 import { assert } from "@std/assert/assert";
 import { assertEquals } from "@std/assert/equals";
+import { configure, type LogRecord, reset } from "@logtape/logtape";
 import {
   createAccount,
   createSignupToken,
@@ -35,6 +36,53 @@ Deno.test({
 
     const deleted = await getSignupToken(kv, token.token);
     assertEquals(deleted, undefined);
+  },
+});
+
+Deno.test({
+  name: "signup token debug log omits replay secrets",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  async fn() {
+    const { kv } = createTestKv();
+    const records: LogRecord[] = [];
+    const email = "candidate@example.com";
+    const inviterId = "019d9162-ffff-7fff-8fff-ffffffffffff";
+
+    await configure({
+      reset: true,
+      sinks: { capture: (record) => records.push(record) },
+      loggers: [
+        {
+          category: ["hackerspub", "models", "signup"],
+          lowestLevel: "debug",
+          sinks: ["capture"],
+        },
+      ],
+    });
+
+    try {
+      const token = await createSignupToken(kv, email, { inviterId });
+      const record = records.find((record) =>
+        record.rawMessage ===
+          "Created sign-up token (expires in {expires}, invited: {invited})"
+      );
+
+      assert(record != null);
+      assertEquals(record.properties.invited, true);
+      assertEquals(record.properties.email, undefined);
+      assertEquals(record.properties.inviterId, undefined);
+      assertEquals(record.properties.token, undefined);
+      assertEquals(record.properties.code, undefined);
+
+      const serializedProperties = JSON.stringify(record.properties);
+      assertEquals(serializedProperties.includes(email), false);
+      assertEquals(serializedProperties.includes(inviterId), false);
+      assertEquals(serializedProperties.includes(token.token), false);
+      assertEquals(serializedProperties.includes(token.code), false);
+    } finally {
+      await reset();
+    }
   },
 });
 

--- a/models/signup.ts
+++ b/models/signup.ts
@@ -56,10 +56,13 @@ export async function createSignupToken(
     tokenData,
     expiration.total("millisecond"),
   );
-  logger.debug("Created sign-up token (expires in {expires}): {token}", {
-    expires: EXPIRATION,
-    token: tokenData,
-  });
+  logger.debug(
+    "Created sign-up token (expires in {expires}, invited: {invited})",
+    {
+      expires: expiration,
+      invited: tokenData.inviterId != null,
+    },
+  );
   return tokenData;
 }
 


### PR DESCRIPTION
## Summary
- Redact sign-in token debug logs so they keep account/expiry context without logging token UUIDs or verification codes.
- Redact sign-up token debug logs so they keep expiry/invited metadata without logging email addresses, inviter IDs, token UUIDs, or verification codes.
- Add LogTape capture tests that exercise the real token creation paths and assert replay secrets are absent from debug log properties.

Fixes #245

## AI assistance
This pull request and commit were prepared with OpenAI GPT-5.5. I reviewed the issue, policy, code paths, tests, and validation output before submitting.

## Validation
- RED: `docker run --rm -u "$(id -u):$(id -g)" -e DENO_DIR=/workspace/.deno_cache -e DATABASE_URL=postgres://postgres:postgres@127.0.0.1:5432/hackerspub_test -v "$PWD":/workspace -w /workspace denoland/deno:2.7.13 deno test --allow-all --filter "token debug log omits" models/signin.test.ts models/signup.test.ts` failed before the fix because the expected redacted log records were absent.
- GREEN: same focused debug-log test command passed after the fix.
- `docker run --rm -u "$(id -u):$(id -g)" -e DENO_DIR=/workspace/.deno_cache -e DATABASE_URL=postgres://postgres:postgres@127.0.0.1:5432/hackerspub_test -v "$PWD":/workspace -w /workspace denoland/deno:2.7.13 deno test --allow-all --filter "token" models/signin.test.ts models/signup.test.ts` passed: 4 passed, 0 failed, 1 filtered.
- `docker run --rm -u "$(id -u):$(id -g)" -e DENO_DIR=/workspace/.deno_cache -v "$PWD":/workspace -w /workspace denoland/deno:2.7.13 deno fmt --check models/signin.ts models/signin.test.ts models/signup.ts models/signup.test.ts` passed.
- `docker run --rm -u "$(id -u):$(id -g)" -e DENO_DIR=/workspace/.deno_cache -e DATABASE_URL=postgres://postgres:postgres@127.0.0.1:5432/hackerspub_test -v "$PWD":/workspace -w /workspace denoland/deno:2.7.13 deno lint models/signin.ts models/signin.test.ts models/signup.ts models/signup.test.ts` passed.
- `docker run --rm -u "$(id -u):$(id -g)" -e DENO_DIR=/workspace/.deno_cache -v "$PWD":/workspace -w /workspace denoland/deno:2.7.13 deno check models/signin.test.ts models/signup.test.ts` passed.
- `git diff --check -- models/signin.ts models/signin.test.ts models/signup.ts models/signup.test.ts` passed.
