### PR TITLE
web-next: Reduce per-interaction allocations

### DIFF
--- a/web-next/src/components/LanguageSelect.tsx
+++ b/web-next/src/components/LanguageSelect.tsx
@@ -1,5 +1,5 @@
 import { POSSIBLE_LOCALES } from "@hackerspub/models/i18n";
-import { Show } from "solid-js";
+import { createMemo, Show } from "solid-js";
 import {
   Combobox,
   ComboboxContent,
@@ -28,20 +28,37 @@ interface LocaleInfo {
   readonly disabled: boolean;
 }
 
+// `Intl.DisplayNames` instances are expensive: each one loads CLDR tables for
+// its target locale. With ~200 entries in POSSIBLE_LOCALES we'd otherwise
+// allocate that many tables on every read of `locales()`. Cache per-locale
+// formatters once at module scope and reuse them.
+const nativeDisplayNamesCache = new Map<string, Intl.DisplayNames>();
+function getNativeDisplayNames(locale: string): Intl.DisplayNames {
+  let dn = nativeDisplayNamesCache.get(locale);
+  if (dn == null) {
+    dn = new Intl.DisplayNames(locale, { type: "language" });
+    nativeDisplayNamesCache.set(locale, dn);
+  }
+  return dn;
+}
+
+const englishNames = new Intl.DisplayNames("en", { type: "language" });
+
 export function LanguageSelect(props: LanguageSelectProps) {
   const { t, i18n } = useLingui();
-  const displayNames = new Intl.DisplayNames(i18n.locale, { type: "language" });
-  const englishNames = new Intl.DisplayNames("en", { type: "language" });
-  const locales = () => {
+  const displayNames = createMemo(() =>
+    new Intl.DisplayNames(i18n.locale, { type: "language" })
+  );
+  const locales = createMemo(() => {
+    const dn = displayNames();
     const localeCodes: string[] = [...POSSIBLE_LOCALES];
-    if (props.value != null && localeCodes.includes(props.value.baseName)) {
+    if (props.value != null && !localeCodes.includes(props.value.baseName)) {
       localeCodes.push(props.value.baseName);
     }
-    const locales = localeCodes.map<LocaleInfo>((locale) => {
-      const name = displayNames.of(locale) ?? locale;
-      const nativeName =
-        new Intl.DisplayNames(locale, { type: "language" }).of(locale) ??
-          locale;
+    const exclude = props.exclude;
+    const result = localeCodes.map<LocaleInfo>((locale) => {
+      const name = dn.of(locale) ?? locale;
+      const nativeName = getNativeDisplayNames(locale).of(locale) ?? locale;
       return {
         code: locale,
         name,
@@ -50,12 +67,12 @@ export function LanguageSelect(props: LanguageSelectProps) {
           englishNames.of(locale) ?? ""
         }`
           .trim(),
-        disabled: props.exclude?.some((l) => l.baseName === locale) ?? false,
+        disabled: exclude?.some((l) => l.baseName === locale) ?? false,
       };
     });
-    locales.sort((a, b) => a.name.localeCompare(b.name));
-    return locales;
-  };
+    result.sort((a, b) => a.name.localeCompare(b.name));
+    return result;
+  });
   return (
     <Combobox<LocaleInfo>
       options={locales()}

--- a/web-next/src/components/Timestamp.tsx
+++ b/web-next/src/components/Timestamp.tsx
@@ -88,6 +88,25 @@ export function getRelativeTimeUpdateDelayMs(
   return DAY;
 }
 
+// `Intl.RelativeTimeFormat` is comparatively expensive to construct (it loads
+// CLDR data for the locale). The previous implementation built a fresh
+// formatter on every render, which is wasteful when 25+ timeline cards each
+// re-render their relative timestamp every 1s/30s/1min. Cache by the
+// (locale, options) tuple that actually affects output.
+const relativeTimeFormatCache = new Map<string, Intl.RelativeTimeFormat>();
+function getRelativeTimeFormat(
+  locale: string,
+  options: Intl.RelativeTimeFormatOptions,
+): Intl.RelativeTimeFormat {
+  const key = `${locale}|${options.numeric ?? ""}|${options.style ?? ""}`;
+  let f = relativeTimeFormatCache.get(key);
+  if (f == null) {
+    f = new Intl.RelativeTimeFormat(locale, options);
+    relativeTimeFormatCache.set(key, f);
+  }
+  return f;
+}
+
 function formatRelativeTime(
   currentDate: Date,
   targetDate: Date,
@@ -107,16 +126,17 @@ function formatRelativeTime(
   for (const { unit, ms } of UNITS) {
     if (absDiff >= ms) {
       const value = Math.round(diffMs / ms);
-      const f = new Intl.RelativeTimeFormat(locale, options).format(
-        value,
-        unit,
-      );
+      const f = getRelativeTimeFormat(locale, options).format(value, unit);
       return options.capitalizeFirstLetter
         ? f.charAt(0).toUpperCase() + f.slice(1)
         : f;
     }
   }
-  const f = new Intl.RelativeTimeFormat(locale).format(0, "second");
+  // Use the caller-supplied `options` here so the fallback respects
+  // `numeric` / `style` the same way the loop above does. Hardcoding a
+  // different `numeric` would change the output for value=0 (e.g. "now"
+  // under "auto" vs "0 seconds ago" under the Intl default "always").
+  const f = getRelativeTimeFormat(locale, options).format(0, "second");
   return options.capitalizeFirstLetter
     ? f.charAt(0).toUpperCase() + f.slice(1)
     : f;


### PR DESCRIPTION
## Summary

Firefox profiler traces of `https://hackers.pub/feed` showed a sustained **+10 MB/s heap growth during interaction** while the same route was flat (~0 MB/s) when idle. This PR fixes the two app-level hotspots that explain a large share of that. The remaining follow-ups are tracked in #333 (see "What's not in this PR").

The single biggest interaction-time allocator was opening the `NoteComposer` and triggering `LanguageSelect`; further re-mount churn of Kobalte primitives traces to an upstream solid-relay bug (see below).

## What's in this PR

### `LanguageSelect.tsx` — memoize the locale list, cache Intl formatters

- `locales` was a plain function (not a memo), so every reactive read from `<Combobox>` re-ran a `.map()` over ~200 `POSSIBLE_LOCALES` entries. Each iteration allocated a fresh `Intl.DisplayNames(locale, { type: "language" })`, which loads the CLDR table for its target locale. Steady-state cost: ~200 CLDR-backed instances per reactive tick.
- Wrap `locales` in `createMemo`, hoist `englishNames` to module scope (its locale is constant), and memoize `displayNames` so it only rebuilds when `i18n.locale` actually changes.
- Cache per-locale `Intl.DisplayNames` instances at module scope so the native-name lookup costs one allocation over the lifetime of the page.

**Drive-by fix:** the existing guard pushed `props.value.baseName` onto the locale list only when it was *already present* (producing a duplicate) and never extended the list to cover a non-standard locale. The condition is inverted so the value is appended when missing, which matches the apparent intent (the combobox needs to be able to show the active value even if it's outside the canonical set).

### `Timestamp.tsx` — cache `Intl.RelativeTimeFormat`

- `formatRelativeTime` constructed a new `Intl.RelativeTimeFormat` on every render, which fires once per visible timestamp every 1s / 30s / 1min depending on age. Cache instances by `(locale, numeric, style)` at module scope.
- The value=0 fallback path is also routed through the cache and now uses the caller's `options`, so its `numeric`/`style` stays consistent with the loop above (the previous code passed no options in the fallback, falling through to Intl's `"always"` default while the loop honoured the caller's `"auto"`).

## What's not in this PR

The original draft also dropped `keyed` from two `<Show keyed when={…()}>` wrappers (`PostEngagementBar`, `PublicTimeline`). The local lint plugin `web-next/lint-plugins/keyed-show.ts` correctly enforces `keyed` for solid-relay-backed accessors — non-keyed risks the documented "Stale read from `<Show>`" race when a fragment flips to null inside the same tick as a downstream reactive read — so that draft has been reverted.

The perf cost that motivated the original drop is **real**: with the current `solid-relay@1.0.0-beta.25`, `<Show keyed>` over a Relay fragment re-mounts the entire subtree on every snapshot tick, including pure field updates such as a reaction toggle or a polled count delta. Profiler runs showed `_$createComponent` dominating the leaf-sample list during interaction, with the Kobalte chunks (`@kobalte/core/dist/chunk/*`) at ~1,200 inclusive samples per ~1,733 hackers.pub samples.

The root cause is upstream: `createFragment` pre-clears `data` to `undefined` immediately before applying its identity-preserving `reconcile({ key: "__id", merge: true })`. Solid's `reconcile` early-exits to "return the new value as-is" when the current state isn't wrappable (see `solid-js/store` `modifiers.ts`), so the pre-clear guarantees a fresh top-level reference on every snapshot — defeating the merge.

Upstream fix proposed at **XiNiHa/solid-relay#68**. Once that ships, the `keyed` Shows in this codebase stop re-mounting on field updates with no change needed here. As an interim, the workspace could vendor it via `pnpm-workspace.yaml#patchedDependencies` (the workspace already patches `@kobalte/core`, `@solidjs/start`, and `solid-js`).

Other follow-ups from this investigation, tracked in #333 rather than an in-repo TODO file:

- Lazy-mount `Tooltip` in `PostEngagementBar` (~100 primitives mounted at all times on a 25-card timeline).
- Lazy-mount `ActorHoverCard` (×25 author avatars + per-mention).
- Replace `ui/skeleton.tsx` with a plain element (Kobalte's `Skeleton` is `<div role="status" aria-busy="true">`; the 18 in-app uses are decorative shapes).
- Replace `ui/separator.tsx` with `<hr>` (one call site).
- Drop `ui/button.tsx` wrapper for non-polymorphic uses (~46 call sites; mechanical but high churn for small gain).


