### PR TITLE
Make GraphQL schema generation explicit

### DIFF
--- a/graphql/deno.json
+++ b/graphql/deno.json
@@ -11,7 +11,7 @@
     ]
   },
   "tasks": {
-    "codegen": "deno run -A --env-file=../.env mod.ts",
+    "codegen": "deno run -A --env-file=../.env generate-schema.ts",
     "dev": "deno run -A --unstable-cron --env-file=../.env main.ts",
     "start": "deno run -A --unstable-otel --unstable-cron --env-file=../.env main.ts",
     "dev:worker": "deno run -A --unstable-cron --env-file=../.env worker.ts",

--- a/graphql/generate-schema.ts
+++ b/graphql/generate-schema.ts
@@ -1,0 +1,10 @@
+import { printSchema } from "graphql";
+import { schema } from "./mod.ts";
+
+export async function generateSchema(
+  output: URL = new URL("schema.graphql", import.meta.url),
+): Promise<void> {
+  await Deno.writeTextFile(output, printSchema(schema));
+}
+
+if (import.meta.main) await generateSchema();

--- a/graphql/mod.ts
+++ b/graphql/mod.ts
@@ -1,5 +1,4 @@
-import { type GraphQLSchema, printSchema } from "graphql";
-import path from "node:path";
+import type { GraphQLSchema } from "graphql";
 import "./account.ts";
 import "./admin.ts";
 import "./actor.ts";
@@ -34,8 +33,3 @@ export type { UserContext as Context } from "./builder.ts";
 export { createYogaServer } from "./server.ts";
 
 export const schema: GraphQLSchema = builder.toSchema();
-
-void Deno.writeTextFile(
-  path.join(import.meta.dirname ?? "", "schema.graphql"),
-  printSchema(schema),
-);

--- a/graphql/schema-generation.test.ts
+++ b/graphql/schema-generation.test.ts
@@ -1,0 +1,55 @@
+import assert from "node:assert";
+import { join } from "node:path";
+import test from "node:test";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { generateSchema } from "./generate-schema.ts";
+
+const repositoryRoot = new URL("../", import.meta.url);
+const rootConfig = new URL("deno.json", repositoryRoot);
+const schemaModule = new URL("graphql/mod.ts", repositoryRoot);
+
+test("runtime schema can be imported without write access", async () => {
+  const source = `await import(${JSON.stringify(schemaModule.href)});`;
+  const entrypoint = `data:application/typescript,${
+    encodeURIComponent(source)
+  }`;
+  const output = await new Deno.Command(Deno.execPath(), {
+    args: [
+      "run",
+      "--config",
+      fileURLToPath(rootConfig),
+      "--cached-only",
+      "--allow-all",
+      "--deny-write",
+      entrypoint,
+    ],
+    cwd: repositoryRoot,
+    stdout: "piped",
+    stderr: "piped",
+  }).output();
+
+  assert.equal(
+    output.success,
+    true,
+    new TextDecoder().decode(output.stderr),
+  );
+});
+
+test("explicit schema generation is deterministic", async () => {
+  const directory = await Deno.makeTempDir();
+  try {
+    const firstOutput = pathToFileURL(join(directory, "schema-1.graphql"));
+    const secondOutput = pathToFileURL(join(directory, "schema-2.graphql"));
+
+    await generateSchema(firstOutput);
+    await generateSchema(secondOutput);
+
+    const checkedInSchema = await Deno.readTextFile(
+      new URL("schema.graphql", import.meta.url),
+    );
+    assert.equal(await Deno.readTextFile(firstOutput), checkedInSchema);
+    assert.equal(await Deno.readTextFile(secondOutput), checkedInSchema);
+  } finally {
+    await Deno.remove(directory, { recursive: true });
+  }
+});


### PR DESCRIPTION
Closes #339.


Why
---

Before this change, importing the runtime GraphQL module also scheduled a write to *graphql/schema.graphql*. That tied schema assembly to code generation: a server startup or test import needed filesystem write access, and the write was started without being awaited. Runtime consumers should only receive the assembled schema. Updating a checked-in artifact should require an explicit command.


Approach
--------

The runtime module now stops after building and exporting the schema. A new *graphql/generate-schema.ts* module owns serialization and file output. Its exported `generateSchema()` function accepts an output URL, which makes the behavior testable without touching the working tree. An `import.meta.main` guard reserves the default checked-in write for direct execution. The GraphQL codegen task in *graphql/deno.json* invokes this entry point, so `mise run codegen` remains the workspace command that refreshes the schema.

The regression test starts a fresh Deno process with write access denied and imports *graphql/mod.ts*. This tests the permission boundary itself instead of checking for a particular implementation detail. A second test generates the schema twice into temporary files and compares both results with *graphql/schema.graphql*. The comparison fails if two runs diverge or if the checked-in artifact is stale.