### PR TITLE
Split `NoteComposer` into focused state and UI modules

### DIFF
--- a/web-next/src/components/NoteComposer.tsx
+++ b/web-next/src/components/NoteComposer.tsx
@@ -1,58 +1,29 @@
 import { useNavigate } from "@solidjs/router";
-import {
-  ConnectionHandler,
-  fetchQuery,
-  graphql,
-  type RecordSourceSelectorProxy,
-} from "relay-runtime";
-import { createStore, produce } from "solid-js/store";
+import { fetchQuery, graphql } from "relay-runtime";
 import IconFileText from "~icons/lucide/file-text";
 import IconImage from "~icons/lucide/image";
 import IconListChecks from "~icons/lucide/list-checks";
-import IconPlus from "~icons/lucide/plus";
-import IconSquare from "~icons/lucide/square";
-import IconTrash from "~icons/lucide/trash-2";
 import IconX from "~icons/lucide/x";
 import {
   batch,
   createEffect,
   createMemo,
   createSignal,
-  For,
   on,
   onCleanup,
   onMount,
   Show,
   untrack,
 } from "solid-js";
-import { createMutation, useRelayEnvironment } from "solid-relay";
-import { getBrowserLocalStorage } from "~/lib/browserStorage.ts";
-import { ensureLinkInContent } from "~/lib/composerLink.ts";
-import { encodeHandleSegment } from "~/lib/handleSegment.ts";
+import { useRelayEnvironment } from "solid-relay";
 import { detectLanguage } from "~/lib/langdet.ts";
 import { shouldSuggestArticleForNote } from "~/lib/formatGuidance.ts";
 import {
-  getNoteDraftStorageKey,
-  isMeaningfulNoteDraft,
   type NoteDraftData,
-  type NoteDraftMedia,
   type NoteDraftScope,
-  readNoteDraft,
-  removeNoteDraft,
   type StoredNoteDraft,
-  writeNoteDraft,
 } from "~/lib/noteDraftStorage.ts";
 import {
-  publishNoteDraftChange,
-  registerNoteDraftFlush,
-  subscribeNoteDraftChanges,
-} from "~/lib/noteDraftSync.ts";
-import {
-  UploadAbortedError,
-  uploadMediumFile,
-} from "~/lib/uploadMediumWithProgress.ts";
-import {
-  getSupportedImageContentType,
   isSupportedImageFile,
   supportedImageAccept,
 } from "~/lib/supportedImageFile.ts";
@@ -90,174 +61,25 @@ import {
 } from "~/contexts/ActingAccountContext.tsx";
 import { useViewer } from "~/contexts/ViewerContext.tsx";
 import { useLingui } from "~/lib/i18n/macro.d.ts";
-import type { NoteComposerGeneratedAltTextQuery } from "./__generated__/NoteComposerGeneratedAltTextQuery.graphql.ts";
-import type { NoteComposerArticleDraftMutation } from "./__generated__/NoteComposerArticleDraftMutation.graphql.ts";
-import type { NoteComposerMutation } from "./__generated__/NoteComposerMutation.graphql.ts";
-import type { NoteComposerDraftMediaQuery } from "./__generated__/NoteComposerDraftMediaQuery.graphql.ts";
+import {
+  createMediaController,
+  MAX_MEDIA,
+} from "./note-composer/createMediaController.ts";
+import { createDraftController } from "./note-composer/createDraftController.ts";
+import { createPollController } from "./note-composer/createPollController.ts";
+import { createSubmissionController } from "./note-composer/createSubmissionController.ts";
+import {
+  createNoteDraftData,
+  getNoteComposerDraftScope,
+  hasUnstorableDraftMedia,
+  toStorableNoteDraftData,
+} from "./note-composer/draftState.ts";
+import { MediaEditor } from "./note-composer/MediaEditor.tsx";
+import { PollEditor } from "./note-composer/PollEditor.tsx";
+import { MIN_POLL_OPTIONS } from "./note-composer/pollState.ts";
 import type { NoteComposerPostByUrlQuery } from "./__generated__/NoteComposerPostByUrlQuery.graphql.ts";
-import type { NoteComposerQuestionMutation } from "./__generated__/NoteComposerQuestionMutation.graphql.ts";
 import type { NoteComposerQuotedPostQuery } from "./__generated__/NoteComposerQuotedPostQuery.graphql.ts";
 import type { NoteComposerReplyTargetQuery } from "./__generated__/NoteComposerReplyTargetQuery.graphql.ts";
-import type { NoteComposerUpdateMutation } from "./__generated__/NoteComposerUpdateMutation.graphql.ts";
-
-const NoteComposerMutation = graphql`
-  mutation NoteComposerMutation(
-    $input: CreateNoteInput!
-    $connections: [ID!]!
-    $includeDiscussionThreadFields: Boolean!
-    $actingAccountId: ID
-  ) {
-    createNote(input: $input) {
-      __typename
-      ... on CreateNotePayload {
-        note
-          @prependNode(
-            connections: $connections
-            edgeTypeName: "PostLinkSharingPostsConnectionEdge"
-          ) {
-          id
-          uuid
-          sourceId
-          replyTarget(actingAccountId: $actingAccountId) {
-            id
-          }
-          hasVisibleReplies(actingAccountId: $actingAccountId)
-          actor {
-            id
-            handle
-            username
-            local
-          }
-          ...PermalinkThread_replyNode @arguments(
-            actingAccountId: $actingAccountId
-          )
-          # Only news-discussion posts prepend into a connection and need the
-          # row fields; skip them for every other compose/reply/quote path.
-          ...NewsDiscussionThread_post
-            @arguments(actingAccountId: $actingAccountId)
-            @include(if: $includeDiscussionThreadFields)
-        }
-      }
-      ... on InvalidInputError {
-        inputPath
-      }
-      ... on NotAuthenticatedError {
-        notAuthenticated
-      }
-    }
-  }
-`;
-
-const NoteComposerQuestionMutation = graphql`
-  mutation NoteComposerQuestionMutation(
-    $input: CreateQuestionInput!
-    $connections: [ID!]!
-    $includeDiscussionThreadFields: Boolean!
-    $actingAccountId: ID
-  ) {
-    createQuestion(input: $input) {
-      __typename
-      ... on CreateQuestionPayload {
-        question
-          @prependNode(
-            connections: $connections
-            edgeTypeName: "PostLinkSharingPostsConnectionEdge"
-          ) {
-          id
-          uuid
-          sourceId
-          replyTarget(actingAccountId: $actingAccountId) {
-            id
-          }
-          hasVisibleReplies(actingAccountId: $actingAccountId)
-          actor {
-            id
-          }
-          ...PermalinkThread_replyNode @arguments(
-            actingAccountId: $actingAccountId
-          )
-          ...NewsDiscussionThread_post
-            @arguments(actingAccountId: $actingAccountId)
-            @include(if: $includeDiscussionThreadFields)
-        }
-      }
-      ... on InvalidInputError {
-        inputPath
-      }
-      ... on NotAuthenticatedError {
-        notAuthenticated
-      }
-    }
-  }
-`;
-
-const NoteComposerUpdateMutation = graphql`
-  mutation NoteComposerUpdateMutation($input: UpdateNoteInput!) {
-    updateNote(input: $input) {
-      __typename
-      ... on UpdateNotePayload {
-        note {
-          id
-          content
-          rawContent
-          language
-          quotePolicy
-        }
-      }
-      ... on InvalidInputError {
-        inputPath
-      }
-      ... on NotAuthenticatedError {
-        notAuthenticated
-      }
-    }
-  }
-`;
-
-const NoteComposerArticleDraftMutation = graphql`
-  mutation NoteComposerArticleDraftMutation(
-    $input: SaveArticleDraftInput!
-    $connections: [ID!]!
-  ) {
-    saveArticleDraft(input: $input) {
-      __typename
-      ... on SaveArticleDraftPayload {
-        draft
-          @prependNode(
-            connections: $connections
-            edgeTypeName: "AccountArticleDraftsConnectionEdge"
-          ) {
-          id
-          uuid
-          title
-          content
-          tags
-          updated
-        }
-      }
-      ... on InvalidInputError {
-        inputPath
-      }
-      ... on NotAuthenticatedError {
-        notAuthenticated
-      }
-    }
-  }
-`;
-
-const NoteComposerDraftMediaQuery = graphql`
-  query NoteComposerDraftMediaQuery($ids: [ID!]!) {
-    nodes(ids: $ids) {
-      ... on Medium {
-        id
-        uuid
-        url
-        width
-        height
-      }
-    }
-  }
-`;
 
 const NoteComposerQuotedPostQuery = graphql`
   query NoteComposerQuotedPostQuery($id: ID!) {
@@ -371,89 +193,6 @@ const NoteComposerPostByUrlQuery = graphql`
   }
 `;
 
-const NoteComposerGeneratedAltTextQuery = graphql`
-  query NoteComposerGeneratedAltTextQuery(
-    $mediumId: ID!
-    $language: Locale!
-    $context: String
-  ) {
-    node(id: $mediumId) {
-      ... on Medium {
-        generatedAltText(language: $language, context: $context)
-      }
-    }
-  }
-`;
-
-const MAX_MEDIA = 20;
-const MIN_POLL_OPTIONS = 2;
-const MAX_POLL_OPTIONS = 20;
-
-interface PollOptionDraft {
-  localId: string;
-  title: string;
-}
-
-interface ValidatedPollInput {
-  title: string;
-  multiple: boolean;
-  options: string[];
-  ends: string;
-}
-
-function createLocalId(): string {
-  return globalThis.crypto?.randomUUID?.() ??
-    Math.random().toString(36).slice(2);
-}
-
-function formatDateTimeLocal(date: Date): string {
-  const pad = (value: number) => String(value).padStart(2, "0");
-  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${
-    pad(date.getDate())
-  }T${pad(date.getHours())}:${pad(date.getMinutes())}`;
-}
-
-function parseDateTimeLocal(value: string): Date {
-  const match = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})$/.exec(value);
-  if (match == null) return new Date(NaN);
-  const [, year, month, day, hours, minutes] = match.map(Number);
-  const date = new Date(year, month - 1, day, hours, minutes);
-  if (
-    date.getFullYear() !== year ||
-    date.getMonth() !== month - 1 ||
-    date.getDate() !== day ||
-    date.getHours() !== hours ||
-    date.getMinutes() !== minutes
-  ) {
-    return new Date(NaN);
-  }
-  return date;
-}
-
-function defaultPollEnds(): string {
-  const date = new Date();
-  date.setDate(date.getDate() + 1);
-  date.setSeconds(0, 0);
-  return formatDateTimeLocal(date);
-}
-
-interface MediaItem {
-  localId: string;
-  file?: File;
-  previewUrl: string;
-  alt: string;
-  mediumRelayId?: string;
-  uuid?: string;
-  url?: string;
-  width?: number;
-  height?: number;
-  uploading: boolean;
-  uploadProgress: number;
-  generatingAlt: boolean;
-  abortUpload?: () => void;
-  altSubscription?: { unsubscribe: () => void };
-}
-
 interface QuotedPostPreview {
   typename: "Note" | "Article" | "Question";
   excerpt: string;
@@ -464,10 +203,6 @@ interface QuotedPostPreview {
 }
 
 export type NoteDraftFlush = () => boolean;
-
-function revokePreviewUrl(url: string): void {
-  if (url.startsWith("blob:")) URL.revokeObjectURL(url);
-}
 
 export interface NoteComposerProps {
   onSuccess?: () => void;
@@ -587,10 +322,6 @@ export function NoteComposer(props: NoteComposerProps) {
     selectedActingAccountOption() == null
       ? {}
       : actingAccount.composeInputForKey(actingAccountKey());
-  const editActingAccountInput = () =>
-    props.editingAuthorAccountId == null
-      ? {}
-      : { actingAccountId: props.editingAuthorAccountId };
   const allowPoll = () => props.allowPoll !== false;
   const canCreatePoll = () => !props.editingNoteId && allowPoll();
   const [pastedQuoteId, setPastedQuoteId] = createSignal<string | null>(null);
@@ -632,72 +363,23 @@ export function NoteComposer(props: NoteComposerProps) {
     ),
   );
 
-  const [createNote, isCreating] = createMutation<NoteComposerMutation>(
-    NoteComposerMutation,
-  );
-  const [createQuestion, isCreatingQuestion] = createMutation<
-    NoteComposerQuestionMutation
-  >(
-    NoteComposerQuestionMutation,
-  );
-  const [updateNote, isUpdating] = createMutation<NoteComposerUpdateMutation>(
-    NoteComposerUpdateMutation,
-  );
-  const [saveArticleDraft, isSavingArticleDraft] = createMutation<
-    NoteComposerArticleDraftMutation
-  >(
-    NoteComposerArticleDraftMutation,
-  );
-  const [mediaItems, setMediaItems] = createStore<MediaItem[]>([]);
-  const [pollOptions, setPollOptions] = createStore<PollOptionDraft[]>([
-    { localId: createLocalId(), title: "" },
-    { localId: createLocalId(), title: "" },
-  ]);
-  const [pollEnabled, setPollEnabled] = createSignal(false);
-  const [pollTitle, setPollTitle] = createSignal("");
-  const [pollMultiple, setPollMultiple] = createSignal(false);
-  const [pollEnds, setPollEnds] = createSignal(defaultPollEnds());
+  const media = createMediaController({
+    environment,
+    editing: () => !!props.editingNoteId,
+    language: () => language()?.baseName ?? i18n.locale,
+    content,
+  });
+  const mediaItems = media.items;
+  const poll = createPollController();
   const [isDraggingOver, setIsDraggingOver] = createSignal(false);
   const [editorResetKey, setEditorResetKey] = createSignal(0);
   let formRef: HTMLFormElement | undefined;
   let removeDragListeners: (() => void) | undefined;
   let textareaRef: HTMLTextAreaElement | undefined;
   let fileInputRef: HTMLInputElement | undefined;
-  let saveDraftTimer: ReturnType<typeof setTimeout> | undefined;
-  let draftRestoreMediaSubscription:
-    | { unsubscribe: () => void }
-    | undefined;
-  let restoringDraft = false;
-  let formDraftKey: string | null = null;
-  let unregisterDraftFlush: (() => void) | undefined;
-  const draftSyncOrigin = Symbol("NoteComposer");
 
-  const draftScope = createMemo<NoteDraftScope | null>(() => {
-    if (props.editingNoteId) return null;
-    if (props.replyTargetId) {
-      return { type: "reply", targetId: props.replyTargetId };
-    }
-    const quoteId = props.quotedPostId;
-    if (quoteId) return { type: "quote", targetId: quoteId };
-    if (props.ensureLinkUrl) return { type: "link", url: props.ensureLinkUrl };
-    const initial = props.initialContent?.trim();
-    if (initial) return { type: "prefill", content: initial };
-    return { type: "new" };
-  });
-  const draftStorageKey = createMemo(() => {
-    if (props.draftActive === false) return null;
-    const scope = draftScope();
-    const username = viewer.username();
-    if (scope == null || username == null) return null;
-    return getNoteDraftStorageKey(username, scope);
-  });
-  const [loadedDraftKey, setLoadedDraftKey] = createSignal<string | null>(null);
-  const [hasLocalDraft, setHasLocalDraft] = createSignal(false);
-  const [draftSaveStatus, setDraftSaveStatus] = createSignal<
-    "idle" | "saved" | "unavailable"
-  >("idle");
-  const [showDeleteDraftConfirm, setShowDeleteDraftConfirm] = createSignal(
-    false,
+  const draftScope = createMemo<NoteDraftScope | null>(() =>
+    getNoteComposerDraftScope(props)
   );
   const [showArticleSuggestion, setShowArticleSuggestion] = createSignal(
     false,
@@ -709,17 +391,7 @@ export function NoteComposer(props: NoteComposerProps) {
   );
 
   onCleanup(() => {
-    saveCurrentDraftNow();
-    props.onDraftFlushAvailable?.(null);
-    unregisterDraftFlush?.();
     removeDragListeners?.();
-    clearTimeout(saveDraftTimer);
-    draftRestoreMediaSubscription?.unsubscribe();
-    for (const item of mediaItems) {
-      item.abortUpload?.();
-      item.altSubscription?.unsubscribe();
-      revokePreviewUrl(item.previewUrl);
-    }
   });
 
   // In edit mode treat any divergence from the original as dirty, including
@@ -733,13 +405,11 @@ export function NoteComposer(props: NoteComposerProps) {
       language()?.baseName !== (props.initialLanguage ?? undefined) ||
       quotePolicy() !== (props.initialQuotePolicy ?? "EVERYONE")
     );
-    const pollDirty = canCreatePoll() && pollEnabled();
-    return contentDirty || mediaItems.length > 0 || editMetaDirty || pollDirty;
+    const pollDirty = canCreatePoll() && poll.enabled();
+    return contentDirty || mediaItems().length > 0 || editMetaDirty ||
+      pollDirty;
   });
   createEffect(() => props.onContentChange?.(dirty()));
-  const isSubmitting = () =>
-    isCreating() || isCreatingQuestion() ||
-    isUpdating() || isSavingArticleDraft();
   const isPlainNewNote = () =>
     !props.editingNoteId &&
     !props.replyTargetId &&
@@ -749,64 +419,9 @@ export function NoteComposer(props: NoteComposerProps) {
     effectiveQuotedPostId() == null;
   const canSwitchToArticle = () =>
     isPlainNewNote() &&
-    mediaItems.length === 0 &&
-    !pollEnabled() &&
+    mediaItems().length === 0 &&
+    !poll.enabled() &&
     content().trim() !== "";
-  const articleDraftConnections = () => {
-    const viewerId = viewer.id();
-    if (viewerId == null) return [];
-    return [
-      "SignedAccount_articleDrafts",
-      "draftsPaginationFragment_articleDrafts",
-      "FloatingComposeButton_articleDrafts",
-    ].map((connectionKey) =>
-      ConnectionHandler.getConnectionID(viewerId, connectionKey)
-    );
-  };
-  const appendCreatedPostToConnections = (
-    store: RecordSourceSelectorProxy,
-    rootFieldName: "createNote" | "createQuestion",
-    postFieldName: "note" | "question",
-  ): boolean => {
-    const payload = store.getRootField(rootFieldName);
-    if (
-      payload?.getValue("__typename") !==
-        (rootFieldName === "createNote"
-          ? "CreateNotePayload"
-          : "CreateQuestionPayload")
-    ) {
-      return false;
-    }
-    const post = payload.getLinkedRecord(postFieldName);
-    if (post == null) return false;
-    const connections = props.appendToConnections ?? [];
-    for (const connectionId of connections) {
-      const connection = store.get(connectionId);
-      if (connection == null) continue;
-      const edge = ConnectionHandler.createEdge(
-        store,
-        connection,
-        post,
-        "PostDescendantsConnectionEdge",
-      );
-      ConnectionHandler.insertEdgeAfter(connection, edge);
-    }
-    return true;
-  };
-  const incrementReplyCount = (store: RecordSourceSelectorProxy) => {
-    if (props.replyTargetId == null) return;
-    const target = store.get(props.replyTargetId);
-    const replies = target?.getLinkedRecord("replies", {
-      first: 0,
-      actingAccountId: actingAccountInput().actingAccountId ?? null,
-    });
-    if (replies == null) return;
-    const totalCount = replies.getValue("totalCount");
-    if (typeof totalCount !== "number") return;
-    replies.setValue(totalCount + 1, "totalCount");
-  };
-
-  const getBrowserDraftStorage = getBrowserLocalStorage;
 
   createEffect(() => {
     if (
@@ -827,267 +442,30 @@ export function NoteComposer(props: NoteComposerProps) {
     setShowArticleSwitchButton(true);
   };
 
-  const switchToArticleDraft = () => {
-    const username = viewer.username();
-    const draftContent = content().trim();
-    if (username == null) {
-      showToast({
-        title: t`Error`,
-        description: t`You must be signed in to save a draft`,
-        variant: "error",
-      });
-      return;
-    }
-    if (!canSwitchToArticle() || draftContent === "") {
-      setShowArticleSuggestion(false);
-      return;
-    }
-
-    saveCurrentDraftNow();
-    saveArticleDraft({
-      variables: {
-        input: {
-          title: "",
-          content: draftContent,
-          tags: [],
-        },
-        connections: articleDraftConnections(),
-      },
-      onCompleted(response) {
-        if (
-          response.saveArticleDraft.__typename === "SaveArticleDraftPayload"
-        ) {
-          const draft = response.saveArticleDraft.draft;
-          clearCurrentDraft();
-          resetForm();
-          setShowArticleSuggestion(false);
-          setShowArticleSwitchButton(false);
-          showToast({
-            title: t`Success`,
-            description: t`Draft saved`,
-            variant: "success",
-          });
-          navigate(
-            `/@${encodeHandleSegment(username)}/drafts/${draft.uuid}`,
-          );
-        } else if (
-          response.saveArticleDraft.__typename === "InvalidInputError"
-        ) {
-          showToast({
-            title: t`Error`,
-            description:
-              t`Invalid input: ${response.saveArticleDraft.inputPath}`,
-            variant: "error",
-          });
-        } else if (
-          response.saveArticleDraft.__typename === "NotAuthenticatedError"
-        ) {
-          showToast({
-            title: t`Error`,
-            description: t`You must be signed in to save a draft`,
-            variant: "error",
-          });
-        }
-      },
-      onError(error) {
-        showToast({
-          title: t`Error`,
-          description: error.message,
-          variant: "error",
-        });
+  const currentDraftData = (): NoteDraftData =>
+    createNoteDraftData({
+      content: content(),
+      language: language()?.baseName,
+      visibility: visibility(),
+      quotePolicy: quotePolicy(),
+      actingAccountKey: actingAccountKey(),
+      quotedPostId: effectiveQuotedPostId(),
+      replyTargetId: props.replyTargetId,
+      ensureLinkUrl: props.ensureLinkUrl,
+      media: mediaItems(),
+      poll: {
+        ...poll.snapshot(),
+        enabled: canCreatePoll() && poll.enabled(),
       },
     });
-  };
-
-  const currentDraftData = (): NoteDraftData => ({
-    content: content(),
-    language: language()?.baseName,
-    visibility: visibility(),
-    quotePolicy: quotePolicy(),
-    actingAccountKey: actingAccountKey(),
-    quotedPostId: effectiveQuotedPostId() ?? undefined,
-    replyTargetId: props.replyTargetId ?? undefined,
-    ensureLinkUrl: props.ensureLinkUrl ?? undefined,
-    media: mediaItems
-      .filter((item) =>
-        item.uuid != null && item.mediumRelayId != null &&
-        (item.url != null || !item.previewUrl.startsWith("blob:"))
-      )
-      .map((item): NoteDraftMedia => ({
-        localId: item.localId,
-        mediumRelayId: item.mediumRelayId!,
-        uuid: item.uuid!,
-        url: item.url ?? item.previewUrl,
-        alt: item.alt,
-        width: item.width,
-        height: item.height,
-      })),
-    poll: {
-      enabled: canCreatePoll() && pollEnabled(),
-      title: pollTitle(),
-      multiple: pollMultiple(),
-      ends: pollEnds(),
-      options: pollOptions.map((option) => ({
-        localId: option.localId,
-        title: option.title,
-      })),
-    },
-    updated: new Date().toISOString(),
-  });
 
   const currentStorableDraftData = (): NoteDraftData => {
-    const draft = currentDraftData();
-    if (dirty()) return draft;
-    return {
-      ...draft,
-      content: "",
-      media: [],
-      poll: {
-        ...draft.poll,
-        enabled: false,
-      },
-    };
+    return toStorableNoteDraftData(currentDraftData(), dirty());
   };
 
-  const hasUnstorableMedia = () =>
-    mediaItems.some((item) =>
-      item.uploading ||
-      item.uuid == null ||
-      item.mediumRelayId == null ||
-      (item.url == null && item.previewUrl.startsWith("blob:"))
-    );
-
-  const currentDraftIsMeaningful = createMemo(() =>
-    !props.editingNoteId && isMeaningfulNoteDraft(currentStorableDraftData())
-  );
-
-  const saveCurrentDraftNow = (notifyChange = true): boolean => {
-    const key = draftStorageKey();
-    const scope = draftScope();
-    if (
-      key == null || scope == null || loadedDraftKey() !== key ||
-      restoringDraft
-    ) {
-      return !dirty();
-    }
-
-    clearTimeout(saveDraftTimer);
-    const draft = currentStorableDraftData();
-    const hasMediaNotInDraft = hasUnstorableMedia();
-    const result = writeNoteDraft(getBrowserDraftStorage(), key, scope, draft);
-    setHasLocalDraft(result === "ok");
-    if (result === "ok") {
-      formDraftKey = key;
-      setDraftSaveStatus(hasMediaNotInDraft ? "idle" : "saved");
-      if (notifyChange) {
-        publishNoteDraftChange({ key, origin: draftSyncOrigin });
-      }
-      return !hasMediaNotInDraft;
-    }
-    if (result === "empty" && notifyChange) {
-      publishNoteDraftChange({ key, origin: draftSyncOrigin });
-    }
-    if (result === "unavailable" && isMeaningfulNoteDraft(draft)) {
-      setDraftSaveStatus("unavailable");
-      return false;
-    }
-    setDraftSaveStatus("idle");
-    return !dirty();
-  };
-
-  createEffect(() => {
-    if (props.editingNoteId) {
-      props.onDraftFlushAvailable?.(null);
-    } else {
-      props.onDraftFlushAvailable?.(saveCurrentDraftNow);
-    }
-  });
-
-  createEffect(() => {
-    unregisterDraftFlush?.();
-    unregisterDraftFlush = undefined;
-    const scope = draftScope();
-    if (props.editingNoteId || props.draftActive === false || scope == null) {
-      return;
-    }
-    unregisterDraftFlush = registerNoteDraftFlush(scope, saveCurrentDraftNow);
-  });
-
-  const restoreDraftMedia = (media: readonly NoteDraftMedia[]) => {
-    draftRestoreMediaSubscription?.unsubscribe();
-    draftRestoreMediaSubscription = undefined;
-    if (media.length < 1) {
-      setMediaItems([]);
-      return;
-    }
-    setMediaItems(media.map((item) => ({
-      localId: item.localId,
-      previewUrl: item.url,
-      alt: item.alt,
-      mediumRelayId: item.mediumRelayId,
-      uuid: item.uuid,
-      url: item.url,
-      width: item.width,
-      height: item.height,
-      uploading: false,
-      uploadProgress: 100,
-      generatingAlt: false,
-    })));
-    const storedById = new Map(media.map((item) => [item.mediumRelayId, item]));
-    draftRestoreMediaSubscription = fetchQuery<NoteComposerDraftMediaQuery>(
-      environment(),
-      NoteComposerDraftMediaQuery,
-      { ids: media.map((item) => item.mediumRelayId) },
-    ).subscribe({
-      next(data) {
-        const restored = (data.nodes ?? []).flatMap((node) => {
-          if (
-            node == null || node.id == null || node.uuid == null ||
-            node.url == null
-          ) {
-            return [];
-          }
-          const stored = storedById.get(node.id);
-          if (stored == null) return [];
-          return [
-            {
-              localId: stored.localId,
-              previewUrl: node.url.toString(),
-              alt: stored.alt,
-              mediumRelayId: node.id,
-              uuid: node.uuid,
-              url: node.url.toString(),
-              width: node.width ?? undefined,
-              height: node.height ?? undefined,
-              uploading: false,
-              uploadProgress: 100,
-              generatingAlt: false,
-            } satisfies MediaItem,
-          ];
-        });
-        if (restored.length < media.length) {
-          showToast({
-            title: t`Warning`,
-            description:
-              t`Some locally saved images are no longer available and were removed from the draft.`,
-            variant: "warning",
-          });
-        }
-        setMediaItems(restored);
-      },
-      error() {
-        showToast({
-          title: t`Warning`,
-          description:
-            t`Could not verify locally saved images. They may fail when you post.`,
-          variant: "warning",
-        });
-      },
-    });
-  };
+  const hasUnstorableMedia = () => hasUnstorableDraftMedia(mediaItems());
 
   const applyStoredDraft = (draft: StoredNoteDraft) => {
-    restoringDraft = true;
     batch(() => {
       setContent(draft.content);
       setVisibility(draft.visibility);
@@ -1098,119 +476,56 @@ export function NoteComposer(props: NoteComposerProps) {
       if (draft.quotedPostId && !props.quotedPostId) {
         setPastedQuoteId(draft.quotedPostId);
       }
-      setPollEnabled(canCreatePoll() && draft.poll.enabled);
-      setPollTitle(draft.poll.title);
-      setPollMultiple(draft.poll.multiple);
-      setPollEnds(draft.poll.ends || defaultPollEnds());
-      setPollOptions(
-        draft.poll.options.length >= MIN_POLL_OPTIONS
-          ? draft.poll.options.map((option) => ({
-            localId: option.localId,
-            title: option.title,
-          }))
-          : [
-            { localId: createLocalId(), title: "" },
-            { localId: createLocalId(), title: "" },
-          ],
-      );
-      restoreDraftMedia(draft.media);
+      poll.restore(draft.poll, canCreatePoll());
+      media.restore(draft.media);
       setEditorResetKey((k) => k + 1);
     });
-    queueMicrotask(() => {
-      restoringDraft = false;
-    });
   };
 
-  const loadDraftFromStorage = (
-    key: string,
-    scope: NoteDraftScope,
-    shouldPreserveCurrentForm: boolean,
-  ) => {
-    setDraftSaveStatus("idle");
-    const draft = readNoteDraft(getBrowserDraftStorage(), key);
-    if (draft != null) {
-      if (!shouldPreserveCurrentForm) {
-        applyStoredDraft(draft);
-      }
-      setHasLocalDraft(true);
-    } else {
-      if (!shouldPreserveCurrentForm) {
-        resetFormForDraftScope(scope);
-      }
-      setHasLocalDraft(false);
-    }
-    formDraftKey = key;
-    setLoadedDraftKey(key);
-  };
-
-  createEffect(() => {
-    const key = draftStorageKey();
-    const scope = draftScope();
-    clearTimeout(saveDraftTimer);
-    if (key == null || scope == null) {
-      setDraftSaveStatus("idle");
-      setLoadedDraftKey(null);
-      formDraftKey = null;
-      setHasLocalDraft(false);
-      return;
-    }
-    const previousLoadedDraftKey = untrack(loadedDraftKey);
-    const shouldPreserveCurrentForm = untrack(() =>
-      previousLoadedDraftKey != null &&
-      formDraftKey === previousLoadedDraftKey &&
-      previousLoadedDraftKey !== key &&
-      dirty()
-    );
-    untrack(() => loadDraftFromStorage(key, scope, shouldPreserveCurrentForm));
+  const draft = createDraftController({
+    active: () => props.draftActive !== false,
+    editing: () => !!props.editingNoteId,
+    username: viewer.username,
+    scope: draftScope,
+    dirty,
+    snapshot: currentStorableDraftData,
+    hasUnstorableMedia,
+    apply: applyStoredDraft,
+    resetForm,
+    resetFormForScope: resetFormForDraftScope,
+    onFlushAvailable: () => props.onDraftFlushAvailable,
   });
-
-  onCleanup(subscribeNoteDraftChanges((change) => {
-    if (change.origin === draftSyncOrigin) return;
-    const key = untrack(draftStorageKey);
-    const scope = untrack(draftScope);
-    if (key == null || scope == null || change.key !== key) return;
-    clearTimeout(saveDraftTimer);
-    // A stale composer can publish this scope during soft navigation.  Do not
-    // let it overwrite text the active composer has not saved yet.
-    const shouldPreserveCurrentForm = untrack(dirty);
-    loadDraftFromStorage(key, scope, shouldPreserveCurrentForm);
-    if (shouldPreserveCurrentForm) {
-      saveDraftTimer = setTimeout(() => {
-        saveCurrentDraftNow(false);
-      }, 350);
-    }
-  }));
-
-  createEffect(() => {
-    const key = draftStorageKey();
-    const scope = draftScope();
-    if (
-      key == null || scope == null || loadedDraftKey() !== key ||
-      restoringDraft
-    ) {
-      return;
-    }
-    void currentStorableDraftData();
-    clearTimeout(saveDraftTimer);
-    saveDraftTimer = setTimeout(() => {
-      saveCurrentDraftNow();
-    }, 350);
+  const submission = createSubmissionController({
+    content,
+    media: mediaItems,
+    editingNoteId: () => props.editingNoteId,
+    editingVisibility: () => props.editingVisibility,
+    editingAuthorAccountId: () => props.editingAuthorAccountId,
+    language: () => language()?.baseName,
+    fallbackLanguage: () => i18n.locale,
+    visibility,
+    quotePolicy: effectiveQuotePolicy,
+    quotedPostId: effectiveQuotedPostId,
+    replyTargetId: () => props.replyTargetId,
+    ensureLinkUrl: () => props.ensureLinkUrl,
+    actingAccountInput,
+    prependToConnections: () => props.prependToConnections ?? [],
+    appendToConnections: () => props.appendToConnections ?? [],
+    viewerId: viewer.id,
+    username: viewer.username,
+    pollEnabled: () => canCreatePoll() && poll.enabled(),
+    validatedPoll: () => getValidatedPollInput(),
+    canSwitchToArticle,
+    saveDraftNow: draft.saveNow,
+    clearDraft: draft.clear,
+    resetForm,
+    onSuccess: () => props.onSuccess?.(),
+    onArticleSwitch: () => {
+      setShowArticleSuggestion(false);
+      setShowArticleSwitchButton(false);
+    },
+    navigate,
   });
-
-  const clearCurrentDraft = () => {
-    const key = draftStorageKey();
-    if (key == null) return;
-    removeNoteDraft(getBrowserDraftStorage(), key);
-    setHasLocalDraft(false);
-    setDraftSaveStatus("idle");
-    publishNoteDraftChange({ key, origin: draftSyncOrigin });
-  };
-
-  const deleteCurrentDraftAndReset = () => {
-    setShowDeleteDraftConfirm(false);
-    clearCurrentDraft();
-    resetForm();
-  };
 
   // Use capture-phase listeners so Firefox's native textarea drag handling
   // cannot block our handlers.  relatedTarget in dragleave tells us whether
@@ -1232,7 +547,7 @@ export function NoteComposer(props: NoteComposerProps) {
     const onDragEnter = (e: DragEvent) => {
       clearTimeout(dragLeaveTimer);
       dragLeaveTimer = undefined;
-      if (hasFiles(e) && mediaItems.length < MAX_MEDIA) {
+      if (hasFiles(e) && mediaItems().length < MAX_MEDIA) {
         setIsDraggingOver(true);
       }
     };
@@ -1257,7 +572,7 @@ export function NoteComposer(props: NoteComposerProps) {
       if (!hasFiles(e)) return;
       e.preventDefault();
       const files = e.dataTransfer!.files;
-      if (files) addFiles(files);
+      if (files) media.addFiles(files);
     };
 
     const opts = { capture: true } as const;
@@ -1424,93 +739,6 @@ export function NoteComposer(props: NoteComposerProps) {
     }
   });
 
-  const addFiles = (files: FileList | File[]) => {
-    if (props.editingNoteId) return;
-    const fileArray = Array.from(files).filter(isSupportedImageFile);
-    if (fileArray.length === 0) return;
-
-    const current = mediaItems;
-    const remaining = MAX_MEDIA - current.length;
-    if (remaining <= 0) {
-      showToast({
-        title: t`Error`,
-        description: t`You can attach up to ${MAX_MEDIA} images`,
-        variant: "error",
-      });
-      return;
-    }
-
-    const toAdd = fileArray.slice(0, remaining);
-    if (toAdd.length < fileArray.length) {
-      showToast({
-        title: t`Warning`,
-        description:
-          t`Some images were skipped because the limit of ${MAX_MEDIA} was reached`,
-        variant: "warning",
-      });
-    }
-    // Create handles before inserting items so abortUpload is set from the
-    // start, avoiding a second setMediaItems pass for each file.
-    const newItems: MediaItem[] = toAdd.map((file) => {
-      const localId = createLocalId();
-      const contentType = getSupportedImageContentType(file);
-      if (contentType == null) {
-        throw new Error("Expected supported image content type");
-      }
-      const handle = uploadMediumFile(file, contentType, (progress) => {
-        setMediaItems(produce((items) => {
-          const m = items.find((m) => m.localId === localId);
-          if (m) m.uploadProgress = progress;
-        }));
-      });
-      handle.result.then((result) => {
-        setMediaItems(produce((items) => {
-          const m = items.find((m) => m.localId === localId);
-          if (m) {
-            m.uploading = false;
-            m.uploadProgress = 100;
-            m.uuid = result.uuid;
-            m.mediumRelayId = result.mediumRelayId;
-            m.url = result.url;
-            m.width = result.width;
-            m.height = result.height;
-            m.abortUpload = undefined;
-          }
-        }));
-      }).catch((err) => {
-        if (err instanceof UploadAbortedError) return;
-        setMediaItems(produce((items) => {
-          const idx = items.findIndex((m) => m.localId === localId);
-          if (idx !== -1) {
-            revokePreviewUrl(items[idx].previewUrl);
-            items.splice(idx, 1);
-          }
-        }));
-        showToast({
-          title: t`Error`,
-          description: err instanceof Error && err.message
-            ? err.message
-            : t`Failed to upload image`,
-          variant: "error",
-        });
-      });
-      return {
-        localId,
-        file,
-        previewUrl: URL.createObjectURL(file),
-        alt: "",
-        uploading: true,
-        uploadProgress: 0,
-        generatingAlt: false,
-        abortUpload: handle.abort,
-      };
-    });
-
-    setMediaItems(produce((items) => {
-      items.push(...newItems);
-    }));
-  };
-
   const handlePaste = (e: ClipboardEvent) => {
     // Check for pasted images first
     const files = e.clipboardData?.files;
@@ -1520,7 +748,7 @@ export function NoteComposer(props: NoteComposerProps) {
       );
       if (imageFiles.length > 0) {
         e.preventDefault();
-        addFiles(imageFiles);
+        media.addFiles(imageFiles);
         return;
       }
     }
@@ -1605,100 +833,34 @@ export function NoteComposer(props: NoteComposerProps) {
     setQuoteFetchError(false);
   };
 
-  const resetPoll = () => {
-    setPollEnabled(false);
-    setPollTitle("");
-    setPollMultiple(false);
-    setPollEnds(defaultPollEnds());
-    setPollOptions([
-      { localId: createLocalId(), title: "" },
-      { localId: createLocalId(), title: "" },
-    ]);
-  };
-
   createEffect(() => {
-    if (props.editingNoteId) resetPoll();
+    if (props.editingNoteId) poll.reset();
   });
 
-  const setPollDuration = (days: number) => {
-    const date = new Date();
-    date.setDate(date.getDate() + days);
-    date.setSeconds(0, 0);
-    setPollEnds(formatDateTimeLocal(date));
-  };
-
-  const getValidatedPollInput = (): ValidatedPollInput | null => {
-    const title = pollTitle().trim();
-    if (!title) {
-      showToast({
-        title: t`Error`,
-        description: t`Poll title cannot be empty`,
-        variant: "error",
-      });
-      return null;
-    }
-
-    const options = pollOptions.map((option) => option.title.trim());
-    if (options.some((option) => option === "")) {
-      showToast({
-        title: t`Error`,
-        description: t`Poll options cannot be empty`,
-        variant: "error",
-      });
-      return null;
-    }
-    if (options.length < MIN_POLL_OPTIONS) {
-      showToast({
-        title: t`Error`,
-        description: t`Add at least ${MIN_POLL_OPTIONS} poll options`,
-        variant: "error",
-      });
-      return null;
-    }
-    if (new Set(options).size !== options.length) {
-      showToast({
-        title: t`Error`,
-        description: t`Poll options must be unique`,
-        variant: "error",
-      });
-      return null;
-    }
-
-    const ends = parseDateTimeLocal(pollEnds());
-    if (!Number.isFinite(ends.getTime())) {
-      showToast({
-        title: t`Error`,
-        description: t`Poll deadline is invalid`,
-        variant: "error",
-      });
-      return null;
-    }
-    if (ends.getTime() - Date.now() < 60_000) {
-      showToast({
-        title: t`Error`,
-        description: t`Poll deadline must be at least 1 minute from now`,
-        variant: "error",
-      });
-      return null;
-    }
-
-    return {
-      title,
-      multiple: pollMultiple(),
-      options,
-      ends: ends.toISOString(),
-    };
+  const getValidatedPollInput = () => {
+    const result = poll.validate();
+    if (result.ok) return result.value;
+    const description = (() => {
+      switch (result.error) {
+        case "empty-title":
+          return t`Poll title cannot be empty`;
+        case "empty-option":
+          return t`Poll options cannot be empty`;
+        case "too-few-options":
+          return t`Add at least ${MIN_POLL_OPTIONS} poll options`;
+        case "duplicate-options":
+          return t`Poll options must be unique`;
+        case "invalid-deadline":
+          return t`Poll deadline is invalid`;
+        case "deadline-too-soon":
+          return t`Poll deadline must be at least 1 minute from now`;
+      }
+    })();
+    showToast({ title: t`Error`, description, variant: "error" });
+    return null;
   };
 
   function resetForm() {
-    formDraftKey = null;
-    draftRestoreMediaSubscription?.unsubscribe();
-    draftRestoreMediaSubscription = undefined;
-    for (const item of mediaItems) {
-      item.abortUpload?.();
-      item.altSubscription?.unsubscribe();
-      revokePreviewUrl(item.previewUrl);
-    }
     prefillRef = "";
     replyPrefillTargetId = null;
     setContent("");
@@ -1712,8 +874,8 @@ export function NoteComposer(props: NoteComposerProps) {
     setQuoteFetchError(false);
     setReplyTargetPost(null);
     setReplyTargetFetchError(false);
-    setMediaItems([]);
-    resetPoll();
+    media.reset();
+    poll.reset();
     setEditorResetKey((k) => k + 1);
   }
 
@@ -1740,310 +902,11 @@ export function NoteComposer(props: NoteComposerProps) {
     }
   }
 
-  const handleSubmit = (e: Event) => {
-    e.preventDefault();
-
-    const noteContent = content().trim();
-    if (!noteContent) {
-      showToast({
-        title: t`Error`,
-        description: t`Content cannot be empty`,
-        variant: "error",
-      });
-      return;
-    }
-
-    const items = mediaItems;
-    if (items.some((m) => m.uploading)) {
-      showToast({
-        title: t`Error`,
-        description: t`All images must finish uploading before posting`,
-        variant: "error",
-      });
-      return;
-    }
-    if (items.some((m) => !m.alt.trim())) {
-      showToast({
-        title: t`Error`,
-        description: t`All images require alt text`,
-        variant: "error",
-      });
-      return;
-    }
-
-    if (props.editingNoteId) {
-      const publicOrUnlisted = props.editingVisibility === "PUBLIC" ||
-        props.editingVisibility === "UNLISTED";
-      updateNote({
-        variables: {
-          input: {
-            noteId: props.editingNoteId,
-            content: noteContent,
-            language: language()?.baseName ?? null,
-            quotePolicy: publicOrUnlisted ? effectiveQuotePolicy() : undefined,
-            ...editActingAccountInput(),
-          },
-        },
-        onCompleted(response) {
-          if (response.updateNote.__typename === "UpdateNotePayload") {
-            showToast({
-              title: t`Success`,
-              description: t`Note updated`,
-              variant: "success",
-            });
-            clearCurrentDraft();
-            resetForm();
-            props.onSuccess?.();
-          } else if (
-            response.updateNote.__typename === "InvalidInputError"
-          ) {
-            showToast({
-              title: t`Error`,
-              description: t`Invalid input: ${response.updateNote.inputPath}`,
-              variant: "error",
-            });
-          } else if (
-            response.updateNote.__typename === "NotAuthenticatedError"
-          ) {
-            showToast({
-              title: t`Error`,
-              description: t`You must be signed in to edit a note`,
-              variant: "error",
-            });
-          }
-        },
-        onError(error) {
-          showToast({
-            title: t`Error`,
-            description: error.message,
-            variant: "error",
-          });
-        },
-      });
-    } else {
-      // Append the discussed link to the bottom unless the author already
-      // included it, so an inline opinion joins this link's discussion.
-      const finalContent = props.ensureLinkUrl
-        ? ensureLinkInContent(noteContent, props.ensureLinkUrl)
-        : noteContent;
-      if (canCreatePoll() && pollEnabled()) {
-        const poll = getValidatedPollInput();
-        if (poll == null) return;
-        createQuestion({
-          variables: {
-            input: {
-              content: finalContent,
-              language: language()?.baseName ?? i18n.locale,
-              visibility: visibility(),
-              quotePolicy: effectiveQuotePolicy(),
-              quotedPostId: effectiveQuotedPostId() ?? null,
-              replyTargetId: props.replyTargetId ?? null,
-              ...actingAccountInput(),
-              poll,
-              media: items.map((m) => ({
-                mediumId: m
-                  .uuid! as `${string}-${string}-${string}-${string}-${string}`,
-                alt: m.alt.trim(),
-              })),
-            },
-            connections: props.prependToConnections ?? [],
-            actingAccountId: actingAccountInput().actingAccountId ?? null,
-            includeDiscussionThreadFields:
-              (props.prependToConnections?.length ?? 0) > 0,
-          },
-          updater(store) {
-            if (
-              appendCreatedPostToConnections(
-                store,
-                "createQuestion",
-                "question",
-              )
-            ) {
-              incrementReplyCount(store);
-            }
-          },
-          onCompleted(response) {
-            if (
-              response.createQuestion.__typename === "CreateQuestionPayload"
-            ) {
-              showToast({
-                title: t`Success`,
-                description: t`Poll created successfully`,
-                variant: "success",
-              });
-              clearCurrentDraft();
-              resetForm();
-              props.onSuccess?.();
-            } else if (
-              response.createQuestion.__typename === "InvalidInputError"
-            ) {
-              showToast({
-                title: t`Error`,
-                description:
-                  t`Invalid input: ${response.createQuestion.inputPath}`,
-                variant: "error",
-              });
-            } else if (
-              response.createQuestion.__typename === "NotAuthenticatedError"
-            ) {
-              showToast({
-                title: t`Error`,
-                description: t`You must be signed in to create a poll`,
-                variant: "error",
-              });
-            }
-          },
-          onError(error) {
-            showToast({
-              title: t`Error`,
-              description: error.message,
-              variant: "error",
-            });
-          },
-        });
-        return;
-      }
-      createNote({
-        variables: {
-          input: {
-            content: finalContent,
-            language: language()?.baseName ?? i18n.locale,
-            visibility: visibility(),
-            quotePolicy: effectiveQuotePolicy(),
-            quotedPostId: effectiveQuotedPostId() ?? null,
-            replyTargetId: props.replyTargetId ?? null,
-            ...actingAccountInput(),
-            media: items.map((m) => ({
-              mediumId: m
-                .uuid! as `${string}-${string}-${string}-${string}-${string}`,
-              alt: m.alt.trim(),
-            })),
-          },
-          connections: props.prependToConnections ?? [],
-          actingAccountId: actingAccountInput().actingAccountId ?? null,
-          includeDiscussionThreadFields:
-            (props.prependToConnections?.length ?? 0) > 0,
-        },
-        updater(store) {
-          if (appendCreatedPostToConnections(store, "createNote", "note")) {
-            incrementReplyCount(store);
-          }
-        },
-        onCompleted(response) {
-          if (response.createNote.__typename === "CreateNotePayload") {
-            const href = getNoteInternalHref(response.createNote.note);
-            showToast({
-              title: t`Success`,
-              description: t`Note created successfully`,
-              href,
-              variant: "success",
-            });
-            clearCurrentDraft();
-            resetForm();
-            props.onSuccess?.();
-          } else if (response.createNote.__typename === "InvalidInputError") {
-            showToast({
-              title: t`Error`,
-              description: t`Invalid input: ${response.createNote.inputPath}`,
-              variant: "error",
-            });
-          } else if (
-            response.createNote.__typename === "NotAuthenticatedError"
-          ) {
-            showToast({
-              title: t`Error`,
-              description: t`You must be signed in to create a note`,
-              variant: "error",
-            });
-          }
-        },
-        onError(error) {
-          showToast({
-            title: t`Error`,
-            description: error.message,
-            variant: "error",
-          });
-        },
-      });
-    }
-  };
-
-  const handleGenerateAlt = (localId: string) => {
-    const item = mediaItems.find((m) => m.localId === localId);
-    if (!item?.mediumRelayId) return;
-
-    setMediaItems(produce((items) => {
-      const m = items.find((m) => m.localId === localId);
-      if (m) m.generatingAlt = true;
-    }));
-
-    const subscription = fetchQuery<NoteComposerGeneratedAltTextQuery>(
-      environment(),
-      NoteComposerGeneratedAltTextQuery,
-      {
-        mediumId: item.mediumRelayId,
-        language: language()?.baseName ?? i18n.locale,
-        context: content().trim() || undefined,
-      },
-    ).subscribe({
-      next(data) {
-        const medium = data.node;
-        if (medium && "generatedAltText" in medium) {
-          setMediaItems(produce((items) => {
-            const m = items.find((m) => m.localId === localId);
-            if (m) {
-              m.generatingAlt = false;
-              m.alt = medium.generatedAltText ?? m.alt;
-              m.altSubscription = undefined;
-            }
-          }));
-        } else {
-          setMediaItems(produce((items) => {
-            const m = items.find((m) => m.localId === localId);
-            if (m) {
-              m.generatingAlt = false;
-              m.altSubscription = undefined;
-            }
-          }));
-        }
-      },
-      error(err: Error) {
-        setMediaItems(produce((items) => {
-          const m = items.find((m) => m.localId === localId);
-          if (m) {
-            m.generatingAlt = false;
-            m.altSubscription = undefined;
-          }
-        }));
-        showToast({
-          title: t`Error`,
-          description: err?.message || t`Failed to generate alt text`,
-          variant: "error",
-        });
-      },
-    });
-    setMediaItems(produce((items) => {
-      const m = items.find((m) => m.localId === localId);
-      if (m) m.altSubscription = subscription;
-    }));
-  };
-
-  const handleCancelAlt = (localId: string) => {
-    setMediaItems(produce((items) => {
-      const m = items.find((m) => m.localId === localId);
-      if (m) {
-        m.altSubscription?.unsubscribe();
-        m.altSubscription = undefined;
-        m.generatingAlt = false;
-      }
-    }));
-  };
-
   return (
     <>
       <form
         ref={(el) => (formRef = el)}
-        onSubmit={handleSubmit}
+        onSubmit={submission.submit}
         class={props.class}
       >
         <div
@@ -2204,9 +1067,9 @@ export function NoteComposer(props: NoteComposerProps) {
               onKeyDown={(e) => {
                 if (e.key === "Enter" && (e.ctrlKey || e.metaKey)) {
                   e.preventDefault();
-                  const submitting = isSubmitting() ||
+                  const submitting = submission.submitting() ||
                     (!props.editingNoteId && viewer.suspended()) ||
-                    mediaItems.some((m) => m.uploading) ||
+                    mediaItems().some((m) => m.uploading) ||
                     (!!effectiveQuotedPostId() && !quotedPost() &&
                       !quoteFetchError()) ||
                     (!!props.replyTargetId &&
@@ -2246,7 +1109,7 @@ export function NoteComposer(props: NoteComposerProps) {
                     type="button"
                     variant="ghost"
                     size="icon"
-                    disabled={mediaItems.length >= MAX_MEDIA}
+                    disabled={mediaItems().length >= MAX_MEDIA}
                     title={t`Attach image`}
                     aria-label={t`Attach image`}
                     onClick={() => fileInputRef?.click()}
@@ -2256,13 +1119,13 @@ export function NoteComposer(props: NoteComposerProps) {
                   <Show when={allowPoll()}>
                     <Button
                       type="button"
-                      variant={pollEnabled() ? "secondary" : "ghost"}
+                      variant={poll.enabled() ? "secondary" : "ghost"}
                       size="icon"
-                      title={pollEnabled() ? t`Remove poll` : t`Add poll`}
-                      aria-label={pollEnabled() ? t`Remove poll` : t`Add poll`}
+                      title={poll.enabled() ? t`Remove poll` : t`Add poll`}
+                      aria-label={poll.enabled() ? t`Remove poll` : t`Add poll`}
                       onClick={() => {
-                        if (pollEnabled()) resetPoll();
-                        else setPollEnabled(true);
+                        if (poll.enabled()) poll.reset();
+                        else poll.setEnabled(true);
                       }}
                     >
                       <IconListChecks class="size-5" />
@@ -2278,7 +1141,7 @@ export function NoteComposer(props: NoteComposerProps) {
                 class="hidden"
                 onChange={(e) => {
                   const files = e.currentTarget.files;
-                  if (files) addFiles(files);
+                  if (files) media.addFiles(files);
                   e.currentTarget.value = "";
                 }}
               />
@@ -2311,168 +1174,8 @@ export function NoteComposer(props: NoteComposerProps) {
             </div>
           </TextField>
 
-          <Show when={canCreatePoll() && pollEnabled()}>
-            <section class="rounded-md border border-input p-3">
-              <div class="flex items-start justify-between gap-3">
-                <div class="flex min-w-0 items-center gap-2">
-                  <IconListChecks class="size-4 shrink-0 text-muted-foreground" />
-                  <h3 class="text-sm font-medium">{t`Poll`}</h3>
-                </div>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon"
-                  class="size-7 shrink-0"
-                  title={t`Remove poll`}
-                  aria-label={t`Remove poll`}
-                  onClick={resetPoll}
-                >
-                  <IconX class="size-4" />
-                </Button>
-              </div>
-
-              <div class="mt-3 grid gap-3">
-                <label class="grid gap-1.5">
-                  <span class="text-xs font-medium text-muted-foreground">
-                    {t`Poll title`}
-                  </span>
-                  <input
-                    type="text"
-                    value={pollTitle()}
-                    maxLength={200}
-                    onInput={(e) => setPollTitle(e.currentTarget.value)}
-                    placeholder={t`What should people decide?`}
-                    class="h-9 rounded-md border border-input bg-background px-3 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                  />
-                </label>
-
-                <div class="grid gap-1.5">
-                  <span class="text-xs font-medium text-muted-foreground">
-                    {t`Selection`}
-                  </span>
-                  <div class="grid grid-cols-2 overflow-hidden rounded-md border border-input">
-                    <Button
-                      type="button"
-                      variant={pollMultiple() ? "ghost" : "secondary"}
-                      class="h-9 rounded-none border-r"
-                      onClick={() => setPollMultiple(false)}
-                    >
-                      {t`Single choice`}
-                    </Button>
-                    <Button
-                      type="button"
-                      variant={pollMultiple() ? "secondary" : "ghost"}
-                      class="h-9 rounded-none"
-                      onClick={() => setPollMultiple(true)}
-                    >
-                      {t`Multiple choice`}
-                    </Button>
-                  </div>
-                </div>
-
-                <div class="grid gap-2">
-                  <div class="flex items-center justify-between gap-2">
-                    <span class="text-xs font-medium text-muted-foreground">
-                      {t`Options`}
-                    </span>
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="sm"
-                      disabled={pollOptions.length >= MAX_POLL_OPTIONS}
-                      onClick={() =>
-                        setPollOptions(produce((options) => {
-                          if (options.length >= MAX_POLL_OPTIONS) return;
-                          options.push({
-                            localId: createLocalId(),
-                            title: "",
-                          });
-                        }))}
-                    >
-                      <IconPlus class="mr-1 size-3.5" />
-                      {t`Add option`}
-                    </Button>
-                  </div>
-                  <For each={pollOptions}>
-                    {(option, index) => (
-                      <div class="grid grid-cols-[1fr_auto] gap-2">
-                        <input
-                          type="text"
-                          value={option.title}
-                          maxLength={200}
-                          onInput={(e) =>
-                            setPollOptions(
-                              index(),
-                              "title",
-                              e.currentTarget.value,
-                            )}
-                          placeholder={t`Option ${index() + 1}`}
-                          class="h-9 min-w-0 rounded-md border border-input bg-background px-3 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                        />
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="icon"
-                          class="size-9 text-muted-foreground hover:text-foreground"
-                          disabled={pollOptions.length <= MIN_POLL_OPTIONS}
-                          title={t`Remove option`}
-                          aria-label={t`Remove option`}
-                          onClick={() =>
-                            setPollOptions(produce((options) => {
-                              if (options.length <= MIN_POLL_OPTIONS) return;
-                              options.splice(index(), 1);
-                            }))}
-                        >
-                          <IconTrash class="size-4" />
-                        </Button>
-                      </div>
-                    )}
-                  </For>
-                </div>
-
-                <div class="grid gap-1.5">
-                  <span class="text-xs font-medium text-muted-foreground">
-                    {t`Deadline`}
-                  </span>
-                  <div class="flex flex-wrap gap-1">
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="sm"
-                      onClick={() => setPollDuration(1)}
-                    >
-                      {t`1 day`}
-                    </Button>
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="sm"
-                      onClick={() => setPollDuration(3)}
-                    >
-                      {t`3 days`}
-                    </Button>
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="sm"
-                      onClick={() => setPollDuration(7)}
-                    >
-                      {t`1 week`}
-                    </Button>
-                  </div>
-                  <input
-                    type="datetime-local"
-                    value={pollEnds()}
-                    onInput={(e) => setPollEnds(e.currentTarget.value)}
-                    class="h-9 rounded-md border border-input bg-background px-3 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                  />
-                </div>
-
-                <p class="rounded-md border border-warning/30 bg-warning/10 px-3 py-2 text-xs text-warning-foreground">
-                  {t`Polls cannot be edited after publishing.`}
-                </p>
-              </div>
-            </section>
+          <Show when={canCreatePoll() && poll.enabled()}>
+            <PollEditor poll={poll} />
           </Show>
 
           {/* Toolbar: language, visibility, quote policy */}
@@ -2496,144 +1199,22 @@ export function NoteComposer(props: NoteComposerProps) {
           </div>
 
           {/* Media previews — hidden in edit mode */}
-          <Show when={!props.editingNoteId && mediaItems.length > 0}>
-            <div class="flex flex-col gap-3">
-              <For each={mediaItems}>
-                {(item, index) => (
-                  <div class="flex gap-3 items-start">
-                    {/* Thumbnail with progress overlay */}
-                    <div class="relative flex-shrink-0 w-20 h-20 rounded-md overflow-hidden bg-muted">
-                      <img
-                        src={item.previewUrl}
-                        alt=""
-                        class="w-full h-full object-cover"
-                      />
-                      <Show when={item.uploading}>
-                        <div class="absolute inset-0 flex flex-col items-center justify-center bg-background/70 gap-1 px-2">
-                          <progress
-                            value={item.uploadProgress}
-                            max={100}
-                            class="w-full h-1.5 rounded-full"
-                            aria-label={t`Upload progress`}
-                          />
-                          <span class="text-xs text-muted-foreground">
-                            {item.uploadProgress}%
-                          </span>
-                        </div>
-                      </Show>
-                    </div>
-
-                    {/* Alt text input + controls */}
-                    <div class="flex-1 flex flex-col gap-1.5">
-                      <textarea
-                        value={item.alt}
-                        aria-label={t`Alt text for image ${index() + 1}`}
-                        aria-required="true"
-                        required
-                        onInput={(e) => {
-                          const v = e.currentTarget.value;
-                          setMediaItems(produce((items) => {
-                            const m = items.find((m) =>
-                              m.localId === item.localId
-                            );
-                            if (m) m.alt = v;
-                          }));
-                        }}
-                        placeholder={t`Alt text for visually impaired people (required)`}
-                        disabled={item.generatingAlt}
-                        rows={3}
-                        class="w-full rounded-md border border-input bg-background px-3 py-2 text-sm resize-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50"
-                      />
-                      <div class="flex gap-1 justify-end">
-                        <Show when={item.mediumRelayId && !item.uploading}>
-                          <Button
-                            type="button"
-                            variant="ghost"
-                            size="sm"
-                            disabled={item.generatingAlt}
-                            aria-label={t`Auto-fill alt text`}
-                            title={t`Auto-fill alt text`}
-                            onClick={() => handleGenerateAlt(item.localId)}
-                          >
-                            <Show
-                              when={item.generatingAlt}
-                              fallback={
-                                <span class="text-xs">{t`Auto-fill`}</span>
-                              }
-                            >
-                              {/* Spinner */}
-                              <svg
-                                xmlns="http://www.w3.org/2000/svg"
-                                fill="none"
-                                viewBox="0 0 24 24"
-                                stroke-width="1.5"
-                                stroke="currentColor"
-                                class="size-4 animate-spin"
-                                aria-hidden="true"
-                              >
-                                <path
-                                  stroke-linecap="round"
-                                  stroke-linejoin="round"
-                                  d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0 3.181 3.183a8.25 8.25 0 0 0 13.803-3.7M4.031 9.865a8.25 8.25 0 0 1 13.803-3.7l3.181 3.182m0-4.991v4.99"
-                                />
-                              </svg>
-                              <span class="text-xs ml-1">{t`Generating…`}</span>
-                            </Show>
-                          </Button>
-                        </Show>
-                        <Show when={item.generatingAlt}>
-                          <Button
-                            type="button"
-                            variant="ghost"
-                            size="sm"
-                            aria-label={t`Cancel`}
-                            title={t`Cancel`}
-                            onClick={() => handleCancelAlt(item.localId)}
-                          >
-                            <IconSquare class="size-4" />
-                          </Button>
-                        </Show>
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="sm"
-                          class="text-muted-foreground hover:text-foreground"
-                          aria-label={t`Remove image`}
-                          title={t`Remove image`}
-                          onClick={() => {
-                            item.abortUpload?.();
-                            item.altSubscription?.unsubscribe();
-                            revokePreviewUrl(item.previewUrl);
-                            setMediaItems(produce((items) => {
-                              const idx = items.findIndex(
-                                (m) => m.localId === item.localId,
-                              );
-                              if (idx !== -1) items.splice(idx, 1);
-                            }));
-                          }}
-                        >
-                          <IconX class="size-4" />
-                        </Button>
-                      </div>
-                    </div>
-                  </div>
-                )}
-              </For>
-            </div>
+          <Show when={!props.editingNoteId && mediaItems().length > 0}>
+            <MediaEditor media={media} />
           </Show>
 
           <Show
             when={!props.editingNoteId &&
-              (currentDraftIsMeaningful() || hasLocalDraft() ||
-                draftSaveStatus() === "unavailable")}
+              (draft.meaningful() || draft.hasLocalDraft() ||
+                draft.saveStatus() === "unavailable")}
           >
             <div class="flex flex-wrap items-center justify-between gap-2 border-t pt-3 text-xs text-muted-foreground">
               <span>
                 <Show
-                  when={draftSaveStatus() !== "unavailable"}
+                  when={draft.saveStatus() !== "unavailable"}
                   fallback={t`Local draft could not be saved`}
                 >
-                  {hasLocalDraft() ? t`Saved locally` : t`Local draft`}
+                  {draft.hasLocalDraft() ? t`Saved locally` : t`Local draft`}
                 </Show>
               </span>
               <Button
@@ -2641,7 +1222,7 @@ export function NoteComposer(props: NoteComposerProps) {
                 variant="ghost"
                 size="sm"
                 class="h-7 px-2 text-xs text-muted-foreground hover:text-destructive"
-                onClick={() => setShowDeleteDraftConfirm(true)}
+                onClick={() => draft.setShowDeleteConfirm(true)}
               >
                 {t`Delete local draft`}
               </Button>
@@ -2654,11 +1235,13 @@ export function NoteComposer(props: NoteComposerProps) {
                 type="button"
                 variant="outline"
                 size="sm"
-                onClick={switchToArticleDraft}
-                disabled={isSubmitting()}
+                onClick={submission.switchToArticleDraft}
+                disabled={submission.submitting()}
               >
                 <IconFileText class="size-4" />
-                {isSavingArticleDraft() ? t`Saving…` : t`Switch to article`}
+                {submission.savingArticleDraft()
+                  ? t`Saving…`
+                  : t`Switch to article`}
               </Button>
             </div>
           </Show>
@@ -2669,17 +1252,17 @@ export function NoteComposer(props: NoteComposerProps) {
                 type="button"
                 variant="outline"
                 onClick={() => props.onCancel?.()}
-                disabled={isSubmitting()}
+                disabled={submission.submitting()}
               >
                 {t`Cancel`}
               </Button>
             </Show>
             <Button
               type="submit"
-              disabled={isSubmitting() ||
+              disabled={submission.submitting() ||
                 (props.editingNoteId ? !dirty() : (
                   viewer.suspended() ||
-                  mediaItems.some((m) => m.uploading) ||
+                  mediaItems().some((m) => m.uploading) ||
                   (!!effectiveQuotedPostId() && !quotedPost() &&
                     !quoteFetchError()) ||
                   (!!props.replyTargetId && props.showReplyTarget !== false &&
@@ -2690,8 +1273,9 @@ export function NoteComposer(props: NoteComposerProps) {
                 when={props.editingNoteId}
                 fallback={
                   <Show
-                    when={isCreating() || isCreatingQuestion()}
-                    fallback={canCreatePoll() && pollEnabled()
+                    when={submission.creating() ||
+                      submission.creatingQuestion()}
+                    fallback={canCreatePoll() && poll.enabled()
                       ? t`Create poll`
                       : t`Create note`}
                   >
@@ -2699,7 +1283,7 @@ export function NoteComposer(props: NoteComposerProps) {
                   </Show>
                 }
               >
-                <Show when={isUpdating()} fallback={t`Save changes`}>
+                <Show when={submission.updating()} fallback={t`Save changes`}>
                   {t`Saving…`}
                 </Show>
               </Show>
@@ -2709,8 +1293,8 @@ export function NoteComposer(props: NoteComposerProps) {
       </form>
 
       <AlertDialog
-        open={showDeleteDraftConfirm()}
-        onOpenChange={(open) => !open && setShowDeleteDraftConfirm(false)}
+        open={draft.showDeleteConfirm()}
+        onOpenChange={(open) => !open && draft.setShowDeleteConfirm(false)}
       >
         <AlertDialogContent class="sm:max-w-sm">
           <AlertDialogHeader>
@@ -2723,7 +1307,7 @@ export function NoteComposer(props: NoteComposerProps) {
             <AlertDialogClose>{t`Keep draft`}</AlertDialogClose>
             <AlertDialogAction
               class="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-              onClick={deleteCurrentDraftAndReset}
+              onClick={draft.deleteAndReset}
             >
               {t`Delete draft`}
             </AlertDialogAction>
@@ -2749,27 +1333,16 @@ export function NoteComposer(props: NoteComposerProps) {
               {t`Keep writing note`}
             </AlertDialogClose>
             <AlertDialogAction
-              onClick={switchToArticleDraft}
-              disabled={isSavingArticleDraft()}
+              onClick={submission.switchToArticleDraft}
+              disabled={submission.savingArticleDraft()}
             >
-              {isSavingArticleDraft() ? t`Saving…` : t`Save as article draft`}
+              {submission.savingArticleDraft()
+                ? t`Saving…`
+                : t`Save as article draft`}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
     </>
   );
-}
-
-function getNoteInternalHref(
-  note: NonNullable<
-    NoteComposerMutation["response"]["createNote"] & {
-      __typename: "CreateNotePayload";
-    }
-  >["note"],
-): string {
-  const actorSegment = note.actor.local
-    ? `@${note.actor.username}`
-    : encodeHandleSegment(note.actor.handle);
-  return `/${actorSegment}/${note.sourceId ?? note.uuid}`;
 }

--- a/web-next/src/components/NoteComposer.tsx
+++ b/web-next/src/components/NoteComposer.tsx
@@ -1,9 +1,5 @@
 import { useNavigate } from "@solidjs/router";
 import { fetchQuery, graphql } from "relay-runtime";
-import IconFileText from "~icons/lucide/file-text";
-import IconImage from "~icons/lucide/image";
-import IconListChecks from "~icons/lucide/list-checks";
-import IconX from "~icons/lucide/x";
 import {
   batch,
   createEffect,
@@ -16,8 +12,12 @@ import {
   untrack,
 } from "solid-js";
 import { useRelayEnvironment } from "solid-relay";
-import { detectLanguage } from "~/lib/langdet.ts";
+import IconFileText from "~icons/lucide/file-text";
+import IconImage from "~icons/lucide/image";
+import IconListChecks from "~icons/lucide/list-checks";
+import IconX from "~icons/lucide/x";
 import { shouldSuggestArticleForNote } from "~/lib/formatGuidance.ts";
+import { detectLanguage } from "~/lib/langdet.ts";
 import {
   type NoteDraftData,
   type NoteDraftScope,

--- a/web-next/src/components/NoteComposer.tsx
+++ b/web-next/src/components/NoteComposer.tsx
@@ -61,11 +61,11 @@ import {
 } from "~/contexts/ActingAccountContext.tsx";
 import { useViewer } from "~/contexts/ViewerContext.tsx";
 import { useLingui } from "~/lib/i18n/macro.d.ts";
+import { createDraftController } from "./note-composer/createDraftController.ts";
 import {
   createMediaController,
   MAX_MEDIA,
 } from "./note-composer/createMediaController.ts";
-import { createDraftController } from "./note-composer/createDraftController.ts";
 import { createPollController } from "./note-composer/createPollController.ts";
 import { createSubmissionController } from "./note-composer/createSubmissionController.ts";
 import {

--- a/web-next/src/components/note-composer/MediaEditor.tsx
+++ b/web-next/src/components/note-composer/MediaEditor.tsx
@@ -1,4 +1,4 @@
-import { For, Show } from "solid-js";
+import { Index, Show } from "solid-js";
 import IconSquare from "~icons/lucide/square";
 import IconX from "~icons/lucide/x";
 import type { MediaController } from "./createMediaController.ts";
@@ -14,25 +14,25 @@ export function MediaEditor(props: MediaEditorProps) {
 
   return (
     <div class="flex flex-col gap-3">
-      <For each={props.media.items()}>
+      <Index each={props.media.items()}>
         {(item, index) => (
           <div class="flex gap-3 items-start">
             <div class="relative flex-shrink-0 w-20 h-20 rounded-md overflow-hidden bg-muted">
               <img
-                src={item.previewUrl}
+                src={item().previewUrl}
                 alt=""
                 class="w-full h-full object-cover"
               />
-              <Show when={item.uploading}>
+              <Show when={item().uploading}>
                 <div class="absolute inset-0 flex flex-col items-center justify-center bg-background/70 gap-1 px-2">
                   <progress
-                    value={item.uploadProgress}
+                    value={item().uploadProgress}
                     max={100}
                     class="w-full h-1.5 rounded-full"
                     aria-label={t`Upload progress`}
                   />
                   <span class="text-xs text-muted-foreground">
-                    {item.uploadProgress}%
+                    {item().uploadProgress}%
                   </span>
                 </div>
               </Show>
@@ -40,30 +40,33 @@ export function MediaEditor(props: MediaEditorProps) {
 
             <div class="flex-1 flex flex-col gap-1.5">
               <textarea
-                value={item.alt}
-                aria-label={t`Alt text for image ${index() + 1}`}
+                value={item().alt}
+                aria-label={t`Alt text for image ${index + 1}`}
                 aria-required="true"
                 required
                 onInput={(event) =>
-                  props.media.setAlt(item.localId, event.currentTarget.value)}
+                  props.media.setAlt(
+                    item().localId,
+                    event.currentTarget.value,
+                  )}
                 placeholder={t`Alt text for visually impaired people (required)`}
-                disabled={item.generatingAlt}
+                disabled={item().generatingAlt}
                 rows={3}
                 class="w-full rounded-md border border-input bg-background px-3 py-2 text-sm resize-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50"
               />
               <div class="flex gap-1 justify-end">
-                <Show when={item.mediumRelayId && !item.uploading}>
+                <Show when={item().mediumRelayId && !item().uploading}>
                   <Button
                     type="button"
                     variant="ghost"
                     size="sm"
-                    disabled={item.generatingAlt}
+                    disabled={item().generatingAlt}
                     aria-label={t`Auto-fill alt text`}
                     title={t`Auto-fill alt text`}
-                    onClick={() => props.media.generateAlt(item.localId)}
+                    onClick={() => props.media.generateAlt(item().localId)}
                   >
                     <Show
-                      when={item.generatingAlt}
+                      when={item().generatingAlt}
                       fallback={<span class="text-xs">{t`Auto-fill`}</span>}
                     >
                       <svg
@@ -85,14 +88,14 @@ export function MediaEditor(props: MediaEditorProps) {
                     </Show>
                   </Button>
                 </Show>
-                <Show when={item.generatingAlt}>
+                <Show when={item().generatingAlt}>
                   <Button
                     type="button"
                     variant="ghost"
                     size="sm"
                     aria-label={t`Cancel`}
                     title={t`Cancel`}
-                    onClick={() => props.media.cancelAlt(item.localId)}
+                    onClick={() => props.media.cancelAlt(item().localId)}
                   >
                     <IconSquare class="size-4" />
                   </Button>
@@ -104,7 +107,7 @@ export function MediaEditor(props: MediaEditorProps) {
                   class="text-muted-foreground hover:text-foreground"
                   aria-label={t`Remove image`}
                   title={t`Remove image`}
-                  onClick={() => props.media.remove(item.localId)}
+                  onClick={() => props.media.remove(item().localId)}
                 >
                   <IconX class="size-4" />
                 </Button>
@@ -112,7 +115,7 @@ export function MediaEditor(props: MediaEditorProps) {
             </div>
           </div>
         )}
-      </For>
+      </Index>
     </div>
   );
 }

--- a/web-next/src/components/note-composer/MediaEditor.tsx
+++ b/web-next/src/components/note-composer/MediaEditor.tsx
@@ -1,0 +1,118 @@
+import { For, Show } from "solid-js";
+import IconSquare from "~icons/lucide/square";
+import IconX from "~icons/lucide/x";
+import { Button } from "~/components/ui/button.tsx";
+import { useLingui } from "~/lib/i18n/macro.d.ts";
+import type { MediaController } from "./createMediaController.ts";
+
+export interface MediaEditorProps {
+  media: MediaController;
+}
+
+export function MediaEditor(props: MediaEditorProps) {
+  const { t } = useLingui();
+
+  return (
+    <div class="flex flex-col gap-3">
+      <For each={props.media.items()}>
+        {(item, index) => (
+          <div class="flex gap-3 items-start">
+            <div class="relative flex-shrink-0 w-20 h-20 rounded-md overflow-hidden bg-muted">
+              <img
+                src={item.previewUrl}
+                alt=""
+                class="w-full h-full object-cover"
+              />
+              <Show when={item.uploading}>
+                <div class="absolute inset-0 flex flex-col items-center justify-center bg-background/70 gap-1 px-2">
+                  <progress
+                    value={item.uploadProgress}
+                    max={100}
+                    class="w-full h-1.5 rounded-full"
+                    aria-label={t`Upload progress`}
+                  />
+                  <span class="text-xs text-muted-foreground">
+                    {item.uploadProgress}%
+                  </span>
+                </div>
+              </Show>
+            </div>
+
+            <div class="flex-1 flex flex-col gap-1.5">
+              <textarea
+                value={item.alt}
+                aria-label={t`Alt text for image ${index() + 1}`}
+                aria-required="true"
+                required
+                onInput={(event) =>
+                  props.media.setAlt(item.localId, event.currentTarget.value)}
+                placeholder={t`Alt text for visually impaired people (required)`}
+                disabled={item.generatingAlt}
+                rows={3}
+                class="w-full rounded-md border border-input bg-background px-3 py-2 text-sm resize-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50"
+              />
+              <div class="flex gap-1 justify-end">
+                <Show when={item.mediumRelayId && !item.uploading}>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    disabled={item.generatingAlt}
+                    aria-label={t`Auto-fill alt text`}
+                    title={t`Auto-fill alt text`}
+                    onClick={() => props.media.generateAlt(item.localId)}
+                  >
+                    <Show
+                      when={item.generatingAlt}
+                      fallback={<span class="text-xs">{t`Auto-fill`}</span>}
+                    >
+                      <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke-width="1.5"
+                        stroke="currentColor"
+                        class="size-4 animate-spin"
+                        aria-hidden="true"
+                      >
+                        <path
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0 3.181 3.183a8.25 8.25 0 0 0 13.803-3.7M4.031 9.865a8.25 8.25 0 0 1 13.803-3.7l3.181 3.182m0-4.991v4.99"
+                        />
+                      </svg>
+                      <span class="text-xs ml-1">{t`Generating…`}</span>
+                    </Show>
+                  </Button>
+                </Show>
+                <Show when={item.generatingAlt}>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    aria-label={t`Cancel`}
+                    title={t`Cancel`}
+                    onClick={() => props.media.cancelAlt(item.localId)}
+                  >
+                    <IconSquare class="size-4" />
+                  </Button>
+                </Show>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  class="text-muted-foreground hover:text-foreground"
+                  aria-label={t`Remove image`}
+                  title={t`Remove image`}
+                  onClick={() => props.media.remove(item.localId)}
+                >
+                  <IconX class="size-4" />
+                </Button>
+              </div>
+            </div>
+          </div>
+        )}
+      </For>
+    </div>
+  );
+}

--- a/web-next/src/components/note-composer/MediaEditor.tsx
+++ b/web-next/src/components/note-composer/MediaEditor.tsx
@@ -1,9 +1,9 @@
 import { For, Show } from "solid-js";
 import IconSquare from "~icons/lucide/square";
 import IconX from "~icons/lucide/x";
+import type { MediaController } from "./createMediaController.ts";
 import { Button } from "~/components/ui/button.tsx";
 import { useLingui } from "~/lib/i18n/macro.d.ts";
-import type { MediaController } from "./createMediaController.ts";
 
 export interface MediaEditorProps {
   media: MediaController;

--- a/web-next/src/components/note-composer/PollEditor.tsx
+++ b/web-next/src/components/note-composer/PollEditor.tsx
@@ -1,0 +1,169 @@
+import { For } from "solid-js";
+import IconListChecks from "~icons/lucide/list-checks";
+import IconPlus from "~icons/lucide/plus";
+import IconTrash from "~icons/lucide/trash-2";
+import IconX from "~icons/lucide/x";
+import { Button } from "~/components/ui/button.tsx";
+import { useLingui } from "~/lib/i18n/macro.d.ts";
+import type { PollController } from "./createPollController.ts";
+import { MAX_POLL_OPTIONS, MIN_POLL_OPTIONS } from "./pollState.ts";
+
+export interface PollEditorProps {
+  poll: PollController;
+}
+
+export function PollEditor(props: PollEditorProps) {
+  const { t } = useLingui();
+
+  return (
+    <section class="rounded-md border border-input p-3">
+      <div class="flex items-start justify-between gap-3">
+        <div class="flex min-w-0 items-center gap-2">
+          <IconListChecks class="size-4 shrink-0 text-muted-foreground" />
+          <h3 class="text-sm font-medium">{t`Poll`}</h3>
+        </div>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          class="size-7 shrink-0"
+          title={t`Remove poll`}
+          aria-label={t`Remove poll`}
+          onClick={props.poll.reset}
+        >
+          <IconX class="size-4" />
+        </Button>
+      </div>
+
+      <div class="mt-3 grid gap-3">
+        <label class="grid gap-1.5">
+          <span class="text-xs font-medium text-muted-foreground">
+            {t`Poll title`}
+          </span>
+          <input
+            type="text"
+            value={props.poll.title()}
+            maxLength={200}
+            onInput={(event) => props.poll.setTitle(event.currentTarget.value)}
+            placeholder={t`What should people decide?`}
+            class="h-9 rounded-md border border-input bg-background px-3 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          />
+        </label>
+
+        <div class="grid gap-1.5">
+          <span class="text-xs font-medium text-muted-foreground">
+            {t`Selection`}
+          </span>
+          <div class="grid grid-cols-2 overflow-hidden rounded-md border border-input">
+            <Button
+              type="button"
+              variant={props.poll.multiple() ? "ghost" : "secondary"}
+              class="h-9 rounded-none border-r"
+              onClick={() => props.poll.setMultiple(false)}
+            >
+              {t`Single choice`}
+            </Button>
+            <Button
+              type="button"
+              variant={props.poll.multiple() ? "secondary" : "ghost"}
+              class="h-9 rounded-none"
+              onClick={() => props.poll.setMultiple(true)}
+            >
+              {t`Multiple choice`}
+            </Button>
+          </div>
+        </div>
+
+        <div class="grid gap-2">
+          <div class="flex items-center justify-between gap-2">
+            <span class="text-xs font-medium text-muted-foreground">
+              {t`Options`}
+            </span>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              disabled={props.poll.options().length >= MAX_POLL_OPTIONS}
+              onClick={props.poll.addOption}
+            >
+              <IconPlus class="mr-1 size-3.5" />
+              {t`Add option`}
+            </Button>
+          </div>
+          <For each={props.poll.options()}>
+            {(option, index) => (
+              <div class="grid grid-cols-[1fr_auto] gap-2">
+                <input
+                  type="text"
+                  value={option.title}
+                  maxLength={200}
+                  onInput={(event) =>
+                    props.poll.setOptionTitle(
+                      option.localId,
+                      event.currentTarget.value,
+                    )}
+                  placeholder={t`Option ${index() + 1}`}
+                  class="h-9 min-w-0 rounded-md border border-input bg-background px-3 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                />
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  class="size-9 text-muted-foreground hover:text-foreground"
+                  disabled={props.poll.options().length <= MIN_POLL_OPTIONS}
+                  title={t`Remove option`}
+                  aria-label={t`Remove option`}
+                  onClick={() => props.poll.removeOption(option.localId)}
+                >
+                  <IconTrash class="size-4" />
+                </Button>
+              </div>
+            )}
+          </For>
+        </div>
+
+        <div class="grid gap-1.5">
+          <span class="text-xs font-medium text-muted-foreground">
+            {t`Deadline`}
+          </span>
+          <div class="flex flex-wrap gap-1">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => props.poll.setDuration(1)}
+            >
+              {t`1 day`}
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => props.poll.setDuration(3)}
+            >
+              {t`3 days`}
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => props.poll.setDuration(7)}
+            >
+              {t`1 week`}
+            </Button>
+          </div>
+          <input
+            type="datetime-local"
+            value={props.poll.ends()}
+            onInput={(event) => props.poll.setEnds(event.currentTarget.value)}
+            class="h-9 rounded-md border border-input bg-background px-3 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          />
+        </div>
+
+        <p class="rounded-md border border-warning/30 bg-warning/10 px-3 py-2 text-xs text-warning-foreground">
+          {t`Polls cannot be edited after publishing.`}
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/web-next/src/components/note-composer/PollEditor.tsx
+++ b/web-next/src/components/note-composer/PollEditor.tsx
@@ -57,6 +57,7 @@ export function PollEditor(props: PollEditorProps) {
           <div class="grid grid-cols-2 overflow-hidden rounded-md border border-input">
             <Button
               type="button"
+              aria-pressed={!props.poll.multiple()}
               variant={props.poll.multiple() ? "ghost" : "secondary"}
               class="h-9 rounded-none border-r"
               onClick={() => props.poll.setMultiple(false)}
@@ -65,6 +66,7 @@ export function PollEditor(props: PollEditorProps) {
             </Button>
             <Button
               type="button"
+              aria-pressed={props.poll.multiple()}
               variant={props.poll.multiple() ? "secondary" : "ghost"}
               class="h-9 rounded-none"
               onClick={() => props.poll.setMultiple(true)}

--- a/web-next/src/components/note-composer/PollEditor.tsx
+++ b/web-next/src/components/note-composer/PollEditor.tsx
@@ -1,4 +1,4 @@
-import { For } from "solid-js";
+import { Index } from "solid-js";
 import IconListChecks from "~icons/lucide/list-checks";
 import IconPlus from "~icons/lucide/plus";
 import IconTrash from "~icons/lucide/trash-2";
@@ -90,19 +90,19 @@ export function PollEditor(props: PollEditorProps) {
               {t`Add option`}
             </Button>
           </div>
-          <For each={props.poll.options()}>
+          <Index each={props.poll.options()}>
             {(option, index) => (
               <div class="grid grid-cols-[1fr_auto] gap-2">
                 <input
                   type="text"
-                  value={option.title}
+                  value={option().title}
                   maxLength={200}
                   onInput={(event) =>
                     props.poll.setOptionTitle(
-                      option.localId,
+                      option().localId,
                       event.currentTarget.value,
                     )}
-                  placeholder={t`Option ${index() + 1}`}
+                  placeholder={t`Option ${index + 1}`}
                   class="h-9 min-w-0 rounded-md border border-input bg-background px-3 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring"
                 />
                 <Button
@@ -113,13 +113,13 @@ export function PollEditor(props: PollEditorProps) {
                   disabled={props.poll.options().length <= MIN_POLL_OPTIONS}
                   title={t`Remove option`}
                   aria-label={t`Remove option`}
-                  onClick={() => props.poll.removeOption(option.localId)}
+                  onClick={() => props.poll.removeOption(option().localId)}
                 >
                   <IconTrash class="size-4" />
                 </Button>
               </div>
             )}
-          </For>
+          </Index>
         </div>
 
         <div class="grid gap-1.5">

--- a/web-next/src/components/note-composer/PollEditor.tsx
+++ b/web-next/src/components/note-composer/PollEditor.tsx
@@ -3,10 +3,10 @@ import IconListChecks from "~icons/lucide/list-checks";
 import IconPlus from "~icons/lucide/plus";
 import IconTrash from "~icons/lucide/trash-2";
 import IconX from "~icons/lucide/x";
-import { Button } from "~/components/ui/button.tsx";
-import { useLingui } from "~/lib/i18n/macro.d.ts";
 import type { PollController } from "./createPollController.ts";
 import { MAX_POLL_OPTIONS, MIN_POLL_OPTIONS } from "./pollState.ts";
+import { Button } from "~/components/ui/button.tsx";
+import { useLingui } from "~/lib/i18n/macro.d.ts";
 
 export interface PollEditorProps {
   poll: PollController;

--- a/web-next/src/components/note-composer/createDraftController.ts
+++ b/web-next/src/components/note-composer/createDraftController.ts
@@ -6,6 +6,10 @@ import {
   onCleanup,
   untrack,
 } from "solid-js";
+import {
+  decideExternalDraftChange,
+  shouldPreserveCurrentDraftForm,
+} from "./draftState.ts";
 import { getBrowserLocalStorage } from "~/lib/browserStorage.ts";
 import {
   getNoteDraftStorageKey,
@@ -22,10 +26,6 @@ import {
   registerNoteDraftFlush,
   subscribeNoteDraftChanges,
 } from "~/lib/noteDraftSync.ts";
-import {
-  decideExternalDraftChange,
-  shouldPreserveCurrentDraftForm,
-} from "./draftState.ts";
 
 export type DraftSaveStatus = "idle" | "saved" | "unavailable";
 export type DraftFlush = () => boolean;

--- a/web-next/src/components/note-composer/createDraftController.ts
+++ b/web-next/src/components/note-composer/createDraftController.ts
@@ -1,0 +1,240 @@
+import {
+  type Accessor,
+  createEffect,
+  createMemo,
+  createSignal,
+  onCleanup,
+  untrack,
+} from "solid-js";
+import { getBrowserLocalStorage } from "~/lib/browserStorage.ts";
+import {
+  getNoteDraftStorageKey,
+  isMeaningfulNoteDraft,
+  type NoteDraftData,
+  type NoteDraftScope,
+  readNoteDraft,
+  removeNoteDraft,
+  type StoredNoteDraft,
+  writeNoteDraft,
+} from "~/lib/noteDraftStorage.ts";
+import {
+  publishNoteDraftChange,
+  registerNoteDraftFlush,
+  subscribeNoteDraftChanges,
+} from "~/lib/noteDraftSync.ts";
+import {
+  decideExternalDraftChange,
+  shouldPreserveCurrentDraftForm,
+} from "./draftState.ts";
+
+export type DraftSaveStatus = "idle" | "saved" | "unavailable";
+export type DraftFlush = () => boolean;
+
+export interface DraftControllerOptions {
+  readonly active: Accessor<boolean>;
+  readonly editing: Accessor<boolean>;
+  readonly username: Accessor<string | null | undefined>;
+  readonly scope: Accessor<NoteDraftScope | null>;
+  readonly dirty: Accessor<boolean>;
+  readonly snapshot: () => NoteDraftData;
+  readonly hasUnstorableMedia: Accessor<boolean>;
+  readonly apply: (draft: StoredNoteDraft) => void;
+  readonly resetForm: () => void;
+  readonly resetFormForScope: (scope: NoteDraftScope) => void;
+  readonly onFlushAvailable: Accessor<
+    ((flush: DraftFlush | null) => void) | undefined
+  >;
+}
+
+export interface DraftController {
+  readonly storageKey: Accessor<string | null>;
+  readonly hasLocalDraft: Accessor<boolean>;
+  readonly saveStatus: Accessor<DraftSaveStatus>;
+  readonly meaningful: Accessor<boolean>;
+  readonly showDeleteConfirm: Accessor<boolean>;
+  readonly setShowDeleteConfirm: (show: boolean) => void;
+  readonly saveNow: DraftFlush;
+  readonly clear: () => void;
+  readonly deleteAndReset: () => void;
+}
+
+export function createDraftController(
+  options: DraftControllerOptions,
+): DraftController {
+  const storageKey = createMemo(() => {
+    if (!options.active()) return null;
+    const scope = options.scope();
+    const username = options.username();
+    if (scope == null || username == null) return null;
+    return getNoteDraftStorageKey(username, scope);
+  });
+  const [loadedKey, setLoadedKey] = createSignal<string | null>(null);
+  const [hasLocalDraft, setHasLocalDraft] = createSignal(false);
+  const [saveStatus, setSaveStatus] = createSignal<DraftSaveStatus>("idle");
+  const [showDeleteConfirm, setShowDeleteConfirm] = createSignal(false);
+  let saveTimer: ReturnType<typeof setTimeout> | undefined;
+  let formKey: string | null = null;
+  let restoring = false;
+  let unregisterFlush: (() => void) | undefined;
+  const origin = Symbol("NoteComposer");
+
+  const meaningful = createMemo(() =>
+    !options.editing() && isMeaningfulNoteDraft(options.snapshot())
+  );
+
+  const saveNow = (notifyChange = true): boolean => {
+    const key = storageKey();
+    const scope = options.scope();
+    if (
+      key == null || scope == null || loadedKey() !== key || restoring
+    ) {
+      return !options.dirty();
+    }
+
+    clearTimeout(saveTimer);
+    const draft = options.snapshot();
+    const unstorableMedia = options.hasUnstorableMedia();
+    const result = writeNoteDraft(getBrowserLocalStorage(), key, scope, draft);
+    setHasLocalDraft(result === "ok");
+    if (result === "ok") {
+      formKey = key;
+      setSaveStatus(unstorableMedia ? "idle" : "saved");
+      if (notifyChange) publishNoteDraftChange({ key, origin });
+      return !unstorableMedia;
+    }
+    if (result === "empty" && notifyChange) {
+      publishNoteDraftChange({ key, origin });
+    }
+    if (result === "unavailable" && isMeaningfulNoteDraft(draft)) {
+      setSaveStatus("unavailable");
+      return false;
+    }
+    setSaveStatus("idle");
+    return !options.dirty();
+  };
+
+  const apply = (draft: StoredNoteDraft) => {
+    restoring = true;
+    options.apply(draft);
+    queueMicrotask(() => {
+      restoring = false;
+    });
+  };
+
+  const load = (
+    key: string,
+    scope: NoteDraftScope,
+    preserveCurrentForm: boolean,
+  ) => {
+    setSaveStatus("idle");
+    const draft = readNoteDraft(getBrowserLocalStorage(), key);
+    if (draft != null) {
+      if (!preserveCurrentForm) apply(draft);
+      setHasLocalDraft(true);
+    } else {
+      if (!preserveCurrentForm) options.resetFormForScope(scope);
+      setHasLocalDraft(false);
+    }
+    formKey = key;
+    setLoadedKey(key);
+  };
+
+  const clear = () => {
+    const key = storageKey();
+    if (key == null) return;
+    removeNoteDraft(getBrowserLocalStorage(), key);
+    setHasLocalDraft(false);
+    setSaveStatus("idle");
+    publishNoteDraftChange({ key, origin });
+  };
+
+  createEffect(() => {
+    options.onFlushAvailable()?.(options.editing() ? null : saveNow);
+  });
+
+  createEffect(() => {
+    unregisterFlush?.();
+    unregisterFlush = undefined;
+    const scope = options.scope();
+    if (options.editing() || !options.active() || scope == null) return;
+    unregisterFlush = registerNoteDraftFlush(scope, saveNow);
+  });
+
+  createEffect(() => {
+    const key = storageKey();
+    const scope = options.scope();
+    clearTimeout(saveTimer);
+    if (key == null || scope == null) {
+      setSaveStatus("idle");
+      setLoadedKey(null);
+      formKey = null;
+      setHasLocalDraft(false);
+      return;
+    }
+    const previousLoadedKey = untrack(loadedKey);
+    const preserveCurrentForm = untrack(() =>
+      shouldPreserveCurrentDraftForm({
+        previousLoadedKey,
+        formDraftKey: formKey,
+        nextKey: key,
+        dirty: options.dirty(),
+      })
+    );
+    untrack(() => load(key, scope, preserveCurrentForm));
+  });
+
+  onCleanup(subscribeNoteDraftChanges((change) => {
+    const decision = decideExternalDraftChange({
+      sameOrigin: change.origin === origin,
+      changeKey: change.key,
+      currentKey: untrack(storageKey),
+      dirty: untrack(options.dirty),
+    });
+    if (decision === "ignore") return;
+    const key = untrack(storageKey);
+    const scope = untrack(options.scope);
+    if (key == null || scope == null) return;
+    clearTimeout(saveTimer);
+    load(key, scope, decision === "preserve-and-resave");
+    if (decision === "preserve-and-resave") {
+      saveTimer = setTimeout(() => saveNow(false), 350);
+    }
+  }));
+
+  createEffect(() => {
+    const key = storageKey();
+    const scope = options.scope();
+    // Track the form even while applying a restored draft.  Otherwise this
+    // effect can return on its first run without subscribing to the snapshot,
+    // and later edits to an existing local draft are never persisted.
+    void options.snapshot();
+    if (key == null || scope == null || loadedKey() !== key || restoring) {
+      return;
+    }
+    clearTimeout(saveTimer);
+    saveTimer = setTimeout(saveNow, 350);
+  });
+
+  onCleanup(() => {
+    saveNow();
+    options.onFlushAvailable()?.(null);
+    unregisterFlush?.();
+    clearTimeout(saveTimer);
+  });
+
+  return {
+    storageKey,
+    hasLocalDraft,
+    saveStatus,
+    meaningful,
+    showDeleteConfirm,
+    setShowDeleteConfirm,
+    saveNow,
+    clear,
+    deleteAndReset: () => {
+      setShowDeleteConfirm(false);
+      clear();
+      options.resetForm();
+    },
+  };
+}

--- a/web-next/src/components/note-composer/createMediaController.ts
+++ b/web-next/src/components/note-composer/createMediaController.ts
@@ -1,0 +1,303 @@
+import { fetchQuery, graphql, type IEnvironment } from "relay-runtime";
+import { type Accessor, createSignal, onCleanup } from "solid-js";
+import { showToast } from "~/components/ui/toast.tsx";
+import { useLingui } from "~/lib/i18n/macro.d.ts";
+import type { NoteDraftMedia } from "~/lib/noteDraftStorage.ts";
+import {
+  getSupportedImageContentType,
+  isSupportedImageFile,
+} from "~/lib/supportedImageFile.ts";
+import {
+  UploadAbortedError,
+  uploadMediumFile,
+} from "~/lib/uploadMediumWithProgress.ts";
+import type { createMediaControllerDraftMediaQuery } from "./__generated__/createMediaControllerDraftMediaQuery.graphql.ts";
+import type { createMediaControllerGeneratedAltTextQuery } from "./__generated__/createMediaControllerGeneratedAltTextQuery.graphql.ts";
+import { type MediaItem, reduceMediaItems } from "./mediaState.ts";
+
+const DraftMediaQuery = graphql`
+  query createMediaControllerDraftMediaQuery($ids: [ID!]!) {
+    nodes(ids: $ids) {
+      ... on Medium {
+        id
+        uuid
+        url
+        width
+        height
+      }
+    }
+  }
+`;
+
+const GeneratedAltTextQuery = graphql`
+  query createMediaControllerGeneratedAltTextQuery(
+    $mediumId: ID!
+    $language: Locale!
+    $context: String
+  ) {
+    node(id: $mediumId) {
+      ... on Medium {
+        generatedAltText(language: $language, context: $context)
+      }
+    }
+  }
+`;
+
+export const MAX_MEDIA = 20;
+
+export interface MediaControllerOptions {
+  readonly environment: Accessor<IEnvironment>;
+  readonly editing: Accessor<boolean>;
+  readonly language: Accessor<string>;
+  readonly content: Accessor<string>;
+}
+
+export interface MediaController {
+  readonly items: Accessor<readonly MediaItem[]>;
+  readonly addFiles: (files: FileList | readonly File[]) => void;
+  readonly restore: (media: readonly NoteDraftMedia[]) => void;
+  readonly setAlt: (localId: string, alt: string) => void;
+  readonly generateAlt: (localId: string) => void;
+  readonly cancelAlt: (localId: string) => void;
+  readonly remove: (localId: string) => void;
+  readonly reset: () => void;
+}
+
+export function createMediaController(
+  options: MediaControllerOptions,
+): MediaController {
+  const { t } = useLingui();
+  const [items, setItems] = createSignal<readonly MediaItem[]>([]);
+  let restoreSubscription: { unsubscribe(): void } | undefined;
+
+  const dispatch = (
+    action: Parameters<typeof reduceMediaItems>[1],
+  ) => setItems((current) => reduceMediaItems(current, action));
+
+  const disposeItem = (item: MediaItem) => {
+    item.abortUpload?.();
+    item.altSubscription?.unsubscribe();
+    revokePreviewUrl(item.previewUrl);
+  };
+
+  const reset = () => {
+    restoreSubscription?.unsubscribe();
+    restoreSubscription = undefined;
+    for (const item of items()) disposeItem(item);
+    dispatch({ type: "replace", items: [] });
+  };
+
+  const remove = (localId: string) => {
+    const item = items().find((candidate) => candidate.localId === localId);
+    if (item == null) return;
+    disposeItem(item);
+    dispatch({ type: "remove", localId });
+  };
+
+  const addFiles = (files: FileList | readonly File[]) => {
+    if (options.editing()) return;
+    const supported = Array.from(files).filter(isSupportedImageFile);
+    if (supported.length === 0) return;
+
+    const remaining = MAX_MEDIA - items().length;
+    if (remaining <= 0) {
+      showToast({
+        title: t`Error`,
+        description: t`You can attach up to ${MAX_MEDIA} images`,
+        variant: "error",
+      });
+      return;
+    }
+
+    const selected = supported.slice(0, remaining);
+    if (selected.length < supported.length) {
+      showToast({
+        title: t`Warning`,
+        description:
+          t`Some images were skipped because the limit of ${MAX_MEDIA} was reached`,
+        variant: "warning",
+      });
+    }
+
+    const newItems = selected.map((file): MediaItem => {
+      const localId = createLocalId();
+      const contentType = getSupportedImageContentType(file);
+      if (contentType == null) {
+        throw new Error("Expected supported image content type");
+      }
+      const handle = uploadMediumFile(file, contentType, (progress) => {
+        dispatch({ type: "upload-progress", localId, progress });
+      });
+      handle.result.then((result) => {
+        dispatch({ type: "upload-completed", localId, result });
+      }).catch((error) => {
+        if (error instanceof UploadAbortedError) return;
+        const failed = items().find((item) => item.localId === localId);
+        if (failed != null) {
+          revokePreviewUrl(failed.previewUrl);
+          dispatch({ type: "remove", localId });
+        }
+        showToast({
+          title: t`Error`,
+          description: error instanceof Error && error.message
+            ? error.message
+            : t`Failed to upload image`,
+          variant: "error",
+        });
+      });
+      return {
+        localId,
+        file,
+        previewUrl: URL.createObjectURL(file),
+        alt: "",
+        uploading: true,
+        uploadProgress: 0,
+        generatingAlt: false,
+        abortUpload: handle.abort,
+      };
+    });
+    dispatch({ type: "append", items: newItems });
+  };
+
+  const restore = (media: readonly NoteDraftMedia[]) => {
+    reset();
+    if (media.length < 1) return;
+    dispatch({
+      type: "replace",
+      items: media.map((item) => ({
+        localId: item.localId,
+        previewUrl: item.url,
+        alt: item.alt,
+        mediumRelayId: item.mediumRelayId,
+        uuid: item.uuid,
+        url: item.url,
+        width: item.width,
+        height: item.height,
+        uploading: false,
+        uploadProgress: 100,
+        generatingAlt: false,
+      })),
+    });
+    const storedById = new Map(media.map((item) => [item.mediumRelayId, item]));
+    restoreSubscription = fetchQuery<createMediaControllerDraftMediaQuery>(
+      options.environment(),
+      DraftMediaQuery,
+      { ids: media.map((item) => item.mediumRelayId) },
+    ).subscribe({
+      next(data) {
+        const restored = (data.nodes ?? []).flatMap((node) => {
+          if (
+            node == null || node.id == null || node.uuid == null ||
+            node.url == null
+          ) {
+            return [];
+          }
+          const stored = storedById.get(node.id);
+          if (stored == null) return [];
+          return [
+            {
+              localId: stored.localId,
+              previewUrl: node.url.toString(),
+              alt: stored.alt,
+              mediumRelayId: node.id,
+              uuid: node.uuid,
+              url: node.url.toString(),
+              width: node.width ?? undefined,
+              height: node.height ?? undefined,
+              uploading: false,
+              uploadProgress: 100,
+              generatingAlt: false,
+            } satisfies MediaItem,
+          ];
+        });
+        if (restored.length < media.length) {
+          showToast({
+            title: t`Warning`,
+            description:
+              t`Some locally saved images are no longer available and were removed from the draft.`,
+            variant: "warning",
+          });
+        }
+        dispatch({ type: "replace", items: restored });
+      },
+      error() {
+        showToast({
+          title: t`Warning`,
+          description:
+            t`Could not verify locally saved images. They may fail when you post.`,
+          variant: "warning",
+        });
+      },
+    });
+  };
+
+  const generateAlt = (localId: string) => {
+    const item = items().find((candidate) => candidate.localId === localId);
+    if (item?.mediumRelayId == null) return;
+    dispatch({ type: "alt-started", localId });
+    const subscription = fetchQuery<createMediaControllerGeneratedAltTextQuery>(
+      options.environment(),
+      GeneratedAltTextQuery,
+      {
+        mediumId: item.mediumRelayId,
+        language: options.language(),
+        context: options.content().trim() || undefined,
+      },
+    ).subscribe({
+      next(data) {
+        const medium = data.node;
+        dispatch({
+          type: "alt-completed",
+          localId,
+          alt: medium && "generatedAltText" in medium
+            ? (medium.generatedAltText ?? null)
+            : null,
+        });
+      },
+      error(error: Error) {
+        dispatch({ type: "alt-completed", localId, alt: null });
+        showToast({
+          title: t`Error`,
+          description: error?.message || t`Failed to generate alt text`,
+          variant: "error",
+        });
+      },
+    });
+    dispatch({
+      type: "alt-subscription-set",
+      localId,
+      subscription,
+    });
+  };
+
+  const cancelAlt = (localId: string) => {
+    const item = items().find((candidate) => candidate.localId === localId);
+    item?.altSubscription?.unsubscribe();
+    dispatch({ type: "alt-cancelled", localId });
+  };
+
+  onCleanup(() => {
+    restoreSubscription?.unsubscribe();
+    for (const item of items()) disposeItem(item);
+  });
+
+  return {
+    items,
+    addFiles,
+    restore,
+    setAlt: (localId, alt) => dispatch({ type: "alt-changed", localId, alt }),
+    generateAlt,
+    cancelAlt,
+    remove,
+    reset,
+  };
+}
+
+function createLocalId(): string {
+  return globalThis.crypto?.randomUUID?.() ??
+    Math.random().toString(36).slice(2);
+}
+
+function revokePreviewUrl(url: string): void {
+  if (url.startsWith("blob:")) URL.revokeObjectURL(url);
+}

--- a/web-next/src/components/note-composer/createMediaController.ts
+++ b/web-next/src/components/note-composer/createMediaController.ts
@@ -1,5 +1,8 @@
 import { fetchQuery, graphql, type IEnvironment } from "relay-runtime";
 import { type Accessor, createSignal, onCleanup } from "solid-js";
+import type { createMediaControllerDraftMediaQuery } from "./__generated__/createMediaControllerDraftMediaQuery.graphql.ts";
+import type { createMediaControllerGeneratedAltTextQuery } from "./__generated__/createMediaControllerGeneratedAltTextQuery.graphql.ts";
+import { type MediaItem, reduceMediaItems } from "./mediaState.ts";
 import { showToast } from "~/components/ui/toast.tsx";
 import { useLingui } from "~/lib/i18n/macro.d.ts";
 import type { NoteDraftMedia } from "~/lib/noteDraftStorage.ts";
@@ -11,9 +14,6 @@ import {
   UploadAbortedError,
   uploadMediumFile,
 } from "~/lib/uploadMediumWithProgress.ts";
-import type { createMediaControllerDraftMediaQuery } from "./__generated__/createMediaControllerDraftMediaQuery.graphql.ts";
-import type { createMediaControllerGeneratedAltTextQuery } from "./__generated__/createMediaControllerGeneratedAltTextQuery.graphql.ts";
-import { type MediaItem, reduceMediaItems } from "./mediaState.ts";
 
 const DraftMediaQuery = graphql`
   query createMediaControllerDraftMediaQuery($ids: [ID!]!) {

--- a/web-next/src/components/note-composer/createPollController.ts
+++ b/web-next/src/components/note-composer/createPollController.ts
@@ -1,5 +1,4 @@
 import { type Accessor, createSignal } from "solid-js";
-import type { NoteDraftPoll } from "~/lib/noteDraftStorage.ts";
 import {
   addPollOption,
   createPollDraft,
@@ -10,6 +9,7 @@ import {
   setPollDuration,
   validatePollDraft,
 } from "./pollState.ts";
+import type { NoteDraftPoll } from "~/lib/noteDraftStorage.ts";
 
 export interface PollController {
   readonly draft: Accessor<PollDraft>;

--- a/web-next/src/components/note-composer/createPollController.ts
+++ b/web-next/src/components/note-composer/createPollController.ts
@@ -1,0 +1,78 @@
+import { type Accessor, createSignal } from "solid-js";
+import type { NoteDraftPoll } from "~/lib/noteDraftStorage.ts";
+import {
+  addPollOption,
+  createPollDraft,
+  type PollDraft,
+  type PollValidationResult,
+  removePollOption,
+  restorePollDraft,
+  setPollDuration,
+  validatePollDraft,
+} from "./pollState.ts";
+
+export interface PollController {
+  readonly draft: Accessor<PollDraft>;
+  readonly enabled: Accessor<boolean>;
+  readonly title: Accessor<string>;
+  readonly multiple: Accessor<boolean>;
+  readonly ends: Accessor<string>;
+  readonly options: Accessor<PollDraft["options"]>;
+  readonly setEnabled: (enabled: boolean) => void;
+  readonly setTitle: (title: string) => void;
+  readonly setMultiple: (multiple: boolean) => void;
+  readonly setEnds: (ends: string) => void;
+  readonly setDuration: (days: number) => void;
+  readonly addOption: () => void;
+  readonly removeOption: (localId: string) => void;
+  readonly setOptionTitle: (localId: string, title: string) => void;
+  readonly restore: (draft: NoteDraftPoll, allowed: boolean) => void;
+  readonly reset: () => void;
+  readonly snapshot: () => NoteDraftPoll;
+  readonly validate: () => PollValidationResult;
+}
+
+export function createPollController(): PollController {
+  const [draft, setDraft] = createSignal<PollDraft>(createPollDraft());
+
+  const reset = () => setDraft(createPollDraft());
+
+  return {
+    draft,
+    enabled: () => draft().enabled,
+    title: () => draft().title,
+    multiple: () => draft().multiple,
+    ends: () => draft().ends,
+    options: () => draft().options,
+    setEnabled: (enabled) => setDraft((current) => ({ ...current, enabled })),
+    setTitle: (title) => setDraft((current) => ({ ...current, title })),
+    setMultiple: (multiple) =>
+      setDraft((current) => ({ ...current, multiple })),
+    setEnds: (ends) => setDraft((current) => ({ ...current, ends })),
+    setDuration: (days) =>
+      setDraft((current) => ({
+        ...current,
+        ends: setPollDuration(new Date(), days),
+      })),
+    addOption: () => setDraft((current) => addPollOption(current)),
+    removeOption: (localId) =>
+      setDraft((current) => removePollOption(current, localId)),
+    setOptionTitle: (localId, title) =>
+      setDraft((current) => ({
+        ...current,
+        options: current.options.map((option) =>
+          option.localId === localId ? { ...option, title } : option
+        ),
+      })),
+    restore: (stored, allowed) => setDraft(restorePollDraft(stored, allowed)),
+    reset,
+    snapshot: () => ({
+      enabled: draft().enabled,
+      title: draft().title,
+      multiple: draft().multiple,
+      ends: draft().ends,
+      options: draft().options.map((option) => ({ ...option })),
+    }),
+    validate: () => validatePollDraft(draft()),
+  };
+}

--- a/web-next/src/components/note-composer/createSubmissionController.ts
+++ b/web-next/src/components/note-composer/createSubmissionController.ts
@@ -1,10 +1,5 @@
 import { ConnectionHandler, graphql } from "relay-runtime";
 import { createMutation } from "solid-relay";
-import type { PostVisibility } from "~/components/PostVisibilitySelect.tsx";
-import type { QuotePolicy } from "~/components/QuotePolicySelect.tsx";
-import { showToast } from "~/components/ui/toast.tsx";
-import { encodeHandleSegment } from "~/lib/handleSegment.ts";
-import { useLingui } from "~/lib/i18n/macro.d.ts";
 import type { createSubmissionControllerArticleDraftMutation } from "./__generated__/createSubmissionControllerArticleDraftMutation.graphql.ts";
 import type { createSubmissionControllerCreateNoteMutation } from "./__generated__/createSubmissionControllerCreateNoteMutation.graphql.ts";
 import type { createSubmissionControllerCreateQuestionMutation } from "./__generated__/createSubmissionControllerCreateQuestionMutation.graphql.ts";
@@ -18,6 +13,11 @@ import {
   type SubmissionMedium,
   validateSubmission,
 } from "./submissionState.ts";
+import type { PostVisibility } from "~/components/PostVisibilitySelect.tsx";
+import type { QuotePolicy } from "~/components/QuotePolicySelect.tsx";
+import { showToast } from "~/components/ui/toast.tsx";
+import { encodeHandleSegment } from "~/lib/handleSegment.ts";
+import { useLingui } from "~/lib/i18n/macro.d.ts";
 
 const CreateNoteMutation = graphql`
   mutation createSubmissionControllerCreateNoteMutation(

--- a/web-next/src/components/note-composer/createSubmissionController.ts
+++ b/web-next/src/components/note-composer/createSubmissionController.ts
@@ -11,6 +11,7 @@ import {
   buildUpdateNoteInput,
   getNoteInternalHref,
   type SubmissionMedium,
+  type SubmissionValidationError,
   validateSubmission,
 } from "./submissionState.ts";
 import type { PostVisibility } from "~/components/PostVisibilitySelect.tsx";
@@ -229,13 +230,13 @@ export function createSubmissionController(
   const submitting = () =>
     creating() || creatingQuestion() || updating() || savingArticleDraft();
 
-  const showValidationError = (
-    error: "empty-content" | "uploading-media" | "missing-alt",
-  ) => {
+  const showValidationError = (error: SubmissionValidationError) => {
     const description = error === "empty-content"
       ? t`Content cannot be empty`
       : error === "uploading-media"
       ? t`All images must finish uploading before posting`
+      : error === "failed-media-upload"
+      ? t`Failed to upload image`
       : t`All images require alt text`;
     showToast({ title: t`Error`, description, variant: "error" });
   };
@@ -313,7 +314,7 @@ export function createSubmissionController(
       quotedPostId: options.quotedPostId(),
       replyTargetId: options.replyTargetId(),
       actingAccountInput,
-      media: options.media(),
+      media: validation.media,
     });
     const connections = [...options.prependToConnections()];
     const mutationVariables = {

--- a/web-next/src/components/note-composer/createSubmissionController.ts
+++ b/web-next/src/components/note-composer/createSubmissionController.ts
@@ -1,0 +1,510 @@
+import { ConnectionHandler, graphql } from "relay-runtime";
+import { createMutation } from "solid-relay";
+import type { PostVisibility } from "~/components/PostVisibilitySelect.tsx";
+import type { QuotePolicy } from "~/components/QuotePolicySelect.tsx";
+import { showToast } from "~/components/ui/toast.tsx";
+import { encodeHandleSegment } from "~/lib/handleSegment.ts";
+import { useLingui } from "~/lib/i18n/macro.d.ts";
+import type { createSubmissionControllerArticleDraftMutation } from "./__generated__/createSubmissionControllerArticleDraftMutation.graphql.ts";
+import type { createSubmissionControllerCreateNoteMutation } from "./__generated__/createSubmissionControllerCreateNoteMutation.graphql.ts";
+import type { createSubmissionControllerCreateQuestionMutation } from "./__generated__/createSubmissionControllerCreateQuestionMutation.graphql.ts";
+import type { createSubmissionControllerUpdateNoteMutation } from "./__generated__/createSubmissionControllerUpdateNoteMutation.graphql.ts";
+import type { ValidatedPollInput } from "./pollState.ts";
+import { updateCreatedPostConnections } from "./relayUpdates.ts";
+import {
+  buildCreatePostInput,
+  buildUpdateNoteInput,
+  getNoteInternalHref,
+  type SubmissionMedium,
+  validateSubmission,
+} from "./submissionState.ts";
+
+const CreateNoteMutation = graphql`
+  mutation createSubmissionControllerCreateNoteMutation(
+    $input: CreateNoteInput!
+    $connections: [ID!]!
+    $includeDiscussionThreadFields: Boolean!
+    $actingAccountId: ID
+  ) {
+    createNote(input: $input) {
+      __typename
+      ... on CreateNotePayload {
+        note
+          @prependNode(
+            connections: $connections
+            edgeTypeName: "PostLinkSharingPostsConnectionEdge"
+          ) {
+          id
+          uuid
+          sourceId
+          replyTarget(actingAccountId: $actingAccountId) {
+            id
+          }
+          hasVisibleReplies(actingAccountId: $actingAccountId)
+          actor {
+            id
+            handle
+            username
+            local
+          }
+          ...PermalinkThread_replyNode @arguments(
+            actingAccountId: $actingAccountId
+          )
+          # Only news-discussion posts prepend into a connection and need the
+          # row fields; skip them for every other compose/reply/quote path.
+          ...NewsDiscussionThread_post
+            @arguments(actingAccountId: $actingAccountId)
+            @include(if: $includeDiscussionThreadFields)
+        }
+      }
+      ... on InvalidInputError {
+        inputPath
+      }
+      ... on NotAuthenticatedError {
+        notAuthenticated
+      }
+    }
+  }
+`;
+
+const CreateQuestionMutation = graphql`
+  mutation createSubmissionControllerCreateQuestionMutation(
+    $input: CreateQuestionInput!
+    $connections: [ID!]!
+    $includeDiscussionThreadFields: Boolean!
+    $actingAccountId: ID
+  ) {
+    createQuestion(input: $input) {
+      __typename
+      ... on CreateQuestionPayload {
+        question
+          @prependNode(
+            connections: $connections
+            edgeTypeName: "PostLinkSharingPostsConnectionEdge"
+          ) {
+          id
+          uuid
+          sourceId
+          replyTarget(actingAccountId: $actingAccountId) {
+            id
+          }
+          hasVisibleReplies(actingAccountId: $actingAccountId)
+          actor {
+            id
+          }
+          ...PermalinkThread_replyNode @arguments(
+            actingAccountId: $actingAccountId
+          )
+          ...NewsDiscussionThread_post
+            @arguments(actingAccountId: $actingAccountId)
+            @include(if: $includeDiscussionThreadFields)
+        }
+      }
+      ... on InvalidInputError {
+        inputPath
+      }
+      ... on NotAuthenticatedError {
+        notAuthenticated
+      }
+    }
+  }
+`;
+
+const UpdateNoteMutation = graphql`
+  mutation createSubmissionControllerUpdateNoteMutation(
+    $input: UpdateNoteInput!
+  ) {
+    updateNote(input: $input) {
+      __typename
+      ... on UpdateNotePayload {
+        note {
+          id
+          content
+          rawContent
+          language
+          quotePolicy
+        }
+      }
+      ... on InvalidInputError {
+        inputPath
+      }
+      ... on NotAuthenticatedError {
+        notAuthenticated
+      }
+    }
+  }
+`;
+
+const ArticleDraftMutation = graphql`
+  mutation createSubmissionControllerArticleDraftMutation(
+    $input: SaveArticleDraftInput!
+    $connections: [ID!]!
+  ) {
+    saveArticleDraft(input: $input) {
+      __typename
+      ... on SaveArticleDraftPayload {
+        draft
+          @prependNode(
+            connections: $connections
+            edgeTypeName: "AccountArticleDraftsConnectionEdge"
+          ) {
+          id
+          uuid
+          title
+          content
+          tags
+          updated
+        }
+      }
+      ... on InvalidInputError {
+        inputPath
+      }
+      ... on NotAuthenticatedError {
+        notAuthenticated
+      }
+    }
+  }
+`;
+
+interface ActingAccountInput {
+  readonly actingAccountId?: string;
+}
+
+export interface SubmissionControllerOptions {
+  readonly content: () => string;
+  readonly media: () => readonly SubmissionMedium[];
+  readonly editingNoteId: () => string | null | undefined;
+  readonly editingVisibility: () => PostVisibility | null | undefined;
+  readonly editingAuthorAccountId: () => string | null | undefined;
+  readonly language: () => string | undefined;
+  readonly fallbackLanguage: () => string;
+  readonly visibility: () => PostVisibility;
+  readonly quotePolicy: () => QuotePolicy;
+  readonly quotedPostId: () => string | null | undefined;
+  readonly replyTargetId: () => string | null | undefined;
+  readonly ensureLinkUrl: () => string | null | undefined;
+  readonly actingAccountInput: () => ActingAccountInput;
+  readonly prependToConnections: () => readonly string[];
+  readonly appendToConnections: () => readonly string[];
+  readonly viewerId: () => string | null | undefined;
+  readonly username: () => string | null | undefined;
+  readonly pollEnabled: () => boolean;
+  readonly validatedPoll: () => ValidatedPollInput | null;
+  readonly canSwitchToArticle: () => boolean;
+  readonly saveDraftNow: () => boolean;
+  readonly clearDraft: () => void;
+  readonly resetForm: () => void;
+  readonly onSuccess: () => void;
+  readonly onArticleSwitch: () => void;
+  readonly navigate: (href: string) => void;
+}
+
+export interface SubmissionController {
+  readonly submit: (event: Event) => void;
+  readonly switchToArticleDraft: () => void;
+  readonly creating: () => boolean;
+  readonly creatingQuestion: () => boolean;
+  readonly updating: () => boolean;
+  readonly savingArticleDraft: () => boolean;
+  readonly submitting: () => boolean;
+}
+
+export function createSubmissionController(
+  options: SubmissionControllerOptions,
+): SubmissionController {
+  const { t } = useLingui();
+  const [createNote, creating] = createMutation<
+    createSubmissionControllerCreateNoteMutation
+  >(CreateNoteMutation);
+  const [createQuestion, creatingQuestion] = createMutation<
+    createSubmissionControllerCreateQuestionMutation
+  >(CreateQuestionMutation);
+  const [updateNote, updating] = createMutation<
+    createSubmissionControllerUpdateNoteMutation
+  >(UpdateNoteMutation);
+  const [saveArticleDraft, savingArticleDraft] = createMutation<
+    createSubmissionControllerArticleDraftMutation
+  >(ArticleDraftMutation);
+
+  const submitting = () =>
+    creating() || creatingQuestion() || updating() || savingArticleDraft();
+
+  const showValidationError = (
+    error: "empty-content" | "uploading-media" | "missing-alt",
+  ) => {
+    const description = error === "empty-content"
+      ? t`Content cannot be empty`
+      : error === "uploading-media"
+      ? t`All images must finish uploading before posting`
+      : t`All images require alt text`;
+    showToast({ title: t`Error`, description, variant: "error" });
+  };
+
+  const finish = () => {
+    options.clearDraft();
+    options.resetForm();
+    options.onSuccess();
+  };
+
+  const submit = (event: Event) => {
+    event.preventDefault();
+    const validation = validateSubmission(options.content(), options.media());
+    if (!validation.ok) {
+      showValidationError(validation.error);
+      return;
+    }
+
+    const noteId = options.editingNoteId();
+    if (noteId != null) {
+      updateNote({
+        variables: {
+          input: buildUpdateNoteInput({
+            noteId,
+            content: validation.content,
+            language: options.language(),
+            quotePolicy: options.quotePolicy(),
+            visibility: options.editingVisibility(),
+            actingAccountId: options.editingAuthorAccountId() ?? undefined,
+          }),
+        },
+        onCompleted(response) {
+          if (response.updateNote.__typename === "UpdateNotePayload") {
+            showToast({
+              title: t`Success`,
+              description: t`Note updated`,
+              variant: "success",
+            });
+            finish();
+          } else if (response.updateNote.__typename === "InvalidInputError") {
+            showToast({
+              title: t`Error`,
+              description: t`Invalid input: ${response.updateNote.inputPath}`,
+              variant: "error",
+            });
+          } else if (
+            response.updateNote.__typename === "NotAuthenticatedError"
+          ) {
+            showToast({
+              title: t`Error`,
+              description: t`You must be signed in to edit a note`,
+              variant: "error",
+            });
+          }
+        },
+        onError(error) {
+          showToast({
+            title: t`Error`,
+            description: error.message,
+            variant: "error",
+          });
+        },
+      });
+      return;
+    }
+
+    const actingAccountInput = options.actingAccountInput();
+    const input = buildCreatePostInput({
+      content: validation.content,
+      ensureLinkUrl: options.ensureLinkUrl(),
+      language: options.language(),
+      fallbackLanguage: options.fallbackLanguage(),
+      visibility: options.visibility(),
+      quotePolicy: options.quotePolicy(),
+      quotedPostId: options.quotedPostId(),
+      replyTargetId: options.replyTargetId(),
+      actingAccountInput,
+      media: options.media(),
+    });
+    const connections = [...options.prependToConnections()];
+    const mutationVariables = {
+      connections,
+      actingAccountId: actingAccountInput.actingAccountId ?? null,
+      includeDiscussionThreadFields: connections.length > 0,
+    };
+    const connectionUpdate = {
+      appendConnectionIds: options.appendToConnections(),
+      replyTargetId: options.replyTargetId(),
+      actingAccountId: actingAccountInput.actingAccountId,
+    };
+
+    if (options.pollEnabled()) {
+      const poll = options.validatedPoll();
+      if (poll == null) return;
+      createQuestion({
+        variables: { input: { ...input, poll }, ...mutationVariables },
+        updater(store) {
+          updateCreatedPostConnections(store, {
+            ...connectionUpdate,
+            rootFieldName: "createQuestion",
+            postFieldName: "question",
+          });
+        },
+        onCompleted(response) {
+          if (
+            response.createQuestion.__typename === "CreateQuestionPayload"
+          ) {
+            showToast({
+              title: t`Success`,
+              description: t`Poll created successfully`,
+              variant: "success",
+            });
+            finish();
+          } else if (
+            response.createQuestion.__typename === "InvalidInputError"
+          ) {
+            showToast({
+              title: t`Error`,
+              description:
+                t`Invalid input: ${response.createQuestion.inputPath}`,
+              variant: "error",
+            });
+          } else if (
+            response.createQuestion.__typename === "NotAuthenticatedError"
+          ) {
+            showToast({
+              title: t`Error`,
+              description: t`You must be signed in to create a poll`,
+              variant: "error",
+            });
+          }
+        },
+        onError(error) {
+          showToast({
+            title: t`Error`,
+            description: error.message,
+            variant: "error",
+          });
+        },
+      });
+      return;
+    }
+
+    createNote({
+      variables: { input, ...mutationVariables },
+      updater(store) {
+        updateCreatedPostConnections(store, {
+          ...connectionUpdate,
+          rootFieldName: "createNote",
+          postFieldName: "note",
+        });
+      },
+      onCompleted(response) {
+        if (response.createNote.__typename === "CreateNotePayload") {
+          showToast({
+            title: t`Success`,
+            description: t`Note created successfully`,
+            href: getNoteInternalHref(response.createNote.note),
+            variant: "success",
+          });
+          finish();
+        } else if (response.createNote.__typename === "InvalidInputError") {
+          showToast({
+            title: t`Error`,
+            description: t`Invalid input: ${response.createNote.inputPath}`,
+            variant: "error",
+          });
+        } else if (
+          response.createNote.__typename === "NotAuthenticatedError"
+        ) {
+          showToast({
+            title: t`Error`,
+            description: t`You must be signed in to create a note`,
+            variant: "error",
+          });
+        }
+      },
+      onError(error) {
+        showToast({
+          title: t`Error`,
+          description: error.message,
+          variant: "error",
+        });
+      },
+    });
+  };
+
+  const switchToArticleDraft = () => {
+    const username = options.username();
+    const content = options.content().trim();
+    if (username == null) {
+      showToast({
+        title: t`Error`,
+        description: t`You must be signed in to save a draft`,
+        variant: "error",
+      });
+      return;
+    }
+    if (!options.canSwitchToArticle() || content === "") {
+      options.onArticleSwitch();
+      return;
+    }
+
+    options.saveDraftNow();
+    const viewerId = options.viewerId();
+    const connections = viewerId == null ? [] : [
+      "SignedAccount_articleDrafts",
+      "draftsPaginationFragment_articleDrafts",
+      "FloatingComposeButton_articleDrafts",
+    ].map((connectionKey) =>
+      ConnectionHandler.getConnectionID(viewerId, connectionKey)
+    );
+    saveArticleDraft({
+      variables: {
+        input: { title: "", content, tags: [] },
+        connections,
+      },
+      onCompleted(response) {
+        if (
+          response.saveArticleDraft.__typename === "SaveArticleDraftPayload"
+        ) {
+          const articleDraft = response.saveArticleDraft.draft;
+          options.clearDraft();
+          options.resetForm();
+          options.onArticleSwitch();
+          showToast({
+            title: t`Success`,
+            description: t`Draft saved`,
+            variant: "success",
+          });
+          options.navigate(
+            `/@${encodeHandleSegment(username)}/drafts/${articleDraft.uuid}`,
+          );
+        } else if (
+          response.saveArticleDraft.__typename === "InvalidInputError"
+        ) {
+          showToast({
+            title: t`Error`,
+            description:
+              t`Invalid input: ${response.saveArticleDraft.inputPath}`,
+            variant: "error",
+          });
+        } else if (
+          response.saveArticleDraft.__typename === "NotAuthenticatedError"
+        ) {
+          showToast({
+            title: t`Error`,
+            description: t`You must be signed in to save a draft`,
+            variant: "error",
+          });
+        }
+      },
+      onError(error) {
+        showToast({
+          title: t`Error`,
+          description: error.message,
+          variant: "error",
+        });
+      },
+    });
+  };
+
+  return {
+    submit,
+    switchToArticleDraft,
+    creating,
+    creatingQuestion,
+    updating,
+    savingArticleDraft,
+    submitting,
+  };
+}

--- a/web-next/src/components/note-composer/draftState.test.ts
+++ b/web-next/src/components/note-composer/draftState.test.ts
@@ -1,0 +1,194 @@
+import assert from "node:assert";
+import test from "node:test";
+import {
+  createNoteDraftData,
+  decideExternalDraftChange,
+  getNoteComposerDraftScope,
+  hasUnstorableDraftMedia,
+  shouldPreserveCurrentDraftForm,
+  toStorableNoteDraftData,
+} from "./draftState.ts";
+
+const poll = {
+  enabled: false,
+  title: "",
+  multiple: false,
+  ends: "2026-07-15T12:00",
+  options: [
+    { localId: "a", title: "" },
+    { localId: "b", title: "" },
+  ],
+};
+
+test("getNoteComposerDraftScope follows composer scope precedence", () => {
+  assert.equal(
+    getNoteComposerDraftScope({ editingNoteId: "edit" }),
+    null,
+  );
+  assert.deepEqual(
+    getNoteComposerDraftScope({
+      replyTargetId: "reply",
+      quotedPostId: "quote",
+      ensureLinkUrl: "https://example.com/",
+      initialContent: "prefill",
+    }),
+    { type: "reply", targetId: "reply" },
+  );
+  assert.deepEqual(
+    getNoteComposerDraftScope({ quotedPostId: "quote" }),
+    { type: "quote", targetId: "quote" },
+  );
+  assert.deepEqual(
+    getNoteComposerDraftScope({ ensureLinkUrl: "https://example.com/" }),
+    { type: "link", url: "https://example.com/" },
+  );
+  assert.deepEqual(
+    getNoteComposerDraftScope({ initialContent: " prefill " }),
+    { type: "prefill", content: "prefill" },
+  );
+  assert.deepEqual(getNoteComposerDraftScope({}), { type: "new" });
+});
+
+test("createNoteDraftData stores only stable uploaded media", () => {
+  const draft = createNoteDraftData({
+    content: "hello",
+    language: "en",
+    visibility: "PUBLIC",
+    quotePolicy: "EVERYONE",
+    actingAccountKey: "personal",
+    quotedPostId: "quote",
+    replyTargetId: "reply",
+    ensureLinkUrl: "https://example.com/",
+    media: [
+      {
+        localId: "uploaded",
+        previewUrl: "blob:uploaded",
+        alt: "diagram",
+        mediumRelayId: "relay-medium",
+        uuid: "00000000-0000-0000-0000-000000000000",
+        url: "https://example.com/media.webp",
+        width: 100,
+        height: 50,
+        uploading: false,
+      },
+      {
+        localId: "pending",
+        previewUrl: "blob:pending",
+        alt: "pending",
+        uploading: true,
+      },
+    ],
+    poll,
+    updated: "2026-07-14T00:00:00.000Z",
+  });
+
+  assert.deepEqual(draft.media, [{
+    localId: "uploaded",
+    mediumRelayId: "relay-medium",
+    uuid: "00000000-0000-0000-0000-000000000000",
+    url: "https://example.com/media.webp",
+    alt: "diagram",
+    width: 100,
+    height: 50,
+  }]);
+  assert.equal(
+    hasUnstorableDraftMedia([
+      {
+        localId: "pending",
+        previewUrl: "blob:pending",
+        alt: "pending",
+        uploading: true,
+      },
+    ]),
+    true,
+  );
+});
+
+test("toStorableNoteDraftData clears non-dirty transient form data", () => {
+  const draft = createNoteDraftData({
+    content: "reply mention prefill",
+    visibility: "PUBLIC",
+    quotePolicy: "EVERYONE",
+    actingAccountKey: "personal",
+    media: [],
+    poll: { ...poll, enabled: true },
+    updated: "2026-07-14T00:00:00.000Z",
+  });
+
+  assert.deepEqual(toStorableNoteDraftData(draft, false), {
+    ...draft,
+    content: "",
+    media: [],
+    poll: { ...draft.poll, enabled: false },
+  });
+  assert.equal(toStorableNoteDraftData(draft, true), draft);
+});
+
+test("shouldPreserveCurrentDraftForm protects dirty scope transitions only", () => {
+  assert.equal(
+    shouldPreserveCurrentDraftForm({
+      previousLoadedKey: "old",
+      formDraftKey: "old",
+      nextKey: "new",
+      dirty: true,
+    }),
+    true,
+  );
+  assert.equal(
+    shouldPreserveCurrentDraftForm({
+      previousLoadedKey: "old",
+      formDraftKey: "other",
+      nextKey: "new",
+      dirty: true,
+    }),
+    false,
+  );
+  assert.equal(
+    shouldPreserveCurrentDraftForm({
+      previousLoadedKey: "old",
+      formDraftKey: "old",
+      nextKey: "new",
+      dirty: false,
+    }),
+    false,
+  );
+});
+
+test("decideExternalDraftChange ignores unrelated changes and protects dirty text", () => {
+  assert.equal(
+    decideExternalDraftChange({
+      sameOrigin: true,
+      changeKey: "draft",
+      currentKey: "draft",
+      dirty: false,
+    }),
+    "ignore",
+  );
+  assert.equal(
+    decideExternalDraftChange({
+      sameOrigin: false,
+      changeKey: "other",
+      currentKey: "draft",
+      dirty: false,
+    }),
+    "ignore",
+  );
+  assert.equal(
+    decideExternalDraftChange({
+      sameOrigin: false,
+      changeKey: "draft",
+      currentKey: "draft",
+      dirty: false,
+    }),
+    "load",
+  );
+  assert.equal(
+    decideExternalDraftChange({
+      sameOrigin: false,
+      changeKey: "draft",
+      currentKey: "draft",
+      dirty: true,
+    }),
+    "preserve-and-resave",
+  );
+});

--- a/web-next/src/components/note-composer/draftState.ts
+++ b/web-next/src/components/note-composer/draftState.ts
@@ -1,0 +1,157 @@
+import type { PostVisibility } from "~/components/PostVisibilitySelect.tsx";
+import type { QuotePolicy } from "~/components/QuotePolicySelect.tsx";
+import type {
+  NoteDraftData,
+  NoteDraftMedia,
+  NoteDraftPoll,
+  NoteDraftScope,
+} from "~/lib/noteDraftStorage.ts";
+
+export interface DraftScopeInput {
+  readonly editingNoteId?: string | null;
+  readonly replyTargetId?: string | null;
+  readonly quotedPostId?: string | null;
+  readonly ensureLinkUrl?: string | null;
+  readonly initialContent?: string | null;
+}
+
+export interface DraftMediaCandidate {
+  readonly localId: string;
+  readonly previewUrl: string;
+  readonly alt: string;
+  readonly mediumRelayId?: string;
+  readonly uuid?: string;
+  readonly url?: string;
+  readonly width?: number;
+  readonly height?: number;
+  readonly uploading: boolean;
+}
+
+export interface NoteDraftDataInput {
+  readonly content: string;
+  readonly language?: string;
+  readonly visibility: PostVisibility;
+  readonly quotePolicy: QuotePolicy;
+  readonly actingAccountKey: string;
+  readonly quotedPostId?: string | null;
+  readonly replyTargetId?: string | null;
+  readonly ensureLinkUrl?: string | null;
+  readonly media: readonly DraftMediaCandidate[];
+  readonly poll: NoteDraftPoll;
+  readonly updated?: string;
+}
+
+export interface DraftScopeTransition {
+  readonly previousLoadedKey: string | null;
+  readonly formDraftKey: string | null;
+  readonly nextKey: string;
+  readonly dirty: boolean;
+}
+
+export interface ExternalDraftChangeInput {
+  readonly sameOrigin: boolean;
+  readonly changeKey: string;
+  readonly currentKey: string | null;
+  readonly dirty: boolean;
+}
+
+export type ExternalDraftChangeDecision =
+  | "ignore"
+  | "load"
+  | "preserve-and-resave";
+
+export function getNoteComposerDraftScope(
+  input: DraftScopeInput,
+): NoteDraftScope | null {
+  if (input.editingNoteId) return null;
+  if (input.replyTargetId) {
+    return { type: "reply", targetId: input.replyTargetId };
+  }
+  if (input.quotedPostId) {
+    return { type: "quote", targetId: input.quotedPostId };
+  }
+  if (input.ensureLinkUrl) return { type: "link", url: input.ensureLinkUrl };
+  const initialContent = input.initialContent?.trim();
+  if (initialContent) return { type: "prefill", content: initialContent };
+  return { type: "new" };
+}
+
+export function createNoteDraftData(
+  input: NoteDraftDataInput,
+): NoteDraftData {
+  return {
+    content: input.content,
+    language: input.language,
+    visibility: input.visibility,
+    quotePolicy: input.quotePolicy,
+    actingAccountKey: input.actingAccountKey,
+    quotedPostId: input.quotedPostId ?? undefined,
+    replyTargetId: input.replyTargetId ?? undefined,
+    ensureLinkUrl: input.ensureLinkUrl ?? undefined,
+    media: input.media.flatMap(toStoredMedium),
+    poll: input.poll,
+    updated: input.updated ?? new Date().toISOString(),
+  };
+}
+
+export function toStorableNoteDraftData(
+  draft: NoteDraftData,
+  dirty: boolean,
+): NoteDraftData {
+  if (dirty) return draft;
+  return {
+    ...draft,
+    content: "",
+    media: [],
+    poll: { ...draft.poll, enabled: false },
+  };
+}
+
+export function hasUnstorableDraftMedia(
+  media: readonly DraftMediaCandidate[],
+): boolean {
+  return media.some((item) =>
+    item.uploading ||
+    item.uuid == null ||
+    item.mediumRelayId == null ||
+    (item.url == null && item.previewUrl.startsWith("blob:"))
+  );
+}
+
+export function shouldPreserveCurrentDraftForm(
+  transition: DraftScopeTransition,
+): boolean {
+  return transition.previousLoadedKey != null &&
+    transition.formDraftKey === transition.previousLoadedKey &&
+    transition.previousLoadedKey !== transition.nextKey &&
+    transition.dirty;
+}
+
+export function decideExternalDraftChange(
+  input: ExternalDraftChangeInput,
+): ExternalDraftChangeDecision {
+  if (input.sameOrigin || input.currentKey == null) return "ignore";
+  if (input.changeKey !== input.currentKey) return "ignore";
+  return input.dirty ? "preserve-and-resave" : "load";
+}
+
+function toStoredMedium(
+  item: DraftMediaCandidate,
+): readonly NoteDraftMedia[] {
+  if (
+    item.uuid == null ||
+    item.mediumRelayId == null ||
+    (item.url == null && item.previewUrl.startsWith("blob:"))
+  ) {
+    return [];
+  }
+  return [{
+    localId: item.localId,
+    mediumRelayId: item.mediumRelayId,
+    uuid: item.uuid,
+    url: item.url ?? item.previewUrl,
+    alt: item.alt,
+    width: item.width,
+    height: item.height,
+  }];
+}

--- a/web-next/src/components/note-composer/mediaState.test.ts
+++ b/web-next/src/components/note-composer/mediaState.test.ts
@@ -1,0 +1,99 @@
+import assert from "node:assert";
+import test from "node:test";
+import { type MediaItem, reduceMediaItems } from "./mediaState.ts";
+
+function item(overrides: Partial<MediaItem> = {}): MediaItem {
+  return {
+    localId: "local",
+    previewUrl: "blob:preview",
+    alt: "",
+    uploading: true,
+    uploadProgress: 0,
+    generatingAlt: false,
+    ...overrides,
+  };
+}
+
+test("reduceMediaItems tracks upload progress and completion", () => {
+  let state: readonly MediaItem[] = [item()];
+  state = reduceMediaItems(state, {
+    type: "upload-progress",
+    localId: "local",
+    progress: 42,
+  });
+  assert.equal(state[0].uploadProgress, 42);
+
+  state = reduceMediaItems(state, {
+    type: "upload-completed",
+    localId: "local",
+    result: {
+      uuid: "00000000-0000-0000-0000-000000000000",
+      mediumRelayId: "relay-medium",
+      url: "https://example.com/media.webp",
+      width: 100,
+      height: 50,
+    },
+  });
+  assert.deepEqual(state[0], {
+    ...item(),
+    uploading: false,
+    uploadProgress: 100,
+    uuid: "00000000-0000-0000-0000-000000000000",
+    mediumRelayId: "relay-medium",
+    url: "https://example.com/media.webp",
+    width: 100,
+    height: 50,
+    abortUpload: undefined,
+  });
+});
+
+test("removed media ignores late asynchronous results", () => {
+  let state: readonly MediaItem[] = reduceMediaItems([item()], {
+    type: "remove",
+    localId: "local",
+  });
+  state = reduceMediaItems(state, {
+    type: "upload-completed",
+    localId: "local",
+    result: {
+      uuid: "00000000-0000-0000-0000-000000000000",
+      mediumRelayId: "relay-medium",
+      url: "https://example.com/media.webp",
+    },
+  });
+  assert.deepEqual(state, []);
+});
+
+test("alt generation preserves existing text when no replacement is returned", () => {
+  let state: readonly MediaItem[] = [item({ alt: "Existing" })];
+  state = reduceMediaItems(state, {
+    type: "alt-started",
+    localId: "local",
+  });
+  assert.equal(state[0].generatingAlt, true);
+
+  state = reduceMediaItems(state, {
+    type: "alt-completed",
+    localId: "local",
+    alt: null,
+  });
+  assert.equal(state[0].generatingAlt, false);
+  assert.equal(state[0].alt, "Existing");
+});
+
+test("alt cancellation clears only the pending state", () => {
+  const subscription = { unsubscribe() {} };
+  const state = reduceMediaItems([
+    item({
+      alt: "Existing",
+      generatingAlt: true,
+      altSubscription: subscription,
+    }),
+  ], {
+    type: "alt-cancelled",
+    localId: "local",
+  });
+  assert.equal(state[0].alt, "Existing");
+  assert.equal(state[0].generatingAlt, false);
+  assert.equal(state[0].altSubscription, undefined);
+});

--- a/web-next/src/components/note-composer/mediaState.ts
+++ b/web-next/src/components/note-composer/mediaState.ts
@@ -1,0 +1,139 @@
+export interface MediaSubscription {
+  unsubscribe(): void;
+}
+
+export interface MediaItem {
+  readonly localId: string;
+  readonly file?: File;
+  readonly previewUrl: string;
+  readonly alt: string;
+  readonly mediumRelayId?: string;
+  readonly uuid?: string;
+  readonly url?: string;
+  readonly width?: number;
+  readonly height?: number;
+  readonly uploading: boolean;
+  readonly uploadProgress: number;
+  readonly generatingAlt: boolean;
+  readonly abortUpload?: () => void;
+  readonly altSubscription?: MediaSubscription;
+}
+
+export interface CompletedMediaUpload {
+  readonly uuid: string;
+  readonly mediumRelayId: string;
+  readonly url: string;
+  readonly width?: number;
+  readonly height?: number;
+}
+
+export type MediaStateAction =
+  | { readonly type: "append"; readonly items: readonly MediaItem[] }
+  | { readonly type: "replace"; readonly items: readonly MediaItem[] }
+  | {
+    readonly type: "upload-progress";
+    readonly localId: string;
+    readonly progress: number;
+  }
+  | {
+    readonly type: "upload-completed";
+    readonly localId: string;
+    readonly result: CompletedMediaUpload;
+  }
+  | {
+    readonly type: "alt-changed";
+    readonly localId: string;
+    readonly alt: string;
+  }
+  | {
+    readonly type: "alt-started";
+    readonly localId: string;
+  }
+  | {
+    readonly type: "alt-subscription-set";
+    readonly localId: string;
+    readonly subscription: MediaSubscription;
+  }
+  | {
+    readonly type: "alt-completed";
+    readonly localId: string;
+    readonly alt: string | null;
+  }
+  | {
+    readonly type: "alt-cancelled";
+    readonly localId: string;
+  }
+  | { readonly type: "remove"; readonly localId: string };
+
+export function reduceMediaItems(
+  items: readonly MediaItem[],
+  action: MediaStateAction,
+): readonly MediaItem[] {
+  switch (action.type) {
+    case "append":
+      return [...items, ...action.items];
+    case "replace":
+      return [...action.items];
+    case "remove":
+      return items.filter((item) => item.localId !== action.localId);
+    case "upload-progress":
+      return updateItem(items, action.localId, (item) => ({
+        ...item,
+        uploadProgress: action.progress,
+      }));
+    case "upload-completed":
+      return updateItem(items, action.localId, (item) => ({
+        ...item,
+        uploading: false,
+        uploadProgress: 100,
+        uuid: action.result.uuid,
+        mediumRelayId: action.result.mediumRelayId,
+        url: action.result.url,
+        width: action.result.width,
+        height: action.result.height,
+        abortUpload: undefined,
+      }));
+    case "alt-changed":
+      return updateItem(items, action.localId, (item) => ({
+        ...item,
+        alt: action.alt,
+      }));
+    case "alt-started":
+      return updateItem(items, action.localId, (item) => ({
+        ...item,
+        generatingAlt: true,
+      }));
+    case "alt-subscription-set":
+      return updateItem(items, action.localId, (item) => ({
+        ...item,
+        altSubscription: action.subscription,
+      }));
+    case "alt-completed":
+      return updateItem(items, action.localId, (item) => ({
+        ...item,
+        generatingAlt: false,
+        alt: action.alt ?? item.alt,
+        altSubscription: undefined,
+      }));
+    case "alt-cancelled":
+      return updateItem(items, action.localId, (item) => ({
+        ...item,
+        generatingAlt: false,
+        altSubscription: undefined,
+      }));
+  }
+}
+
+function updateItem(
+  items: readonly MediaItem[],
+  localId: string,
+  update: (item: MediaItem) => MediaItem,
+): readonly MediaItem[] {
+  let found = false;
+  const updated = items.map((item) => {
+    if (item.localId !== localId) return item;
+    found = true;
+    return update(item);
+  });
+  return found ? updated : items;
+}

--- a/web-next/src/components/note-composer/pollState.test.ts
+++ b/web-next/src/components/note-composer/pollState.test.ts
@@ -1,0 +1,152 @@
+import assert from "node:assert";
+import test from "node:test";
+import {
+  addPollOption,
+  createPollDraft,
+  MAX_POLL_OPTIONS,
+  MIN_POLL_OPTIONS,
+  removePollOption,
+  restorePollDraft,
+  setPollDuration,
+  validatePollDraft,
+} from "./pollState.ts";
+
+const NOW = new Date(2026, 6, 14, 12, 34, 56, 789);
+
+function ids(): () => string {
+  let id = 0;
+  return () => `option-${++id}`;
+}
+
+test("createPollDraft creates the minimum options and a rounded one-day deadline", () => {
+  assert.deepEqual(createPollDraft(NOW, ids()), {
+    enabled: false,
+    title: "",
+    multiple: false,
+    ends: "2026-07-15T12:34",
+    options: [
+      { localId: "option-1", title: "" },
+      { localId: "option-2", title: "" },
+    ],
+  });
+});
+
+test("restorePollDraft disables unavailable polls and repairs too few options", () => {
+  assert.deepEqual(
+    restorePollDraft(
+      {
+        enabled: true,
+        title: "Question",
+        multiple: true,
+        ends: "",
+        options: [{ localId: "only", title: "One" }],
+      },
+      false,
+      NOW,
+      ids(),
+    ),
+    {
+      enabled: false,
+      title: "Question",
+      multiple: true,
+      ends: "2026-07-15T12:34",
+      options: [
+        { localId: "option-1", title: "" },
+        { localId: "option-2", title: "" },
+      ],
+    },
+  );
+});
+
+test("poll options stay within the supported bounds", () => {
+  let draft = createPollDraft(NOW, ids());
+  draft = removePollOption(draft, draft.options[0].localId);
+  assert.equal(draft.options.length, MIN_POLL_OPTIONS);
+
+  const createId = ids();
+  for (let i = 0; i < MAX_POLL_OPTIONS + 5; i++) {
+    draft = addPollOption(draft, createId);
+  }
+  assert.equal(draft.options.length, MAX_POLL_OPTIONS);
+
+  draft = removePollOption(draft, draft.options[5].localId);
+  assert.equal(draft.options.length, MAX_POLL_OPTIONS - 1);
+});
+
+test("setPollDuration uses the supplied clock and rounds to a minute", () => {
+  assert.equal(setPollDuration(NOW, 7), "2026-07-21T12:34");
+});
+
+test("validatePollDraft returns focused validation errors", () => {
+  const base = {
+    ...createPollDraft(NOW, ids()),
+    enabled: true,
+    title: " Question ",
+    ends: "2026-07-15T12:34",
+    options: [
+      { localId: "a", title: " Yes " },
+      { localId: "b", title: " No " },
+    ],
+  };
+
+  assert.deepEqual(
+    validatePollDraft({ ...base, title: " " }, NOW.getTime()),
+    { ok: false, error: "empty-title" },
+  );
+  assert.deepEqual(
+    validatePollDraft({
+      ...base,
+      options: [{ localId: "a", title: "" }, base.options[1]],
+    }, NOW.getTime()),
+    { ok: false, error: "empty-option" },
+  );
+  assert.deepEqual(
+    validatePollDraft({
+      ...base,
+      options: [{ localId: "a", title: "Yes" }],
+    }, NOW.getTime()),
+    { ok: false, error: "too-few-options" },
+  );
+  assert.deepEqual(
+    validatePollDraft({
+      ...base,
+      options: [
+        { localId: "a", title: "Same" },
+        { localId: "b", title: " Same " },
+      ],
+    }, NOW.getTime()),
+    { ok: false, error: "duplicate-options" },
+  );
+  assert.deepEqual(
+    validatePollDraft({ ...base, ends: "2026-02-30T12:00" }, NOW.getTime()),
+    { ok: false, error: "invalid-deadline" },
+  );
+  assert.deepEqual(
+    validatePollDraft({ ...base, ends: "2026-07-14T12:34" }, NOW.getTime()),
+    { ok: false, error: "deadline-too-soon" },
+  );
+});
+
+test("validatePollDraft trims a valid poll and serializes its deadline", () => {
+  const result = validatePollDraft({
+    ...createPollDraft(NOW, ids()),
+    enabled: true,
+    title: " Question ",
+    multiple: true,
+    ends: "2026-07-15T12:34",
+    options: [
+      { localId: "a", title: " Yes " },
+      { localId: "b", title: " No " },
+    ],
+  }, NOW.getTime());
+
+  assert.deepEqual(result, {
+    ok: true,
+    value: {
+      title: "Question",
+      multiple: true,
+      options: ["Yes", "No"],
+      ends: new Date(2026, 6, 15, 12, 34).toISOString(),
+    },
+  });
+});

--- a/web-next/src/components/note-composer/pollState.ts
+++ b/web-next/src/components/note-composer/pollState.ts
@@ -1,0 +1,170 @@
+import type { NoteDraftPoll } from "~/lib/noteDraftStorage.ts";
+
+export const MIN_POLL_OPTIONS = 2;
+export const MAX_POLL_OPTIONS = 20;
+
+export interface PollOptionDraft {
+  readonly localId: string;
+  readonly title: string;
+}
+
+export interface PollDraft {
+  readonly enabled: boolean;
+  readonly title: string;
+  readonly multiple: boolean;
+  readonly ends: string;
+  readonly options: readonly PollOptionDraft[];
+}
+
+export interface ValidatedPollInput {
+  readonly title: string;
+  readonly multiple: boolean;
+  readonly options: readonly string[];
+  readonly ends: string;
+}
+
+export type PollValidationError =
+  | "empty-title"
+  | "empty-option"
+  | "too-few-options"
+  | "duplicate-options"
+  | "invalid-deadline"
+  | "deadline-too-soon";
+
+export type PollValidationResult =
+  | { readonly ok: true; readonly value: ValidatedPollInput }
+  | { readonly ok: false; readonly error: PollValidationError };
+
+export function createPollDraft(
+  now = new Date(),
+  createId: () => string = createLocalId,
+): PollDraft {
+  return {
+    enabled: false,
+    title: "",
+    multiple: false,
+    ends: setPollDuration(now, 1),
+    options: createMinimumOptions(createId),
+  };
+}
+
+export function restorePollDraft(
+  poll: NoteDraftPoll,
+  allowed: boolean,
+  now = new Date(),
+  createId: () => string = createLocalId,
+): PollDraft {
+  return {
+    enabled: allowed && poll.enabled,
+    title: poll.title,
+    multiple: poll.multiple,
+    ends: poll.ends || setPollDuration(now, 1),
+    options: poll.options.length >= MIN_POLL_OPTIONS
+      ? poll.options.map((option) => ({ ...option }))
+      : createMinimumOptions(createId),
+  };
+}
+
+export function addPollOption(
+  draft: PollDraft,
+  createId: () => string = createLocalId,
+): PollDraft {
+  if (draft.options.length >= MAX_POLL_OPTIONS) return draft;
+  return {
+    ...draft,
+    options: [...draft.options, { localId: createId(), title: "" }],
+  };
+}
+
+export function removePollOption(
+  draft: PollDraft,
+  localId: string,
+): PollDraft {
+  if (draft.options.length <= MIN_POLL_OPTIONS) return draft;
+  return {
+    ...draft,
+    options: draft.options.filter((option) => option.localId !== localId),
+  };
+}
+
+export function setPollDuration(now: Date, days: number): string {
+  const date = new Date(now);
+  date.setDate(date.getDate() + days);
+  date.setSeconds(0, 0);
+  return formatDateTimeLocal(date);
+}
+
+export function validatePollDraft(
+  draft: PollDraft,
+  now = Date.now(),
+): PollValidationResult {
+  const title = draft.title.trim();
+  if (title === "") return { ok: false, error: "empty-title" };
+
+  const options = draft.options.map((option) => option.title.trim());
+  if (options.some((option) => option === "")) {
+    return { ok: false, error: "empty-option" };
+  }
+  if (options.length < MIN_POLL_OPTIONS) {
+    return { ok: false, error: "too-few-options" };
+  }
+  if (new Set(options).size !== options.length) {
+    return { ok: false, error: "duplicate-options" };
+  }
+
+  const ends = parseDateTimeLocal(draft.ends);
+  if (!Number.isFinite(ends.getTime())) {
+    return { ok: false, error: "invalid-deadline" };
+  }
+  if (ends.getTime() - now < 60_000) {
+    return { ok: false, error: "deadline-too-soon" };
+  }
+
+  return {
+    ok: true,
+    value: {
+      title,
+      multiple: draft.multiple,
+      options,
+      ends: ends.toISOString(),
+    },
+  };
+}
+
+function createMinimumOptions(
+  createId: () => string,
+): readonly PollOptionDraft[] {
+  return Array.from({ length: MIN_POLL_OPTIONS }, () => ({
+    localId: createId(),
+    title: "",
+  }));
+}
+
+function createLocalId(): string {
+  return globalThis.crypto?.randomUUID?.() ??
+    Math.random().toString(36).slice(2);
+}
+
+function formatDateTimeLocal(date: Date): string {
+  const pad = (value: number) => String(value).padStart(2, "0");
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${
+    pad(date.getDate())
+  }T${pad(date.getHours())}:${pad(date.getMinutes())}`;
+}
+
+function parseDateTimeLocal(value: string): Date {
+  const match = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})$/.exec(value);
+  if (match == null) return new Date(NaN);
+  const [, year, month, day, hours, minutes] = match.map(Number);
+  const date = new Date(year, month - 1, day, hours, minutes);
+  if (
+    date.getFullYear() !== year ||
+    date.getMonth() !== month - 1 ||
+    date.getDate() !== day ||
+    date.getHours() !== hours ||
+    date.getMinutes() !== minutes
+  ) {
+    return new Date(NaN);
+  }
+  return date;
+}

--- a/web-next/src/components/note-composer/relayUpdates.test.ts
+++ b/web-next/src/components/note-composer/relayUpdates.test.ts
@@ -1,0 +1,71 @@
+import assert from "node:assert";
+import test from "node:test";
+import { Environment, Network, RecordSource, Store } from "relay-runtime";
+import { updateCreatedPostConnections } from "./relayUpdates.ts";
+
+function environment(): Environment {
+  return new Environment({
+    network: Network.create(() => Promise.resolve({ data: {} })),
+    store: new Store(new RecordSource()),
+  });
+}
+
+test("updateCreatedPostConnections appends and increments only successful payloads", () => {
+  const env = environment();
+  env.commitUpdate((store) => {
+    const payload = store.create("payload", "CreateNotePayload");
+    const post = store.create("post", "Note");
+    payload.setLinkedRecord(post, "note");
+    store.getRoot().setLinkedRecord(payload, "createNote");
+
+    const connection = store.create("connection", "PostConnection");
+    connection.setLinkedRecords([], "edges");
+    const target = store.create("target", "Note");
+    const replies = store.create("replies", "PostConnection");
+    replies.setValue(4, "totalCount");
+    target.setLinkedRecord(replies, "replies", {
+      first: 0,
+      actingAccountId: null,
+    });
+
+    assert.equal(
+      updateCreatedPostConnections(store, {
+        rootFieldName: "createNote",
+        postFieldName: "note",
+        appendConnectionIds: ["connection"],
+        replyTargetId: "target",
+        actingAccountId: null,
+      }),
+      true,
+    );
+    assert.equal(connection.getLinkedRecords("edges")?.length, 1);
+    assert.equal(replies.getValue("totalCount"), 5);
+  });
+});
+
+test("updateCreatedPostConnections leaves counters unchanged for error payloads", () => {
+  const env = environment();
+  env.commitUpdate((store) => {
+    const payload = store.create("payload", "InvalidInputError");
+    store.getRoot().setLinkedRecord(payload, "createNote");
+    const target = store.create("target", "Note");
+    const replies = store.create("replies", "PostConnection");
+    replies.setValue(4, "totalCount");
+    target.setLinkedRecord(replies, "replies", {
+      first: 0,
+      actingAccountId: null,
+    });
+
+    assert.equal(
+      updateCreatedPostConnections(store, {
+        rootFieldName: "createNote",
+        postFieldName: "note",
+        appendConnectionIds: [],
+        replyTargetId: "target",
+        actingAccountId: null,
+      }),
+      false,
+    );
+    assert.equal(replies.getValue("totalCount"), 4);
+  });
+});

--- a/web-next/src/components/note-composer/relayUpdates.ts
+++ b/web-next/src/components/note-composer/relayUpdates.ts
@@ -1,0 +1,52 @@
+import {
+  ConnectionHandler,
+  type RecordSourceProxy,
+  type RecordSourceSelectorProxy,
+} from "relay-runtime";
+
+export interface CreatedPostConnectionUpdate {
+  readonly rootFieldName: "createNote" | "createQuestion";
+  readonly postFieldName: "note" | "question";
+  readonly appendConnectionIds: readonly string[];
+  readonly replyTargetId?: string | null;
+  readonly actingAccountId?: string | null;
+}
+
+export function updateCreatedPostConnections(
+  store: RecordSourceProxy | RecordSourceSelectorProxy,
+  update: CreatedPostConnectionUpdate,
+): boolean {
+  const payload = "getRootField" in store
+    ? store.getRootField(update.rootFieldName)
+    : store.getRoot().getLinkedRecord(update.rootFieldName);
+  const expectedPayload = update.rootFieldName === "createNote"
+    ? "CreateNotePayload"
+    : "CreateQuestionPayload";
+  if (payload?.getValue("__typename") !== expectedPayload) return false;
+
+  const post = payload.getLinkedRecord(update.postFieldName);
+  if (post == null) return false;
+  for (const connectionId of update.appendConnectionIds) {
+    const connection = store.get(connectionId);
+    if (connection == null) continue;
+    const edge = ConnectionHandler.createEdge(
+      store,
+      connection,
+      post,
+      "PostDescendantsConnectionEdge",
+    );
+    ConnectionHandler.insertEdgeAfter(connection, edge);
+  }
+
+  if (update.replyTargetId == null) return true;
+  const target = store.get(update.replyTargetId);
+  const replies = target?.getLinkedRecord("replies", {
+    first: 0,
+    actingAccountId: update.actingAccountId ?? null,
+  });
+  const totalCount = replies?.getValue("totalCount");
+  if (typeof totalCount === "number") {
+    replies?.setValue(totalCount + 1, "totalCount");
+  }
+  return true;
+}

--- a/web-next/src/components/note-composer/submissionState.test.ts
+++ b/web-next/src/components/note-composer/submissionState.test.ts
@@ -1,0 +1,127 @@
+import assert from "node:assert";
+import test from "node:test";
+import {
+  buildCreatePostInput,
+  buildUpdateNoteInput,
+  getNoteInternalHref,
+  validateSubmission,
+} from "./submissionState.ts";
+
+const uploadedMedia = [{
+  uuid: "00000000-0000-0000-0000-000000000000",
+  alt: " Diagram ",
+  uploading: false,
+}];
+
+test("validateSubmission rejects empty content and incomplete media", () => {
+  assert.deepEqual(validateSubmission(" ", []), {
+    ok: false,
+    error: "empty-content",
+  });
+  assert.deepEqual(
+    validateSubmission("hello", [{
+      ...uploadedMedia[0],
+      uploading: true,
+    }]),
+    {
+      ok: false,
+      error: "uploading-media",
+    },
+  );
+  assert.deepEqual(
+    validateSubmission("hello", [{
+      ...uploadedMedia[0],
+      alt: " ",
+    }]),
+    {
+      ok: false,
+      error: "missing-alt",
+    },
+  );
+});
+
+test("buildCreatePostInput normalizes shared note fields", () => {
+  assert.deepEqual(
+    buildCreatePostInput({
+      content: " Opinion ",
+      ensureLinkUrl: "https://example.com/story",
+      language: undefined,
+      fallbackLanguage: "ko",
+      visibility: "PUBLIC",
+      quotePolicy: "EVERYONE",
+      quotedPostId: "quote",
+      replyTargetId: "reply",
+      actingAccountInput: { actingAccountId: "account" },
+      media: uploadedMedia,
+    }),
+    {
+      content: "Opinion\n\nhttps://example.com/story",
+      language: "ko",
+      visibility: "PUBLIC",
+      quotePolicy: "EVERYONE",
+      quotedPostId: "quote",
+      replyTargetId: "reply",
+      actingAccountId: "account",
+      media: [{
+        mediumId: "00000000-0000-0000-0000-000000000000",
+        alt: "Diagram",
+      }],
+    },
+  );
+});
+
+test("buildUpdateNoteInput includes quote policy only for applicable visibility", () => {
+  assert.deepEqual(
+    buildUpdateNoteInput({
+      noteId: "note",
+      content: " Edited ",
+      language: undefined,
+      quotePolicy: "FOLLOWERS",
+      visibility: "FOLLOWERS",
+      actingAccountId: "author",
+    }),
+    {
+      noteId: "note",
+      content: "Edited",
+      language: null,
+      actingAccountId: "author",
+    },
+  );
+  assert.equal(
+    buildUpdateNoteInput({
+      noteId: "note",
+      content: "Edited",
+      language: "en",
+      quotePolicy: "FOLLOWERS",
+      visibility: "UNLISTED",
+    }).quotePolicy,
+    "FOLLOWERS",
+  );
+});
+
+test("getNoteInternalHref uses local usernames and remote handles", () => {
+  assert.equal(
+    getNoteInternalHref({
+      uuid: "uuid",
+      sourceId: "source",
+      actor: {
+        local: true,
+        username: "alice",
+        handle: "@alice@example.com",
+      },
+    }),
+    "/@alice/source",
+  );
+  assert.equal(
+    getNoteInternalHref({
+      uuid: "uuid",
+      sourceId: null,
+      actor: {
+        local: false,
+        username: "alice",
+        handle: "@alice@example.com",
+      },
+    }),
+    "/@alice@example.com/uuid",
+  );
+});

--- a/web-next/src/components/note-composer/submissionState.test.ts
+++ b/web-next/src/components/note-composer/submissionState.test.ts
@@ -11,7 +11,7 @@ const uploadedMedia = [{
   uuid: "00000000-0000-0000-0000-000000000000",
   alt: " Diagram ",
   uploading: false,
-}];
+}] as const;
 
 test("validateSubmission rejects empty content and incomplete media", () => {
   assert.deepEqual(validateSubmission(" ", []), {
@@ -30,6 +30,16 @@ test("validateSubmission rejects empty content and incomplete media", () => {
   );
   assert.deepEqual(
     validateSubmission("hello", [{
+      alt: "Diagram",
+      uploading: false,
+    }]),
+    {
+      ok: false,
+      error: "failed-media-upload",
+    },
+  );
+  assert.deepEqual(
+    validateSubmission("hello", [{
       ...uploadedMedia[0],
       alt: " ",
     }]),
@@ -38,6 +48,11 @@ test("validateSubmission rejects empty content and incomplete media", () => {
       error: "missing-alt",
     },
   );
+  assert.deepEqual(validateSubmission(" hello ", uploadedMedia), {
+    ok: true,
+    content: "hello",
+    media: uploadedMedia,
+  });
 });
 
 test("buildCreatePostInput normalizes shared note fields", () => {

--- a/web-next/src/components/note-composer/submissionState.ts
+++ b/web-next/src/components/note-composer/submissionState.ts
@@ -1,9 +1,8 @@
+import { type Uuid, validateUuid } from "@hackerspub/models/uuid";
 import type { PostVisibility } from "~/components/PostVisibilitySelect.tsx";
 import type { QuotePolicy } from "~/components/QuotePolicySelect.tsx";
 import { ensureLinkInContent } from "~/lib/composerLink.ts";
 import { encodeHandleSegment } from "~/lib/handleSegment.ts";
-
-type Uuid = `${string}-${string}-${string}-${string}-${string}`;
 
 export interface SubmissionMedium {
   readonly uuid?: string;
@@ -11,11 +10,25 @@ export interface SubmissionMedium {
   readonly uploading: boolean;
 }
 
+export interface ValidatedSubmissionMedium extends SubmissionMedium {
+  readonly uuid: Uuid;
+}
+
+export type SubmissionValidationError =
+  | "empty-content"
+  | "uploading-media"
+  | "failed-media-upload"
+  | "missing-alt";
+
 export type SubmissionValidationResult =
-  | { readonly ok: true; readonly content: string }
+  | {
+    readonly ok: true;
+    readonly content: string;
+    readonly media: readonly ValidatedSubmissionMedium[];
+  }
   | {
     readonly ok: false;
-    readonly error: "empty-content" | "uploading-media" | "missing-alt";
+    readonly error: SubmissionValidationError;
   };
 
 export interface BuildCreatePostInputOptions {
@@ -28,7 +41,7 @@ export interface BuildCreatePostInputOptions {
   readonly quotedPostId?: string | null;
   readonly replyTargetId?: string | null;
   readonly actingAccountInput: { readonly actingAccountId?: string };
-  readonly media: readonly SubmissionMedium[];
+  readonly media: readonly ValidatedSubmissionMedium[];
 }
 
 export interface CreatePostInput {
@@ -81,10 +94,19 @@ export function validateSubmission(
   if (media.some((item) => item.uploading)) {
     return { ok: false, error: "uploading-media" };
   }
+  if (!media.every(hasUploadedUuid)) {
+    return { ok: false, error: "failed-media-upload" };
+  }
   if (media.some((item) => item.alt.trim() === "")) {
     return { ok: false, error: "missing-alt" };
   }
-  return { ok: true, content: normalizedContent };
+  return { ok: true, content: normalizedContent, media };
+}
+
+function hasUploadedUuid(
+  medium: SubmissionMedium,
+): medium is ValidatedSubmissionMedium {
+  return validateUuid(medium.uuid);
 }
 
 export function buildCreatePostInput(
@@ -102,7 +124,7 @@ export function buildCreatePostInput(
     replyTargetId: options.replyTargetId ?? null,
     ...options.actingAccountInput,
     media: options.media.map((item) => ({
-      mediumId: item.uuid! as Uuid,
+      mediumId: item.uuid,
       alt: item.alt.trim(),
     })),
   };

--- a/web-next/src/components/note-composer/submissionState.ts
+++ b/web-next/src/components/note-composer/submissionState.ts
@@ -1,0 +1,132 @@
+import type { PostVisibility } from "~/components/PostVisibilitySelect.tsx";
+import type { QuotePolicy } from "~/components/QuotePolicySelect.tsx";
+import { ensureLinkInContent } from "~/lib/composerLink.ts";
+import { encodeHandleSegment } from "~/lib/handleSegment.ts";
+
+type Uuid = `${string}-${string}-${string}-${string}-${string}`;
+
+export interface SubmissionMedium {
+  readonly uuid?: string;
+  readonly alt: string;
+  readonly uploading: boolean;
+}
+
+export type SubmissionValidationResult =
+  | { readonly ok: true; readonly content: string }
+  | {
+    readonly ok: false;
+    readonly error: "empty-content" | "uploading-media" | "missing-alt";
+  };
+
+export interface BuildCreatePostInputOptions {
+  readonly content: string;
+  readonly ensureLinkUrl?: string | null;
+  readonly language?: string;
+  readonly fallbackLanguage: string;
+  readonly visibility: PostVisibility;
+  readonly quotePolicy: QuotePolicy;
+  readonly quotedPostId?: string | null;
+  readonly replyTargetId?: string | null;
+  readonly actingAccountInput: { readonly actingAccountId?: string };
+  readonly media: readonly SubmissionMedium[];
+}
+
+export interface CreatePostInput {
+  readonly content: string;
+  readonly language: string;
+  readonly visibility: PostVisibility;
+  readonly quotePolicy: QuotePolicy;
+  readonly quotedPostId: string | null;
+  readonly replyTargetId: string | null;
+  readonly actingAccountId?: string;
+  readonly media: readonly {
+    readonly mediumId: Uuid;
+    readonly alt: string;
+  }[];
+}
+
+export interface BuildUpdateNoteInputOptions {
+  readonly noteId: string;
+  readonly content: string;
+  readonly language?: string;
+  readonly quotePolicy: QuotePolicy;
+  readonly visibility?: PostVisibility | null;
+  readonly actingAccountId?: string;
+}
+
+export interface UpdateNoteInput {
+  readonly noteId: string;
+  readonly content: string;
+  readonly language: string | null;
+  readonly quotePolicy?: QuotePolicy;
+  readonly actingAccountId?: string;
+}
+
+export interface CreatedNotePathInput {
+  readonly uuid: string;
+  readonly sourceId?: string | null;
+  readonly actor: {
+    readonly local: boolean;
+    readonly username: string;
+    readonly handle: string;
+  };
+}
+
+export function validateSubmission(
+  content: string,
+  media: readonly SubmissionMedium[],
+): SubmissionValidationResult {
+  const normalizedContent = content.trim();
+  if (normalizedContent === "") return { ok: false, error: "empty-content" };
+  if (media.some((item) => item.uploading)) {
+    return { ok: false, error: "uploading-media" };
+  }
+  if (media.some((item) => item.alt.trim() === "")) {
+    return { ok: false, error: "missing-alt" };
+  }
+  return { ok: true, content: normalizedContent };
+}
+
+export function buildCreatePostInput(
+  options: BuildCreatePostInputOptions,
+): CreatePostInput {
+  const content = options.ensureLinkUrl
+    ? ensureLinkInContent(options.content.trim(), options.ensureLinkUrl)
+    : options.content.trim();
+  return {
+    content,
+    language: options.language ?? options.fallbackLanguage,
+    visibility: options.visibility,
+    quotePolicy: options.quotePolicy,
+    quotedPostId: options.quotedPostId ?? null,
+    replyTargetId: options.replyTargetId ?? null,
+    ...options.actingAccountInput,
+    media: options.media.map((item) => ({
+      mediumId: item.uuid! as Uuid,
+      alt: item.alt.trim(),
+    })),
+  };
+}
+
+export function buildUpdateNoteInput(
+  options: BuildUpdateNoteInputOptions,
+): UpdateNoteInput {
+  const quotePolicyApplicable = options.visibility === "PUBLIC" ||
+    options.visibility === "UNLISTED";
+  return {
+    noteId: options.noteId,
+    content: options.content.trim(),
+    language: options.language ?? null,
+    ...(quotePolicyApplicable ? { quotePolicy: options.quotePolicy } : {}),
+    ...(options.actingAccountId == null
+      ? {}
+      : { actingAccountId: options.actingAccountId }),
+  };
+}
+
+export function getNoteInternalHref(note: CreatedNotePathInput): string {
+  const actorSegment = note.actor.local
+    ? `@${note.actor.username}`
+    : encodeHandleSegment(note.actor.handle);
+  return `/${actorSegment}/${note.sourceId ?? note.uuid}`;
+}


### PR DESCRIPTION
Closes #341.


Why
---

Recent composer fixes have had to account for draft synchronization, async media work, poll state, mutation completion, and Relay updates at the same time. Those concerns shared one component and one lifecycle, so changing a single path meant reasoning about every other path that could react to the same state.

Keeping *web-next/src/components/NoteComposer.tsx* small is secondary. The useful change is putting each side effect next to the state it governs, making cross-feature dependencies visible at the orchestration layer, and giving the fragile transitions direct test coverage.


How
---

*web-next/src/components/NoteComposer.tsx* remains the public entry point. Its props and caller-facing behavior stay unchanged, while it now coordinates a set of modules under *web-next/src/components/note-composer/*. This keeps the refactor local to the composer instead of forcing an unrelated call-site migration.

The extraction follows one rule. Pure functions describe serializable state and transitions, controllers own browser or Relay side effects, and the presentational components receive narrow controller interfaces. This lets the tests exercise decisions without mounting the entire composer, while the top-level component still owns the interactions between content, language, reply and quote previews, acting accounts, and article switching.

The draft controller keeps storage scope changes, cross-composer synchronization, and delayed writes together. In particular, it preserves a dirty form when a stale composer publishes the same draft scope, then writes the active state back without starting a notification loop. Media state uses the same separation for upload progress, preview URL cleanup, draft-media verification, and generated alt text cancellation, so late async results can only update media that still exists.

Poll validation and submission input building are pure modules. The submission controller owns the four mutation paths and delegates Relay bookkeeping to a small updater that checks for a successful payload before appending a reply or incrementing its count. The media and poll editors were split out only where a narrow interface was already available, which avoids moving shared composer state into a second UI layer.

The split was driven by focused tests around the state transitions most likely to regress: draft scope changes, transient media state, poll restoration and validation, submission normalization, and Relay updates for successful and error payloads.


Verification
------------

 -  21 focused state tests pass.
 -  `mise run check` passes.
 -  `mise run test` passes.
 -  `mise run build:web-next` passes.
 -  Signed-in browser checks cover note, reply, quote, poll, media, draft restoration, edit, and article-switch flows.
