### PR TITLE
Scroll wide article tables horizontally

### DIFF
--- a/web-next/src/app.css
+++ b/web-next/src/app.css
@@ -547,6 +547,11 @@
   background-color: transparent !important;
 }
 
+.prose table {
+  display: block;
+  overflow-x: auto;
+}
+
 @media (prefers-color-scheme: dark) {
   .prose pre.shiki,
   .prose pre.shiki span {

--- a/web-next/src/routes/(root)/[handle]/[idOrYear]/[slug]/index.tsx
+++ b/web-next/src/routes/(root)/[handle]/[idOrYear]/[slug]/index.tsx
@@ -1055,8 +1055,8 @@ function ArticleAside(props: ArticleAsideProps) {
   const { t } = useLingui();
 
   return (
-    <aside class="hidden 2xl:block 2xl:w-56 2xl:flex-shrink-0">
-      <div class="2xl:sticky 2xl:top-4">
+    <aside class="hidden 2xl:block 2xl:w-56 2xl:shrink-0">
+      <div class="2xl:sticky 2xl:top-4 max-h-[calc(100svh-2rem)] 2xl:overflow-y-auto">
         <Show when={!props.hidden && props.toc.length > 0}>
           <div>
             <p class="font-bold text-sm leading-7 uppercase text-stone-500 dark:text-stone-400">


### PR DESCRIPTION
Make tables in article bodies scroll within the content column instead
of overlapping the sidebar.

Fixes https://github.com/hackers-pub/hackerspub/issues/363

Assisted-by: Claude Code:claude-fable-5