### PR TITLE
Do not measure detached rows in VirtualizedPostList

### DIFF
--- a/web-next/src/components/VirtualizedPostList.tsx
+++ b/web-next/src/components/VirtualizedPostList.tsx
@@ -1,6 +1,7 @@
 import {
   createWindowVirtualizer,
   defaultRangeExtractor,
+  measureElement as defaultMeasureElement,
   type Range,
 } from "@tanstack/solid-virtual";
 import {
@@ -56,6 +57,18 @@ export function VirtualizedPostList<T>(props: VirtualizedPostListProps<T>) {
       return props.items.length;
     },
     estimateSize: () => ESTIMATED_POST_HEIGHT,
+    // Row refs run before Solid inserts the element, so the synchronous
+    // measurement from the ref sees a detached node and would read 0. A 0px
+    // size is written to the virtualizer immediately, which re-runs the range
+    // calculation while <For> is still iterating the virtual items store and
+    // crashes. Keep the cached/estimated size instead; the ResizeObserver
+    // measures the real height once the row is in the document.
+    measureElement: (element, entry, instance) =>
+      element.isConnected
+        ? defaultMeasureElement(element, entry, instance)
+        : (instance.itemSizeCache.get(
+            getItemKey(instance.indexFromElement(element)),
+          ) ?? ESTIMATED_POST_HEIGHT),
     getItemKey,
     overscan: POST_OVERSCAN,
     get scrollMargin() {
@@ -96,7 +109,7 @@ export function VirtualizedPostList<T>(props: VirtualizedPostListProps<T>) {
     setScrollMargin(listElement.getBoundingClientRect().top + window.scrollY);
   };
 
-  onMount(() => {
+  const activate = () => {
     updateScrollMargin();
     const previousScrollAdjustment =
       virtualizer.shouldAdjustScrollPositionOnItemSizeChange;
@@ -111,6 +124,23 @@ export function VirtualizedPostList<T>(props: VirtualizedPostListProps<T>) {
     }
     initialElements.clear();
     setActive(true);
+  };
+
+  onMount(() => {
+    // On client-side navigation the list mounts while the route is still
+    // inside a pending router transition, so nothing here is in the document
+    // yet and every layout read (scroll margin, initial row heights) would be
+    // 0. Wait for the element to be connected before seeding the virtualizer.
+    let activationFrame: number | undefined;
+    const activateWhenConnected = () => {
+      if (listElement?.isConnected) {
+        activationFrame = undefined;
+        activate();
+        return;
+      }
+      activationFrame = window.requestAnimationFrame(activateWhenConnected);
+    };
+    activateWhenConnected();
 
     let frame: number | undefined;
     const scheduleScrollMarginUpdate = () => {
@@ -137,6 +167,9 @@ export function VirtualizedPostList<T>(props: VirtualizedPostListProps<T>) {
       resizeObserver?.disconnect();
       window.removeEventListener("resize", scheduleScrollMarginUpdate);
       if (frame != null) window.cancelAnimationFrame(frame);
+      if (activationFrame != null) {
+        window.cancelAnimationFrame(activationFrame);
+      }
     });
   });
 


### PR DESCRIPTION
Fixes the "Something went wrong — Cannot read properties of undefined (reading 'index')" screen that appears when navigating between timeline and profile pages in web-next.

## Symptom

Client-side navigation (e.g. `/local` → `/fediverse`, or into a profile) sometimes replaces the page with `AppErrorFallback` showing `Cannot read properties of undefined (reading 'index')`; reloading fixes it. The boundary swallows the stack, so the message was the only clue. With the stack captured it points at `VirtualizedPostList.tsx`: `props.items[virtualItem.index]` inside `<For each={virtualizer.getVirtualItems()}>`, with `virtualItem === undefined`. Reproduced in Chrome (anonymous session, dev server against the production API): the first navigation crashed 5 out of 5 times before the fix.

## Background

`VirtualizedPostList` first renders a few rows plainly, reads their real heights in `onMount` (`virtualizer.resizeItem(index, element.offsetHeight)`), then flips `active` and switches to the virtualized `<For>`. Each virtualized row's `ref` calls `virtualizer.measureElement(el)` synchronously; when the measured size differs from the estimate, virtual-core calls `resizeItem` → `notify()` → the adapter's `onChange`. `@tanstack/solid-virtual` keeps the virtual items in a Solid store and, in `onChange`, runs `setVirtualItems(reconcile(instance.getVirtualItems(), { key: "index" }))` **synchronously**. So a size change reported during rendering rewrites the very array `<For>` is iterating.

## Root cause

Solid Router navigates inside a transition. While the transition is pending (route data still loading), the new route's tree is rendered off-document and the old page stays visible. `onMount` and the row refs of the new `VirtualizedPostList` run in that window: `listElement.isConnected === false` and `location.pathname` is still the previous route (verified with instrumentation).

A detached element has no layout, so every `offsetHeight` read is `0`:

1. `onMount` seeds the initial rows as 0px (and `updateScrollMargin()` reads 0).
2. `setActive(true)` → `<For>` creates rows → each `ref` measures 0 → `resizeItem(…, 0)` → `notify` → the store is reconciled *mid-iteration*.
3. With several 0px items all at `start: 0`, virtual-core's binary search lands on an arbitrary zero-size item, so the range start jumps (observed: `0..9 → 0..10 → 2..11 → … → 9..18`). The store shrinks and shifts while `mapArray` still uses the length it read at the top of the loop; `newItems[j]` is `undefined` and `virtualItem.index` throws.

It never happens on the first load because the list is connected in `onMount`: real heights get cached, the default `measureElement` returns the cached size for a detached ref, and the range only grows (appends), never shifts. It is intermittent because it depends on whether the route data resolves before or after the transition commits; with real API latency the list usually mounts during the pending transition.

## Fix

- `onMount` now waits until `listElement.isConnected` (rAF loop, cancelled on cleanup) before running the activation sequence (`updateScrollMargin`, seeding initial row heights, `setActive(true)`), so those reads see real layout on navigation instead of zeros.
- The `measureElement` option returns the cached size (or the estimate) when the element is not connected and otherwise delegates to TanStack's default `measureElement`. A detached row therefore never reports a size change, so `onChange` is never fired in the middle of `<For>`; the ResizeObserver measures the real height once the row is inserted.

`useCachedMeasurements` (the library's built-in "don't measure while hidden" toggle) was considered and not used: it has to be switched back off before the ResizeObserver's first delivery for the newly connected rows, and that ordering is not guaranteed relative to Solid's insertion. A per-call `isConnected` check has no such window.

## Verification

12 consecutive client-side navigations (local ↔ fediverse ↔ profiles ↔ news) with no errors; virtualization activates on every page; scrolling measures further rows with real heights. `mise run check` (oxfmt, oxlint, tsc) and `virtualList.test.ts` pass.

## Not in scope

On every cold load a Hydration Mismatch in `ReplyControl` (`PostEngagementBar.tsx`) trips the error boundary, after which `entry-client.tsx`'s 1.5 s fallback re-renders the whole app client-side. Pre-existing and unrelated to the navigation crash above.

## References

- `Node.isConnected`, the predicate both guards use
  - [MDN: `Node.isConnected`](https://developer.mozilla.org/en-US/docs/Web/API/Node/isConnected) / [DOM Standard](https://dom.spec.whatwg.org/#dom-node-isconnected): `true` only while the node is attached to a `Document`; O(1), shadow-DOM aware.
  - [MDN: `HTMLElement.offsetHeight`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetHeight): `0` for an element that is not rendered, which is why detached rows measured 0px.
  - [MDN: `ResizeObserver`](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver): measures the real height once the row is inserted.
- TanStack Virtual (`@tanstack/solid-virtual` 3.13.37 / `@tanstack/virtual-core` 3.17.8)
  - [Virtualizer API](https://tanstack.com/virtual/latest/docs/api/virtualizer): `measureElement` option and method, `resizeItem`, `useCachedMeasurements`. [Solid adapter](https://tanstack.com/virtual/latest/docs/framework/solid/solid-virtual).
  - [Default `measureElement`](https://github.com/TanStack/virtual/blob/%40tanstack/virtual-core%403.17.8/packages/virtual-core/src/index.ts#L244-L275): uses the size cache only when there is no entry, otherwise reads `offsetHeight`.
  - [`Virtualizer.measureElement`](https://github.com/TanStack/virtual/blob/%40tanstack/virtual-core%403.17.8/packages/virtual-core/src/index.ts#L1518) / [`resizeItem`](https://github.com/TanStack/virtual/blob/%40tanstack/virtual-core%403.17.8/packages/virtual-core/src/index.ts#L1554): a changed size calls `notify()` synchronously.
  - [`solid-virtual` `onChange`](https://github.com/TanStack/virtual/blob/%40tanstack/solid-virtual%403.13.37/packages/solid-virtual/src/index.tsx#L66-L86): `setVirtualItems(reconcile(...))`, the store write that mutates the array `<For>` is iterating.
- Solid
  - [`onMount`](https://docs.solidjs.com/reference/lifecycle/on-mount): runs after initial render, not necessarily after the subtree is in the document.
  - [`useTransition`](https://docs.solidjs.com/reference/reactive-utilities/use-transition), [`<Suspense>`](https://docs.solidjs.com/reference/components/suspense), Solid Router [`useIsRouting`](https://docs.solidjs.com/solid-router/reference/primitives/use-is-routing): while a transition is pending the new branch renders off-document and the previous UI stays on screen.
  - [`<For>`](https://docs.solidjs.com/reference/components/for), [`reconcile`](https://docs.solidjs.com/reference/store-utilities/reconcile): why a mid-iteration store reconcile surfaces as an `undefined` item.
- In this repo
  - `web-next/src/components/VirtualizedPostList.tsx`: the changed component.
  - `web-next/src/lib/virtualList.ts` (`measureVirtualListItem`): the ref helper that reaches the new `measureElement` option with a detached element (unchanged).
  - `web-next/src/app.tsx` (`AppErrorFallback`): the boundary that showed the message without a stack.


---

Assisted-by: Claude Code:claude-fable-5
