### PR TITLE
Enable Tailwind IntelliSense inside cva and cn calls

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,6 +10,7 @@
   "oxc.enable": true,
   "oxc.fmt.enable": true,
   "relay.rootDirectory": "web-next",
+  "tailwindCSS.classFunctions": ["cva", "cx", "cn"],
   "[javascript]": {
     "editor.defaultFormatter": "oxc.oxc-vscode",
     "editor.formatOnSave": true

--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -4,6 +4,11 @@
       "settings": {
         "rootDirectory": "./web-next"
       }
+    },
+    "tailwindcss-language-server": {
+      "settings": {
+        "classFunctions": ["cva", "cx", "cn"]
+      }
     }
   }
 }


### PR DESCRIPTION
Register `cva`, `cx`, and `cn` as Tailwind class functions in the VS Code
and Zed workspace settings so Tailwind CSS IntelliSense works inside those calls.
<img width="991" height="424" alt="image" src="https://github.com/user-attachments/assets/832f6112-432f-4ce5-8304-1dabcac23e2a" />

Assisted-by: Claude Code:claude-fable-5
