### PR TITLE
Highlight the current page in the sidebar

### DIFF
--- a/web-next/src/components/AppSidebar.tsx
+++ b/web-next/src/components/AppSidebar.tsx
@@ -1091,6 +1091,7 @@ function RecentDraftsSection(props: RecentDraftsSectionProps) {
   const { t } = useLingui();
   const activePath = useActivePath();
   const draftsHref = () => `/@${props.signedAccount!.username}/drafts`;
+  const draftHref = (uuid: string) => `${draftsHref()}/${uuid}`;
   const visibleDrafts = () =>
     props.signedAccount?.articleDrafts?.edges
       .filter((edge) => edge.node != null)
@@ -1120,8 +1121,8 @@ function RecentDraftsSection(props: RecentDraftsSectionProps) {
               <SidebarMenuItem class="list-none">
                 <SidebarMenuButton
                   as={A}
-                  href={`${draftsHref()}/${edge.node.uuid}`}
-                  active={activePath(`${draftsHref()}/${edge.node.uuid}`)}
+                  href={draftHref(edge.node.uuid)}
+                  active={activePath(draftHref(edge.node.uuid))}
                 >
                   <span>{edge.node.title}</span>
                 </SidebarMenuButton>
@@ -1133,7 +1134,12 @@ function RecentDraftsSection(props: RecentDraftsSectionProps) {
               <SidebarMenuButton
                 as={A}
                 href={draftsHref()}
-                active={activePath(draftsHref(), { exact: true })}
+                active={activePath(draftsHref(), {
+                  except: [
+                    draftHref("new"),
+                    ...visibleDrafts().map((edge) => draftHref(edge.node.uuid)),
+                  ],
+                })}
                 class="text-muted-foreground"
               >
                 {t`View all drafts →`}

--- a/web-next/src/components/AppSidebar.tsx
+++ b/web-next/src/components/AppSidebar.tsx
@@ -852,6 +852,7 @@ function AccountSection(props: AccountSectionProps) {
                   href={`/@${profileAccount()?.username ?? signedAccount.username}`}
                   active={activePath(
                     `/@${profileAccount()?.username ?? signedAccount.username}`,
+                    true,
                   )}
                 >
                   <AccountAvatar

--- a/web-next/src/components/AppSidebar.tsx
+++ b/web-next/src/components/AppSidebar.tsx
@@ -59,6 +59,7 @@ import {
   invalidateTimelinePageQueryCache,
   TIMELINE_PAGE_QUERY_CACHE_KEYS,
 } from "~/lib/timelinePageQueryCache.ts";
+import { useActivePath } from "~/lib/useActivePath.ts";
 import { Trans } from "./Trans.tsx";
 import type { AppSidebarSignOutMutation } from "./__generated__/AppSidebarSignOutMutation.graphql.ts";
 import type {
@@ -89,6 +90,7 @@ export function AppSidebar(props: AppSidebarProps) {
   const { t } = useLingui();
   const { open: openNoteCompose } = useNoteCompose();
   const { isMobile: mobile, state } = useSidebar();
+  const activePath = useActivePath();
   const signedAccount = createFragment(
     graphql`
       fragment AppSidebar_signedAccount on Account
@@ -223,6 +225,7 @@ export function AppSidebar(props: AppSidebarProps) {
               <SidebarMenuButton
                 as={A}
                 href="/news"
+                active={activePath("/news")}
                 onClick={() =>
                   invalidateTimelinePageQueryCache(
                     TIMELINE_PAGE_QUERY_CACHE_KEYS.news,
@@ -251,6 +254,7 @@ export function AppSidebar(props: AppSidebarProps) {
                 <SidebarMenuButton
                   as={A}
                   href="/feed"
+                  active={activePath("/feed", true)}
                   onClick={() =>
                     invalidateTimelinePageQueryCache(
                       TIMELINE_PAGE_QUERY_CACHE_KEYS.feed,
@@ -278,6 +282,7 @@ export function AppSidebar(props: AppSidebarProps) {
                 <SidebarMenuButton
                   as={A}
                   href="/feed/without-shares"
+                  active={activePath("/feed/without-shares")}
                   onClick={() =>
                     invalidateTimelinePageQueryCache(
                       TIMELINE_PAGE_QUERY_CACHE_KEYS.feedWithoutShares,
@@ -320,6 +325,7 @@ export function AppSidebar(props: AppSidebarProps) {
                 <SidebarMenuButton
                   as={A}
                   href="/feed/articles"
+                  active={activePath("/feed/articles")}
                   onClick={() =>
                     invalidateTimelinePageQueryCache(
                       TIMELINE_PAGE_QUERY_CACHE_KEYS.feedArticles,
@@ -348,6 +354,7 @@ export function AppSidebar(props: AppSidebarProps) {
               <SidebarMenuButton
                 as={A}
                 href="/local"
+                active={activePath("/local")}
                 onClick={() =>
                   invalidateTimelinePageQueryCache(
                     TIMELINE_PAGE_QUERY_CACHE_KEYS.local,
@@ -366,6 +373,7 @@ export function AppSidebar(props: AppSidebarProps) {
               <SidebarMenuButton
                 as={A}
                 href="/fediverse"
+                active={activePath("/fediverse")}
                 onClick={() =>
                   invalidateTimelinePageQueryCache(
                     TIMELINE_PAGE_QUERY_CACHE_KEYS.fediverse,
@@ -398,7 +406,11 @@ export function AppSidebar(props: AppSidebarProps) {
               </SidebarMenuButton>
             </SidebarMenuItem>
             <SidebarMenuItem class="list-none">
-              <SidebarMenuButton as={A} href="/search">
+              <SidebarMenuButton
+                as={A}
+                href="/search"
+                active={activePath("/search")}
+              >
                 <svg
                   xmlns="http://www.w3.org/2000/svg"
                   fill="none"
@@ -423,6 +435,7 @@ export function AppSidebar(props: AppSidebarProps) {
                     <SidebarMenuButton
                       as={A}
                       href={`/tags/${encodeURIComponent(tag)}`}
+                      active={activePath(`/tags/${encodeURIComponent(tag)}`)}
                     >
                       <svg
                         xmlns="http://www.w3.org/2000/svg"
@@ -792,6 +805,7 @@ function AccountSection(props: AccountSectionProps) {
     actingAccount.selectedOrganization()?.role === "ADMIN"
       ? actingAccount.selectedOrganization()?.organization
       : (actingAccount.personalAccount() ?? props.signedAccount);
+  const activePath = useActivePath();
 
   return (
     <SidebarGroup>
@@ -808,6 +822,7 @@ function AccountSection(props: AccountSectionProps) {
                 href={`/sign?next=${encodeURIComponent(
                   location.pathname + location.search + location.hash,
                 )}`}
+                active={activePath("/sign")}
               >
                 <svg
                   xmlns="http://www.w3.org/2000/svg"
@@ -834,9 +849,10 @@ function AccountSection(props: AccountSectionProps) {
               <SidebarMenuItem class="list-none">
                 <SidebarMenuButton
                   as={A}
-                  href={`/@${
-                    profileAccount()?.username ?? signedAccount.username
-                  }`}
+                  href={`/@${profileAccount()?.username ?? signedAccount.username}`}
+                  active={activePath(
+                    `/@${profileAccount()?.username ?? signedAccount.username}`,
+                  )}
                 >
                   <AccountAvatar
                     account={profileAccount() ?? signedAccount}
@@ -852,6 +868,7 @@ function AccountSection(props: AccountSectionProps) {
                   <SidebarMenuButton
                     as={A}
                     href={`/@${signedAccount.username}/bookmarks`}
+                    active={activePath(`/@${signedAccount.username}/bookmarks`)}
                   >
                     <svg
                       xmlns="http://www.w3.org/2000/svg"
@@ -880,6 +897,9 @@ function AccountSection(props: AccountSectionProps) {
                   <SidebarMenuButton
                     as={A}
                     href={`/@${signedAccount.username}/settings/invite`}
+                    active={activePath(
+                      `/@${signedAccount.username}/settings/invite`,
+                    )}
                   >
                     <svg
                       xmlns="http://www.w3.org/2000/svg"
@@ -905,9 +925,10 @@ function AccountSection(props: AccountSectionProps) {
               <SidebarMenuItem class="list-none">
                 <SidebarMenuButton
                   as={A}
-                  href={`/@${
-                    settingsAccount()?.username ?? signedAccount.username
-                  }/settings`}
+                  href={`/@${settingsAccount()?.username ?? signedAccount.username}/settings`}
+                  active={activePath(
+                    `/@${settingsAccount()?.username ?? signedAccount.username}/settings`,
+                  )}
                 >
                   <svg
                     xmlns="http://www.w3.org/2000/svg"
@@ -933,7 +954,11 @@ function AccountSection(props: AccountSectionProps) {
               </SidebarMenuItem>
               <Show when={!organizationSelected() && signedAccount.moderator}>
                 <SidebarMenuItem class="list-none">
-                  <SidebarMenuButton as={A} href="/admin">
+                  <SidebarMenuButton
+                    as={A}
+                    href="/admin"
+                    active={activePath("/admin")}
+                  >
                     <IconShieldCheck class="size-6" />
                     {t`Admin`}
                   </SidebarMenuButton>
@@ -989,6 +1014,7 @@ interface ComposeSectionProps {
 
 function ComposeSection(props: ComposeSectionProps) {
   const { t } = useLingui();
+  const activePath = useActivePath();
 
   return (
     <Show keyed when={props.visible && props.signedAccount}>
@@ -1022,6 +1048,7 @@ function ComposeSection(props: ComposeSectionProps) {
               <SidebarMenuButton
                 as={A}
                 href={`/@${signedAccount.username}/drafts/new`}
+                active={activePath(`/@${signedAccount.username}/drafts/new`)}
                 class="cursor-pointer"
               >
                 <svg
@@ -1055,6 +1082,8 @@ interface RecentDraftsSectionProps {
 
 function RecentDraftsSection(props: RecentDraftsSectionProps) {
   const { t } = useLingui();
+  const activePath = useActivePath();
+  const draftsHref = () => `/@${props.signedAccount!.username}/drafts`;
   const visibleDrafts = () =>
     props.signedAccount?.articleDrafts?.edges
       .filter((edge) => edge.node != null)
@@ -1084,9 +1113,8 @@ function RecentDraftsSection(props: RecentDraftsSectionProps) {
               <SidebarMenuItem class="list-none">
                 <SidebarMenuButton
                   as={A}
-                  href={`/@${
-                    props.signedAccount!.username
-                  }/drafts/${edge.node.uuid}`}
+                  href={`${draftsHref()}/${edge.node.uuid}`}
+                  active={activePath(`${draftsHref()}/${edge.node.uuid}`)}
                 >
                   <span>{edge.node.title}</span>
                 </SidebarMenuButton>
@@ -1097,7 +1125,8 @@ function RecentDraftsSection(props: RecentDraftsSectionProps) {
             <SidebarMenuItem class="list-none">
               <SidebarMenuButton
                 as={A}
-                href={`/@${props.signedAccount!.username}/drafts`}
+                href={draftsHref()}
+                active={activePath(draftsHref(), true)}
                 class="text-muted-foreground"
               >
                 {t`View all drafts →`}

--- a/web-next/src/components/AppSidebar.tsx
+++ b/web-next/src/components/AppSidebar.tsx
@@ -254,7 +254,7 @@ export function AppSidebar(props: AppSidebarProps) {
                 <SidebarMenuButton
                   as={A}
                   href="/feed"
-                  active={activePath("/feed", true)}
+                  active={activePath("/feed", { exact: true })}
                   onClick={() =>
                     invalidateTimelinePageQueryCache(
                       TIMELINE_PAGE_QUERY_CACHE_KEYS.feed,
@@ -806,6 +806,8 @@ function AccountSection(props: AccountSectionProps) {
       ? actingAccount.selectedOrganization()?.organization
       : (actingAccount.personalAccount() ?? props.signedAccount);
   const activePath = useActivePath();
+  const inviteVisible = () =>
+    !organizationSelected() && (props.signedAccount?.invitationsLeft ?? 0) > 0;
 
   return (
     <SidebarGroup>
@@ -852,7 +854,7 @@ function AccountSection(props: AccountSectionProps) {
                   href={`/@${profileAccount()?.username ?? signedAccount.username}`}
                   active={activePath(
                     `/@${profileAccount()?.username ?? signedAccount.username}`,
-                    true,
+                    { exact: true },
                   )}
                 >
                   <AccountAvatar
@@ -889,11 +891,7 @@ function AccountSection(props: AccountSectionProps) {
                   </SidebarMenuButton>
                 </SidebarMenuItem>
               </Show>
-              <Show
-                when={
-                  !organizationSelected() && signedAccount.invitationsLeft > 0
-                }
-              >
+              <Show when={inviteVisible()}>
                 <SidebarMenuItem class="list-none">
                   <SidebarMenuButton
                     as={A}
@@ -929,6 +927,14 @@ function AccountSection(props: AccountSectionProps) {
                   href={`/@${settingsAccount()?.username ?? signedAccount.username}/settings`}
                   active={activePath(
                     `/@${settingsAccount()?.username ?? signedAccount.username}/settings`,
+                    {
+                      // Invite has an entry of its own whenever it is shown;
+                      // with no invitations left the page is still reachable,
+                      // and then Settings covers it.
+                      except: inviteVisible()
+                        ? [`/@${signedAccount.username}/settings/invite`]
+                        : [],
+                    },
                   )}
                 >
                   <svg
@@ -1127,7 +1133,7 @@ function RecentDraftsSection(props: RecentDraftsSectionProps) {
               <SidebarMenuButton
                 as={A}
                 href={draftsHref()}
-                active={activePath(draftsHref(), true)}
+                active={activePath(draftsHref(), { exact: true })}
                 class="text-muted-foreground"
               >
                 {t`View all drafts →`}

--- a/web-next/src/lib/useActivePath.ts
+++ b/web-next/src/lib/useActivePath.ts
@@ -1,0 +1,27 @@
+import { useLocation } from "@solidjs/router";
+
+export function pathMatches(
+  pathname: string,
+  href: string,
+  exact = false,
+): boolean {
+  const path =
+    pathname.length > 1 && pathname.endsWith("/")
+      ? pathname.slice(0, -1)
+      : pathname;
+  return path === href || (!exact && path.startsWith(`${href}/`));
+}
+
+/**
+ * Reactive form of `pathMatches` bound to the router location. Returns a
+ * predicate for marking navigation links as active:
+ *
+ * ```tsx
+ * const activePath = useActivePath();
+ * <A href="/feed" active={activePath("/feed", true)} />
+ * ```
+ */
+export function useActivePath(): (href: string, exact?: boolean) => boolean {
+  const location = useLocation();
+  return (href, exact = false) => pathMatches(location.pathname, href, exact);
+}

--- a/web-next/src/lib/useActivePath.ts
+++ b/web-next/src/lib/useActivePath.ts
@@ -1,15 +1,30 @@
 import { useLocation } from "@solidjs/router";
 
+export interface ActivePathOptions {
+  /**
+   * Match `href` alone, not the paths below it. For a section whose sub-pages
+   * all have navigation entries of their own.
+   */
+  readonly exact?: boolean;
+  /**
+   * Sub-paths that have an entry of their own. `href` stays inactive on them
+   * and below them, so only the more specific entry lights up. For a section
+   * where just some sub-pages are listed separately; `exact` covers the rest.
+   */
+  readonly except?: readonly string[];
+}
+
 export function pathMatches(
   pathname: string,
   href: string,
-  exact = false,
+  options: ActivePathOptions = {},
 ): boolean {
   const path =
     pathname.length > 1 && pathname.endsWith("/")
       ? pathname.slice(0, -1)
       : pathname;
-  return path === href || (!exact && path.startsWith(`${href}/`));
+  if (options.except?.some((sub) => pathMatches(path, sub))) return false;
+  return path === href || (!options.exact && path.startsWith(`${href}/`));
 }
 
 /**
@@ -18,10 +33,13 @@ export function pathMatches(
  *
  * ```tsx
  * const activePath = useActivePath();
- * <A href="/feed" active={activePath("/feed", true)} />
+ * <A href="/feed" active={activePath("/feed", { exact: true })} />
  * ```
  */
-export function useActivePath(): (href: string, exact?: boolean) => boolean {
+export function useActivePath(): (
+  href: string,
+  options?: ActivePathOptions,
+) => boolean {
   const location = useLocation();
-  return (href, exact = false) => pathMatches(location.pathname, href, exact);
+  return (href, options) => pathMatches(location.pathname, href, options);
 }


### PR DESCRIPTION
Fixes https://github.com/hackers-pub/hackerspub/issues/373

<img width="1185" height="442" alt="image" src="https://github.com/user-attachments/assets/a60e9a29-147c-42e4-8de2-dabb9e6c7168" />

Mark the sidebar entry for the current route as active so readers can
tell where they are. Entries match by path prefix (`/news/123` keeps
News lit); `/feed` and `/@user/drafts` match exactly because their
sub-pages have entries of their own. The matching rule lives in
`web-next/src/lib/useActivePath.ts` so other navigation can reuse it.

Claude Code (claude-fable-5) wrote the code and this description under
my direction; I reviewed every change, chose the matching rules, and
tested them manually.

Assisted-by: Claude Code:claude-fable-5
