### PR TITLE
Skip collapsing marginally long notes

### DIFF
--- a/web-next/src/components/ExpandableHtmlContent.stories.tsx
+++ b/web-next/src/components/ExpandableHtmlContent.stories.tsx
@@ -39,6 +39,18 @@ const longHtml = `
   blocks, and lists.</p>
 `;
 
+const marginalOverflowHtml = `
+  <p>Hackers' Pub을 사용하면서 불편한 점이나 버그, 기능 추가 제안 등을
+  제보하실 때는 개인적으로 연락하는 것도 괜찮지만, 공식 이슈 트래커에
+  이슈를 만들어 주시는 쪽이 좋습니다. 이슈는 영어가 아니어도 됩니다.</p>
+  <ul>
+    <li>서비스 전반, 서버, 웹 앱</li>
+    <li>Android 앱</li>
+    <li>iOS/iPadOS 앱</li>
+  </ul>
+  <p>감사합니다.</p>
+`;
+
 export const ShortContent: Story = {
   name: "Short content (no toggle)",
   args: {
@@ -50,5 +62,13 @@ export const LongContent: Story = {
   name: "Long content (collapsed)",
   args: {
     html: longHtml,
+  },
+};
+
+export const MarginalOverflow: Story = {
+  name: "Marginal overflow (no toggle)",
+  args: {
+    html: marginalOverflowHtml,
+    lang: "ko",
   },
 };

--- a/web-next/src/components/ExpandableHtmlContent.tsx
+++ b/web-next/src/components/ExpandableHtmlContent.tsx
@@ -43,8 +43,10 @@ export function ExpandableHtmlContent(props: ExpandableHtmlContentProps) {
 
   createEffect(() => {
     const initialElement = contentEl();
-    // Re-measure whenever the HTML changes, e.g. the note gets edited.
+    // Re-measure whenever the HTML or language changes, e.g. the note gets
+    // edited or language-specific line breaking changes.
     void props.html;
+    void props.lang;
     if (!initialElement) return;
     const measure = () => {
       const computedStyle = getComputedStyle(initialElement);

--- a/web-next/src/components/ExpandableHtmlContent.tsx
+++ b/web-next/src/components/ExpandableHtmlContent.tsx
@@ -4,13 +4,14 @@ import {
   createUniqueId,
   onCleanup,
   Show,
-  untrack,
 } from "solid-js";
 import { HtmlContent } from "~/components/HtmlContent.tsx";
 import { useLingui } from "~/lib/i18n/macro.ts";
 
 // ~9 lines of plain text (x.com's "Show more" threshold).
 const DEFAULT_MAX_LINES = 9;
+// Expanding should reveal enough content to justify the extra control.
+const DEFAULT_MIN_HIDDEN_LINES = 4;
 
 export interface ExpandableHtmlContentProps {
   html: string;
@@ -19,40 +20,42 @@ export interface ExpandableHtmlContentProps {
   class?: string;
   /** Forwards the rendered content element, e.g. for link/mention handling. */
   contentRef?: (el: HTMLElement) => void;
-  /** Collapsed height, in lines, before a "Show more" toggle appears. */
+  /** Height retained when content is collapsed. */
   maxLines?: number;
 }
 
 /**
- * Renders trusted post HTML, collapsing it behind a "Show more" toggle once
- * its rendered height exceeds `maxLines`. The collapse height is applied
- * unconditionally via the CSS `lh` unit (so it always matches this
- * element's actual line height, however that's set, with no pixel value to
- * keep in sync by hand) so there is no flash of full-height content before
- * measurement; a `ResizeObserver` only decides whether the toggle itself
- * (and the fade) should be shown, by comparing the element's rendered
- * height against its full content height.
+ * Renders trusted post HTML, collapsing it behind a "Show more" toggle only
+ * when the hidden portion is large enough to make expanding worthwhile. The
+ * collapse height is applied before measurement via the CSS `lh` unit so long
+ * content does not flash at full height. After measurement, marginal overflow
+ * is unclamped and shown without a toggle.
  */
 export function ExpandableHtmlContent(props: ExpandableHtmlContentProps) {
   const { t } = useLingui();
   const contentId = createUniqueId();
   const [contentEl, setContentEl] = createSignal<HTMLElement>();
   const [expanded, setExpanded] = createSignal(false);
-  const [overflowing, setOverflowing] = createSignal(false);
+  const [collapsible, setCollapsible] = createSignal<boolean>();
   const maxLines = () => props.maxLines ?? DEFAULT_MAX_LINES;
+  // Keep the initial server/client render clamped until it can be measured.
+  const collapsed = () => collapsible() !== false && !expanded();
 
   createEffect(() => {
     const initialElement = contentEl();
     // Re-measure whenever the HTML changes, e.g. the note gets edited.
     void props.html;
     if (!initialElement) return;
-    // Only measure while collapsed: expanding removes the `max-height`
-    // clamp, so `clientHeight` grows to match `scrollHeight` and this
-    // would otherwise (wrongly) report no overflow, hiding the "Show
-    // less" toggle right after the user opens it.
     const measure = () => {
-      if (untrack(expanded)) return;
-      setOverflowing(initialElement.scrollHeight > initialElement.clientHeight);
+      const computedStyle = getComputedStyle(initialElement);
+      const computedLineHeight = Number.parseFloat(computedStyle.lineHeight);
+      const computedFontSize = Number.parseFloat(computedStyle.fontSize);
+      const lineHeight = Number.isFinite(computedLineHeight)
+        ? computedLineHeight
+        : computedFontSize * 1.2;
+      const collapseThreshold =
+        (maxLines() + DEFAULT_MIN_HIDDEN_LINES) * lineHeight;
+      setCollapsible(initialElement.scrollHeight > collapseThreshold);
     };
     measure();
     const observer = new ResizeObserver(measure);
@@ -72,17 +75,17 @@ export function ExpandableHtmlContent(props: ExpandableHtmlContentProps) {
           html={props.html}
           lang={props.lang}
           class={props.class}
-          classList={{ "overflow-hidden": !expanded() }}
-          style={expanded() ? undefined : { "max-height": `${maxLines()}lh` }}
+          classList={{ "overflow-hidden": collapsed() }}
+          style={collapsed() ? { "max-height": `${maxLines()}lh` } : undefined}
         />
-        <Show when={overflowing() && !expanded()}>
+        <Show when={collapsible() && !expanded()}>
           <div
             aria-hidden="true"
             class="pointer-events-none absolute inset-x-0 bottom-0 h-14 bg-gradient-to-t from-background to-transparent"
           />
         </Show>
       </div>
-      <Show when={overflowing()}>
+      <Show when={collapsible()}>
         <button
           type="button"
           onClick={() => setExpanded((v) => !v)}

--- a/web-next/src/components/NoteCard.stories.tsx
+++ b/web-next/src/components/NoteCard.stories.tsx
@@ -46,7 +46,11 @@ interface LinkPreviewArgs {
 // A single reusable `Actor` mock: every place the fragment tree reaches an
 // actor (post author, organization member, action-menu ownership check)
 // gets the same values, which keeps the payload below readable.
-function mockResolvers(content: string, link?: LinkPreviewArgs): MockResolvers {
+function mockResolvers(
+  content: string,
+  link?: LinkPreviewArgs,
+  language = "en",
+): MockResolvers {
   return {
     Node: () => ({ __typename: "Note" }),
     PostLink: () => ({
@@ -90,7 +94,7 @@ function mockResolvers(content: string, link?: LinkPreviewArgs): MockResolvers {
       viewerCanRevokeQuote: false,
       censored: false,
       content,
-      language: "en",
+      language,
       personalRawContent: null,
       rawContent: null,
       sensitive: false,
@@ -134,6 +138,7 @@ function mockResolvers(content: string, link?: LinkPreviewArgs): MockResolvers {
 function noteCardKey(
   content: string,
   link?: LinkPreviewArgs,
+  language?: string,
 ): {
   environment: Environment;
   note: NoteCard_note$key;
@@ -150,7 +155,7 @@ function noteCardKey(
   );
   const payload = MockPayloadGenerator.generate(
     operation,
-    mockResolvers(content, link),
+    mockResolvers(content, link, language),
   );
   if (payload.data == null) {
     throw new Error("MockPayloadGenerator produced no data");
@@ -167,12 +172,18 @@ interface NoteCardStoryArgs {
   content: string;
   /** When set, the note also carries a link preview (see `LinkPreview`). */
   link?: LinkPreviewArgs;
+  /** BCP 47 language tag for the mocked note content. */
+  language?: string;
 }
 
 const meta = {
   title: "Components/NoteCard",
   render: (args: NoteCardStoryArgs) => {
-    const { environment, note } = noteCardKey(args.content, args.link);
+    const { environment, note } = noteCardKey(
+      args.content,
+      args.link,
+      args.language,
+    );
     return (
       <RelayEnvironmentProvider environment={environment}>
         <div class="max-w-lg border-x">
@@ -206,9 +217,33 @@ const longHtml = `
   blocks, and lists.</p>
 `;
 
+// Mirrors the reported note's paragraph/list/short-closing structure. It
+// crosses the nine-line display height but does not hide enough content to
+// justify an expand/collapse control.
+const marginalNoteHtml = `
+  <p>Hackers' Pub을 사용하면서 불편한 점이나 버그, 기능 추가 제안 등을
+  제보하실 때는 개인적으로 연락하는 것도 괜찮지만, 공식 이슈 트래커에
+  이슈를 만들어 주시는 쪽이 좋습니다. 이슈는 꼭 영어로 작성할 필요는
+  없으니 한국어로도 편하게 올려주세요.</p>
+  <ul>
+    <li>서비스 전반, 서버, 웹 앱: hackers-pub/hackerspub</li>
+    <li>Android 앱: hackers-pub/android</li>
+    <li>iOS/iPadOS 앱: hackers-pub/ios</li>
+  </ul>
+  <p>감사합니다.</p>
+`;
+
 export const ShortNote: Story = {
   name: "Short note (no toggle)",
   args: { content: shortHtml },
+};
+
+export const MarginalNote: Story = {
+  name: "Marginal note (no toggle)",
+  args: {
+    content: marginalNoteHtml,
+    language: "ko",
+  },
 };
 
 export const LongNote: Story = {


### PR DESCRIPTION
## Summary

`Show more` currently appears for any overflow, even when the collapsed state hides only a short closing line. In those cases, the control adds visual noise without meaningfully shortening the card.

This change keeps marginally overflowing notes fully visible and only collapses content when more than four additional lines would be hidden. It also adds Storybook regression cases for the reported note shape.

Follow-up to https://github.com/hackers-pub/hackerspub/pull/380.

## Screenshots

### Before

<img width="680" height="862" alt="image" src="https://github.com/user-attachments/assets/1e091393-3ab5-497d-866a-f60064f3e15c" />


<img width="704" height="904" alt="image" src="https://github.com/user-attachments/assets/ed7adb86-5fe8-4c69-b5bf-6cc5186734c4" />


### After

<img width="674" height="860" alt="image" src="https://github.com/user-attachments/assets/1981e8a0-5c17-4740-b83f-4b18e38eb02a" />

## AI assistance

Codex (`gpt-5.6-sol`) assisted with implementation, tests, and PR preparation.
