### PR TITLE
Wrap long actor handles in profile views

### DIFF
--- a/web-next/src/components/AccountListBase.stories.tsx
+++ b/web-next/src/components/AccountListBase.stories.tsx
@@ -1,8 +1,5 @@
 import type { Meta, StoryObj } from "storybook-solidjs-vite";
-import {
-  AccountListBase,
-  type AccountListBaseProps,
-} from "./AccountListBase.tsx";
+import { AccountListBase } from "./AccountListBase.tsx";
 import {
   type ActorStoryArgs,
   actorAvatarDataUri,
@@ -12,7 +9,7 @@ import {
   StorySurface,
 } from "./storybook/actorStoryFixtures.tsx";
 
-interface AccountListStoryArgs extends ActorStoryArgs, AccountListBaseProps {}
+interface AccountListStoryArgs extends ActorStoryArgs {}
 
 function renderAccountList(args: AccountListStoryArgs) {
   return (
@@ -45,7 +42,6 @@ function renderAccountList(args: AccountListStoryArgs) {
 
 const meta = {
   title: "Components/AccountListBase",
-  component: AccountListBase,
   args: {
     handle: defaultActorHandle,
     name: defaultActorName,

--- a/web-next/src/components/AccountListBase.stories.tsx
+++ b/web-next/src/components/AccountListBase.stories.tsx
@@ -1,0 +1,68 @@
+import type { Meta, StoryObj } from "storybook-solidjs-vite";
+import {
+  AccountListBase,
+  type AccountListBaseProps,
+} from "./AccountListBase.tsx";
+import {
+  type ActorStoryArgs,
+  actorAvatarDataUri,
+  defaultActorHandle,
+  defaultActorName,
+  longActorHandle,
+  StorySurface,
+} from "./storybook/actorStoryFixtures.tsx";
+
+interface AccountListStoryArgs extends ActorStoryArgs, AccountListBaseProps {}
+
+function renderAccountList(args: AccountListStoryArgs) {
+  return (
+    <StorySurface width={args.width}>
+      <AccountListBase
+        edges={[
+          {
+            node: {
+              id: "story-actor",
+              avatarUrl: actorAvatarDataUri,
+              name: args.name,
+              handle: args.handle,
+              local: false,
+              username: "blog_cloudflare_com_rs_5i8zpek",
+            },
+          },
+        ]}
+        hasNext={false}
+        pending={false}
+        loadingState="loaded"
+        onLoadMore={() => undefined}
+        onAction={() => undefined}
+        actionLabel="Unblock"
+        actionDisabled={false}
+        emptyMessage="No accounts"
+      />
+    </StorySurface>
+  );
+}
+
+const meta = {
+  title: "Components/AccountListBase",
+  component: AccountListBase,
+  args: {
+    handle: defaultActorHandle,
+    name: defaultActorName,
+    width: 360,
+  },
+  argTypes: {
+    width: { control: { min: 240, max: 720, step: 8, type: "range" } },
+  },
+  parameters: { layout: "padded" },
+  render: renderAccountList,
+} satisfies Meta<AccountListStoryArgs>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const LongHandle: Story = {
+  args: { handle: longActorHandle },
+};

--- a/web-next/src/components/AccountListBase.tsx
+++ b/web-next/src/components/AccountListBase.tsx
@@ -4,6 +4,7 @@ import { HtmlContent } from "./HtmlContent.tsx";
 import { Avatar, AvatarImage } from "~/components/ui/avatar.tsx";
 import { Button } from "~/components/ui/button.tsx";
 import { useLingui } from "~/lib/i18n/macro.ts";
+import { ActorHandle } from "./ActorHandle.tsx";
 
 /** The actor fields a row needs; structurally satisfied by the list fragments. */
 export interface AccountListItem {
@@ -78,12 +79,10 @@ export function AccountListBase(props: AccountListBaseProps) {
                       class="truncate font-semibold"
                     />
                   </Show>
-                  <span
-                    class="truncate text-sm text-muted-foreground select-all"
-                    title={edge.node.handle}
-                  >
-                    {edge.node.handle}
-                  </span>
+                  <ActorHandle
+                    handle={edge.node.handle}
+                    class="truncate text-sm text-muted-foreground"
+                  />
                 </div>
                 <Button
                   variant="outline"

--- a/web-next/src/components/ActorHandle.stories.tsx
+++ b/web-next/src/components/ActorHandle.stories.tsx
@@ -1,202 +1,43 @@
-import {
-  createOperationDescriptor,
-  Environment,
-  getRequest,
-  graphql,
-  Network,
-  RecordSource,
-  Store,
-} from "relay-runtime";
-import { MockPayloadGenerator, type MockResolvers } from "relay-test-utils";
-import { RelayEnvironmentProvider } from "solid-relay";
-import type { JSX } from "solid-js";
 import type { Meta, StoryObj } from "storybook-solidjs-vite";
-import { AccountListBase } from "./AccountListBase.tsx";
-import { ActorHandle } from "./ActorHandle.tsx";
-import { ActorPreviewCard } from "./ActorPreviewCard.tsx";
-import type { ActorHandleStoriesActorQuery } from "./__generated__/ActorHandleStoriesActorQuery.graphql.ts";
-import type { ActorHandleStoriesPostQuery } from "./__generated__/ActorHandleStoriesPostQuery.graphql.ts";
-import { LinkCreatorAttribution } from "./LinkCreatorAttribution.tsx";
-import { PostAuthorLine } from "./PostAuthor.tsx";
-import { ProfileCard } from "./ProfileCard.tsx";
-import { SmallProfileCard } from "./SmallProfileCard.tsx";
+import { ActorHandle, type ActorHandleProps } from "./ActorHandle.tsx";
+import {
+  defaultActorHandle,
+  longActorHandle,
+  StorySurface,
+} from "./storybook/actorStoryFixtures.tsx";
 
-const ActorHandleStoriesActorQuery = graphql`
-  query ActorHandleStoriesActorQuery($id: ID!, $actingAccountId: ID) {
-    node(id: $id) {
-      ... on Actor {
-        ...ActorPreviewCard_actor
-          @arguments(actingAccountId: $actingAccountId)
-        ...LinkCreatorAttribution_creator
-        ...ProfileCard_actor @arguments(actingAccountId: $actingAccountId)
-        ...SmallProfileCard_actor
-          @arguments(actingAccountId: $actingAccountId)
-      }
-    }
-  }
-`;
-
-const ActorHandleStoriesPostQuery = graphql`
-  query ActorHandleStoriesPostQuery($id: ID!) {
-    node(id: $id) {
-      ... on Post {
-        ...PostAuthorLine_post
-      }
-    }
-  }
-`;
-
-const longHandle = "@blog_cloudflare_com_rs_5i8zpek@beta.rss2.pub";
-const defaultName = "Cloudflare Blog Feed";
-
-const avatarDataUri =
-  "data:image/svg+xml," +
-  encodeURIComponent(
-    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 80">' +
-      '<rect width="80" height="80" rx="16" fill="#f38020"/>' +
-      '<text x="40" y="50" text-anchor="middle" font-family="sans-serif" ' +
-      'font-size="28" font-weight="700" fill="white">CF</text></svg>',
-  );
-
-interface ActorHandleStoryArgs {
-  handle: string;
-  name: string;
+interface ActorHandleStoryArgs extends ActorHandleProps {
   width: number;
-}
-
-interface StorySurfaceProps {
-  children: JSX.Element;
-  width: number;
-}
-
-function StorySurface(props: StorySurfaceProps) {
-  return (
-    <div
-      class="border bg-background"
-      style={{ width: `${props.width}px`, "max-width": "100%" }}
-    >
-      {props.children}
-    </div>
-  );
-}
-
-function actorResolvers(
-  handle: string,
-  name: string,
-  nodeType: "Actor" | "Note",
-): MockResolvers {
-  return {
-    Node: () => ({ __typename: nodeType }),
-    Actor: () => ({
-      id: "story-actor",
-      name,
-      rawName: name,
-      username: "blog_cloudflare_com_rs_5i8zpek",
-      handle,
-      avatarUrl: avatarDataUri,
-      avatarInitials: "CF",
-      bio: "<p>Engineering updates from the Cloudflare blog.</p>",
-      local: false,
-      url: "https://beta.rss2.pub/@blog_cloudflare_com_rs_5i8zpek",
-      iri: "https://beta.rss2.pub/ap/actors/blog_cloudflare_com_rs_5i8zpek",
-      suspended: false,
-      successor: null,
-      account: null,
-      fields: [],
-      isViewer: false,
-      viewerFollows: false,
-      viewerFollowState: "NONE",
-      viewerBlocks: false,
-      blocksViewer: false,
-      viewerMutes: false,
-      followsViewer: false,
-      followees: { totalCount: 42 },
-      followers: { totalCount: 128 },
-      mutualFollowers: { totalCount: 0, edges: [] },
-    }),
-    Note: () => ({
-      id: "story-post",
-      organizationAuthor: null,
-    }),
-  };
-}
-
-function actorStoryData(handle: string, name: string) {
-  const environment = new Environment({
-    network: Network.create(() => {
-      throw new Error("Storybook's mock environment has no real network");
-    }),
-    store: new Store(new RecordSource()),
-  });
-  const operation = createOperationDescriptor(
-    getRequest(ActorHandleStoriesActorQuery),
-    { id: "story-actor", actingAccountId: null },
-  );
-  const payload = MockPayloadGenerator.generate(
-    operation,
-    actorResolvers(handle, name, "Actor"),
-  );
-  if (payload.data == null) {
-    throw new Error("MockPayloadGenerator produced no actor data");
-  }
-  environment.commitPayload(operation, payload.data);
-  const data = environment.lookup(operation.fragment).data as unknown as
-    | ActorHandleStoriesActorQuery["response"]
-    | undefined;
-  if (data?.node == null) {
-    throw new Error("Actor story query produced no actor");
-  }
-  return { actor: data.node, environment };
-}
-
-function postStoryData(handle: string, name: string) {
-  const environment = new Environment({
-    network: Network.create(() => {
-      throw new Error("Storybook's mock environment has no real network");
-    }),
-    store: new Store(new RecordSource()),
-  });
-  const operation = createOperationDescriptor(
-    getRequest(ActorHandleStoriesPostQuery),
-    { id: "story-post" },
-  );
-  const payload = MockPayloadGenerator.generate(
-    operation,
-    actorResolvers(handle, name, "Note"),
-  );
-  if (payload.data == null) {
-    throw new Error("MockPayloadGenerator produced no post data");
-  }
-  environment.commitPayload(operation, payload.data);
-  const data = environment.lookup(operation.fragment).data as unknown as
-    | ActorHandleStoriesPostQuery["response"]
-    | undefined;
-  if (data?.node == null) {
-    throw new Error("Post story query produced no post");
-  }
-  return { environment, post: data.node };
 }
 
 const meta = {
-  title: "Regressions/Actor handle layouts",
+  title: "Components/ActorHandle",
+  component: ActorHandle,
   args: {
-    handle: longHandle,
-    name: defaultName,
+    handle: defaultActorHandle,
     width: 360,
   },
   argTypes: {
     width: { control: { min: 240, max: 720, step: 8, type: "range" } },
   },
-  parameters: {
-    layout: "padded",
-  },
+  parameters: { layout: "padded" },
 } satisfies Meta<ActorHandleStoryArgs>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const WrappingHandle: Story = {
-  name: "ActorHandle: wrapping",
+export const Default: Story = {
+  render: (args: ActorHandleStoryArgs) => (
+    <StorySurface width={args.width}>
+      <div class="p-4 text-muted-foreground">
+        <ActorHandle handle={args.handle} />
+      </div>
+    </StorySurface>
+  ),
+};
+
+export const Wrapping: Story = {
+  args: { handle: longActorHandle },
   render: (args: ActorHandleStoryArgs) => (
     <StorySurface width={args.width}>
       <div class="p-4 text-muted-foreground">
@@ -206,136 +47,13 @@ export const WrappingHandle: Story = {
   ),
 };
 
-export const TruncatedHandle: Story = {
-  name: "ActorHandle: truncation",
+export const Truncated: Story = {
+  args: { handle: longActorHandle },
   render: (args: ActorHandleStoryArgs) => (
     <StorySurface width={args.width}>
       <div class="min-w-0 p-4 text-muted-foreground">
         <ActorHandle handle={args.handle} class="block truncate" />
       </div>
-    </StorySurface>
-  ),
-};
-
-export const ProfileAtDesktopWidth: Story = {
-  name: "ProfileCard: long handle at desktop width",
-  args: { width: 640 },
-  render: (args: ActorHandleStoryArgs) => {
-    const { actor, environment } = actorStoryData(args.handle, args.name);
-    return (
-      <RelayEnvironmentProvider environment={environment}>
-        <StorySurface width={args.width}>
-          <ProfileCard $actor={actor} />
-        </StorySurface>
-      </RelayEnvironmentProvider>
-    );
-  },
-};
-
-export const ProfileAtMobileWidth: Story = {
-  name: "ProfileCard: long handle at mobile width",
-  args: { width: 320 },
-  render: (args: ActorHandleStoryArgs) => {
-    const { actor, environment } = actorStoryData(args.handle, args.name);
-    return (
-      <RelayEnvironmentProvider environment={environment}>
-        <StorySurface width={args.width}>
-          <ProfileCard $actor={actor} />
-        </StorySurface>
-      </RelayEnvironmentProvider>
-    );
-  },
-};
-
-export const SmallProfile: Story = {
-  name: "SmallProfileCard: truncated handle",
-  render: (args: ActorHandleStoryArgs) => {
-    const { actor, environment } = actorStoryData(args.handle, args.name);
-    return (
-      <RelayEnvironmentProvider environment={environment}>
-        <StorySurface width={args.width}>
-          <SmallProfileCard $actor={actor} />
-        </StorySurface>
-      </RelayEnvironmentProvider>
-    );
-  },
-};
-
-export const ActorPreview: Story = {
-  name: "ActorPreviewCard: truncated handle",
-  args: { width: 320 },
-  render: (args: ActorHandleStoryArgs) => {
-    const { actor, environment } = actorStoryData(args.handle, args.name);
-    return (
-      <RelayEnvironmentProvider environment={environment}>
-        <StorySurface width={args.width}>
-          <ActorPreviewCard $actor={actor} />
-        </StorySurface>
-      </RelayEnvironmentProvider>
-    );
-  },
-};
-
-export const PostAuthor: Story = {
-  name: "PostAuthorLine: truncated handle",
-  args: { width: 280 },
-  render: (args: ActorHandleStoryArgs) => {
-    const { environment, post } = postStoryData(args.handle, args.name);
-    return (
-      <RelayEnvironmentProvider environment={environment}>
-        <StorySurface width={args.width}>
-          <div class="min-w-0 p-4">
-            <PostAuthorLine $post={post} />
-          </div>
-        </StorySurface>
-      </RelayEnvironmentProvider>
-    );
-  },
-};
-
-export const LinkCreator: Story = {
-  name: "LinkCreatorAttribution: wrapping handle",
-  args: { width: 280 },
-  render: (args: ActorHandleStoryArgs) => {
-    const { actor, environment } = actorStoryData(args.handle, args.name);
-    return (
-      <RelayEnvironmentProvider environment={environment}>
-        <StorySurface width={args.width}>
-          <div class="p-4">
-            <LinkCreatorAttribution $creator={actor} />
-          </div>
-        </StorySurface>
-      </RelayEnvironmentProvider>
-    );
-  },
-};
-
-export const AccountList: Story = {
-  name: "AccountListBase: truncated handle",
-  render: (args: ActorHandleStoryArgs) => (
-    <StorySurface width={args.width}>
-      <AccountListBase
-        edges={[
-          {
-            node: {
-              id: "story-actor",
-              avatarUrl: avatarDataUri,
-              name: args.name,
-              handle: args.handle,
-              local: false,
-              username: "blog_cloudflare_com_rs_5i8zpek",
-            },
-          },
-        ]}
-        hasNext={false}
-        pending={false}
-        loadingState="loaded"
-        onLoadMore={() => undefined}
-        onAction={() => undefined}
-        actionLabel="Unblock"
-        actionDisabled={false}
-        emptyMessage="No accounts"
-      />
     </StorySurface>
   ),
 };

--- a/web-next/src/components/ActorHandle.stories.tsx
+++ b/web-next/src/components/ActorHandle.stories.tsx
@@ -1,0 +1,341 @@
+import {
+  createOperationDescriptor,
+  Environment,
+  getRequest,
+  graphql,
+  Network,
+  RecordSource,
+  Store,
+} from "relay-runtime";
+import { MockPayloadGenerator, type MockResolvers } from "relay-test-utils";
+import { RelayEnvironmentProvider } from "solid-relay";
+import type { JSX } from "solid-js";
+import type { Meta, StoryObj } from "storybook-solidjs-vite";
+import { AccountListBase } from "./AccountListBase.tsx";
+import { ActorHandle } from "./ActorHandle.tsx";
+import { ActorPreviewCard } from "./ActorPreviewCard.tsx";
+import type { ActorHandleStoriesActorQuery } from "./__generated__/ActorHandleStoriesActorQuery.graphql.ts";
+import type { ActorHandleStoriesPostQuery } from "./__generated__/ActorHandleStoriesPostQuery.graphql.ts";
+import { LinkCreatorAttribution } from "./LinkCreatorAttribution.tsx";
+import { PostAuthorLine } from "./PostAuthor.tsx";
+import { ProfileCard } from "./ProfileCard.tsx";
+import { SmallProfileCard } from "./SmallProfileCard.tsx";
+
+const ActorHandleStoriesActorQuery = graphql`
+  query ActorHandleStoriesActorQuery($id: ID!, $actingAccountId: ID) {
+    node(id: $id) {
+      ... on Actor {
+        ...ActorPreviewCard_actor
+          @arguments(actingAccountId: $actingAccountId)
+        ...LinkCreatorAttribution_creator
+        ...ProfileCard_actor @arguments(actingAccountId: $actingAccountId)
+        ...SmallProfileCard_actor
+          @arguments(actingAccountId: $actingAccountId)
+      }
+    }
+  }
+`;
+
+const ActorHandleStoriesPostQuery = graphql`
+  query ActorHandleStoriesPostQuery($id: ID!) {
+    node(id: $id) {
+      ... on Post {
+        ...PostAuthorLine_post
+      }
+    }
+  }
+`;
+
+const longHandle = "@blog_cloudflare_com_rs_5i8zpek@beta.rss2.pub";
+const defaultName = "Cloudflare Blog Feed";
+
+const avatarDataUri =
+  "data:image/svg+xml," +
+  encodeURIComponent(
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 80">' +
+      '<rect width="80" height="80" rx="16" fill="#f38020"/>' +
+      '<text x="40" y="50" text-anchor="middle" font-family="sans-serif" ' +
+      'font-size="28" font-weight="700" fill="white">CF</text></svg>',
+  );
+
+interface ActorHandleStoryArgs {
+  handle: string;
+  name: string;
+  width: number;
+}
+
+interface StorySurfaceProps {
+  children: JSX.Element;
+  width: number;
+}
+
+function StorySurface(props: StorySurfaceProps) {
+  return (
+    <div
+      class="border bg-background"
+      style={{ width: `${props.width}px`, "max-width": "100%" }}
+    >
+      {props.children}
+    </div>
+  );
+}
+
+function actorResolvers(
+  handle: string,
+  name: string,
+  nodeType: "Actor" | "Note",
+): MockResolvers {
+  return {
+    Node: () => ({ __typename: nodeType }),
+    Actor: () => ({
+      id: "story-actor",
+      name,
+      rawName: name,
+      username: "blog_cloudflare_com_rs_5i8zpek",
+      handle,
+      avatarUrl: avatarDataUri,
+      avatarInitials: "CF",
+      bio: "<p>Engineering updates from the Cloudflare blog.</p>",
+      local: false,
+      url: "https://beta.rss2.pub/@blog_cloudflare_com_rs_5i8zpek",
+      iri: "https://beta.rss2.pub/ap/actors/blog_cloudflare_com_rs_5i8zpek",
+      suspended: false,
+      successor: null,
+      account: null,
+      fields: [],
+      isViewer: false,
+      viewerFollows: false,
+      viewerFollowState: "NONE",
+      viewerBlocks: false,
+      blocksViewer: false,
+      viewerMutes: false,
+      followsViewer: false,
+      followees: { totalCount: 42 },
+      followers: { totalCount: 128 },
+      mutualFollowers: { totalCount: 0, edges: [] },
+    }),
+    Note: () => ({
+      id: "story-post",
+      organizationAuthor: null,
+    }),
+  };
+}
+
+function actorStoryData(handle: string, name: string) {
+  const environment = new Environment({
+    network: Network.create(() => {
+      throw new Error("Storybook's mock environment has no real network");
+    }),
+    store: new Store(new RecordSource()),
+  });
+  const operation = createOperationDescriptor(
+    getRequest(ActorHandleStoriesActorQuery),
+    { id: "story-actor", actingAccountId: null },
+  );
+  const payload = MockPayloadGenerator.generate(
+    operation,
+    actorResolvers(handle, name, "Actor"),
+  );
+  if (payload.data == null) {
+    throw new Error("MockPayloadGenerator produced no actor data");
+  }
+  environment.commitPayload(operation, payload.data);
+  const data = environment.lookup(operation.fragment).data as unknown as
+    | ActorHandleStoriesActorQuery["response"]
+    | undefined;
+  if (data?.node == null) {
+    throw new Error("Actor story query produced no actor");
+  }
+  return { actor: data.node, environment };
+}
+
+function postStoryData(handle: string, name: string) {
+  const environment = new Environment({
+    network: Network.create(() => {
+      throw new Error("Storybook's mock environment has no real network");
+    }),
+    store: new Store(new RecordSource()),
+  });
+  const operation = createOperationDescriptor(
+    getRequest(ActorHandleStoriesPostQuery),
+    { id: "story-post" },
+  );
+  const payload = MockPayloadGenerator.generate(
+    operation,
+    actorResolvers(handle, name, "Note"),
+  );
+  if (payload.data == null) {
+    throw new Error("MockPayloadGenerator produced no post data");
+  }
+  environment.commitPayload(operation, payload.data);
+  const data = environment.lookup(operation.fragment).data as unknown as
+    | ActorHandleStoriesPostQuery["response"]
+    | undefined;
+  if (data?.node == null) {
+    throw new Error("Post story query produced no post");
+  }
+  return { environment, post: data.node };
+}
+
+const meta = {
+  title: "Regressions/Actor handle layouts",
+  args: {
+    handle: longHandle,
+    name: defaultName,
+    width: 360,
+  },
+  argTypes: {
+    width: { control: { min: 240, max: 720, step: 8, type: "range" } },
+  },
+  parameters: {
+    layout: "padded",
+  },
+} satisfies Meta<ActorHandleStoryArgs>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const WrappingHandle: Story = {
+  name: "ActorHandle: wrapping",
+  render: (args: ActorHandleStoryArgs) => (
+    <StorySurface width={args.width}>
+      <div class="p-4 text-muted-foreground">
+        <ActorHandle handle={args.handle} class="block wrap-anywhere" />
+      </div>
+    </StorySurface>
+  ),
+};
+
+export const TruncatedHandle: Story = {
+  name: "ActorHandle: truncation",
+  render: (args: ActorHandleStoryArgs) => (
+    <StorySurface width={args.width}>
+      <div class="min-w-0 p-4 text-muted-foreground">
+        <ActorHandle handle={args.handle} class="block truncate" />
+      </div>
+    </StorySurface>
+  ),
+};
+
+export const ProfileAtDesktopWidth: Story = {
+  name: "ProfileCard: long handle at desktop width",
+  args: { width: 640 },
+  render: (args: ActorHandleStoryArgs) => {
+    const { actor, environment } = actorStoryData(args.handle, args.name);
+    return (
+      <RelayEnvironmentProvider environment={environment}>
+        <StorySurface width={args.width}>
+          <ProfileCard $actor={actor} />
+        </StorySurface>
+      </RelayEnvironmentProvider>
+    );
+  },
+};
+
+export const ProfileAtMobileWidth: Story = {
+  name: "ProfileCard: long handle at mobile width",
+  args: { width: 320 },
+  render: (args: ActorHandleStoryArgs) => {
+    const { actor, environment } = actorStoryData(args.handle, args.name);
+    return (
+      <RelayEnvironmentProvider environment={environment}>
+        <StorySurface width={args.width}>
+          <ProfileCard $actor={actor} />
+        </StorySurface>
+      </RelayEnvironmentProvider>
+    );
+  },
+};
+
+export const SmallProfile: Story = {
+  name: "SmallProfileCard: truncated handle",
+  render: (args: ActorHandleStoryArgs) => {
+    const { actor, environment } = actorStoryData(args.handle, args.name);
+    return (
+      <RelayEnvironmentProvider environment={environment}>
+        <StorySurface width={args.width}>
+          <SmallProfileCard $actor={actor} />
+        </StorySurface>
+      </RelayEnvironmentProvider>
+    );
+  },
+};
+
+export const ActorPreview: Story = {
+  name: "ActorPreviewCard: truncated handle",
+  args: { width: 320 },
+  render: (args: ActorHandleStoryArgs) => {
+    const { actor, environment } = actorStoryData(args.handle, args.name);
+    return (
+      <RelayEnvironmentProvider environment={environment}>
+        <StorySurface width={args.width}>
+          <ActorPreviewCard $actor={actor} />
+        </StorySurface>
+      </RelayEnvironmentProvider>
+    );
+  },
+};
+
+export const PostAuthor: Story = {
+  name: "PostAuthorLine: truncated handle",
+  args: { width: 280 },
+  render: (args: ActorHandleStoryArgs) => {
+    const { environment, post } = postStoryData(args.handle, args.name);
+    return (
+      <RelayEnvironmentProvider environment={environment}>
+        <StorySurface width={args.width}>
+          <div class="min-w-0 p-4">
+            <PostAuthorLine $post={post} />
+          </div>
+        </StorySurface>
+      </RelayEnvironmentProvider>
+    );
+  },
+};
+
+export const LinkCreator: Story = {
+  name: "LinkCreatorAttribution: wrapping handle",
+  args: { width: 280 },
+  render: (args: ActorHandleStoryArgs) => {
+    const { actor, environment } = actorStoryData(args.handle, args.name);
+    return (
+      <RelayEnvironmentProvider environment={environment}>
+        <StorySurface width={args.width}>
+          <div class="p-4">
+            <LinkCreatorAttribution $creator={actor} />
+          </div>
+        </StorySurface>
+      </RelayEnvironmentProvider>
+    );
+  },
+};
+
+export const AccountList: Story = {
+  name: "AccountListBase: truncated handle",
+  render: (args: ActorHandleStoryArgs) => (
+    <StorySurface width={args.width}>
+      <AccountListBase
+        edges={[
+          {
+            node: {
+              id: "story-actor",
+              avatarUrl: avatarDataUri,
+              name: args.name,
+              handle: args.handle,
+              local: false,
+              username: "blog_cloudflare_com_rs_5i8zpek",
+            },
+          },
+        ]}
+        hasNext={false}
+        pending={false}
+        loadingState="loaded"
+        onLoadMore={() => undefined}
+        onAction={() => undefined}
+        actionLabel="Unblock"
+        actionDisabled={false}
+        emptyMessage="No accounts"
+      />
+    </StorySurface>
+  ),
+};

--- a/web-next/src/components/ActorHandle.tsx
+++ b/web-next/src/components/ActorHandle.tsx
@@ -1,0 +1,23 @@
+import { type ComponentProps, splitProps } from "solid-js";
+import { cn } from "~/lib/utils.ts";
+
+export interface ActorHandleProps extends Omit<
+  ComponentProps<"span">,
+  "children"
+> {
+  readonly handle: string;
+}
+
+/** Displays a canonical fediverse handle without altering its copyable text. */
+export function ActorHandle(props: ActorHandleProps) {
+  const [local, others] = splitProps(props, ["handle", "class", "title"]);
+  return (
+    <span
+      {...others}
+      class={cn("select-all", local.class)}
+      title={local.title ?? local.handle}
+    >
+      {local.handle}
+    </span>
+  );
+}

--- a/web-next/src/components/ActorPreviewCard.stories.tsx
+++ b/web-next/src/components/ActorPreviewCard.stories.tsx
@@ -1,0 +1,73 @@
+import { graphql } from "relay-runtime";
+import { RelayEnvironmentProvider } from "solid-relay";
+import type { Meta, StoryObj } from "storybook-solidjs-vite";
+import {
+  ActorPreviewCard,
+  type ActorPreviewCardProps,
+} from "./ActorPreviewCard.tsx";
+import type { ActorPreviewCardStoriesQuery } from "./__generated__/ActorPreviewCardStoriesQuery.graphql.ts";
+import {
+  type ActorStoryArgs,
+  actorMockResolvers,
+  createRelayStoryData,
+  defaultActorHandle,
+  defaultActorName,
+  longActorHandle,
+  StorySurface,
+} from "./storybook/actorStoryFixtures.tsx";
+
+interface ActorPreviewCardStoryArgs
+  extends ActorStoryArgs, ActorPreviewCardProps {}
+
+const ActorPreviewCardStoriesQuery = graphql`
+  query ActorPreviewCardStoriesQuery($id: ID!, $actingAccountId: ID) {
+    node(id: $id) {
+      ... on Actor {
+        ...ActorPreviewCard_actor
+          @arguments(actingAccountId: $actingAccountId)
+      }
+    }
+  }
+`;
+
+function renderActorPreviewCard(args: ActorPreviewCardStoryArgs) {
+  const { environment, node } = createRelayStoryData<
+    ActorPreviewCardStoriesQuery["response"]
+  >(
+    ActorPreviewCardStoriesQuery,
+    { id: "story-actor", actingAccountId: null },
+    actorMockResolvers(args),
+    "actor",
+  );
+  return (
+    <RelayEnvironmentProvider environment={environment}>
+      <StorySurface width={args.width}>
+        <ActorPreviewCard $actor={node} />
+      </StorySurface>
+    </RelayEnvironmentProvider>
+  );
+}
+
+const meta = {
+  title: "Components/ActorPreviewCard",
+  component: ActorPreviewCard,
+  args: {
+    handle: defaultActorHandle,
+    name: defaultActorName,
+    width: 320,
+  },
+  argTypes: {
+    width: { control: { min: 240, max: 720, step: 8, type: "range" } },
+  },
+  parameters: { layout: "padded" },
+  render: renderActorPreviewCard,
+} satisfies Meta<ActorPreviewCardStoryArgs>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const LongHandle: Story = {
+  args: { handle: longActorHandle },
+};

--- a/web-next/src/components/ActorPreviewCard.stories.tsx
+++ b/web-next/src/components/ActorPreviewCard.stories.tsx
@@ -1,10 +1,7 @@
 import { graphql } from "relay-runtime";
 import { RelayEnvironmentProvider } from "solid-relay";
 import type { Meta, StoryObj } from "storybook-solidjs-vite";
-import {
-  ActorPreviewCard,
-  type ActorPreviewCardProps,
-} from "./ActorPreviewCard.tsx";
+import { ActorPreviewCard } from "./ActorPreviewCard.tsx";
 import type { ActorPreviewCardStoriesQuery } from "./__generated__/ActorPreviewCardStoriesQuery.graphql.ts";
 import {
   type ActorStoryArgs,
@@ -16,8 +13,7 @@ import {
   StorySurface,
 } from "./storybook/actorStoryFixtures.tsx";
 
-interface ActorPreviewCardStoryArgs
-  extends ActorStoryArgs, ActorPreviewCardProps {}
+interface ActorPreviewCardStoryArgs extends ActorStoryArgs {}
 
 const ActorPreviewCardStoriesQuery = graphql`
   query ActorPreviewCardStoriesQuery($id: ID!, $actingAccountId: ID) {
@@ -50,7 +46,6 @@ function renderActorPreviewCard(args: ActorPreviewCardStoryArgs) {
 
 const meta = {
   title: "Components/ActorPreviewCard",
-  component: ActorPreviewCard,
   args: {
     handle: defaultActorHandle,
     name: defaultActorName,

--- a/web-next/src/components/ActorPreviewCard.tsx
+++ b/web-next/src/components/ActorPreviewCard.tsx
@@ -8,6 +8,7 @@ import {
   AvatarImage,
 } from "~/components/ui/avatar.tsx";
 import { msg, plural, useLingui } from "~/lib/i18n/macro.ts";
+import { ActorHandle } from "./ActorHandle.tsx";
 import type { ActorPreviewCard_actor$key } from "./__generated__/ActorPreviewCard_actor.graphql.ts";
 import { FollowButton } from "./FollowButton.tsx";
 import { InternalLink } from "./InternalLink.tsx";
@@ -102,12 +103,10 @@ export function ActorPreviewCard(props: ActorPreviewCardProps) {
                     class="truncate font-semibold"
                   />
                 </Show>
-                <span
-                  class="truncate text-sm text-muted-foreground select-all"
-                  title={a.handle}
-                >
-                  {a.handle}
-                </span>
+                <ActorHandle
+                  handle={a.handle}
+                  class="truncate text-sm text-muted-foreground"
+                />
               </div>
               <div class="shrink-0">
                 <FollowButton $actor={a} />

--- a/web-next/src/components/LinkCreatorAttribution.stories.tsx
+++ b/web-next/src/components/LinkCreatorAttribution.stories.tsx
@@ -1,0 +1,74 @@
+import { graphql } from "relay-runtime";
+import { RelayEnvironmentProvider } from "solid-relay";
+import type { Meta, StoryObj } from "storybook-solidjs-vite";
+import type { LinkCreatorAttributionStoriesQuery } from "./__generated__/LinkCreatorAttributionStoriesQuery.graphql.ts";
+import {
+  LinkCreatorAttribution,
+  type LinkCreatorAttributionProps,
+} from "./LinkCreatorAttribution.tsx";
+import {
+  type ActorStoryArgs,
+  actorMockResolvers,
+  createRelayStoryData,
+  defaultActorHandle,
+  defaultActorName,
+  longActorHandle,
+  StorySurface,
+} from "./storybook/actorStoryFixtures.tsx";
+
+interface LinkCreatorAttributionStoryArgs
+  extends ActorStoryArgs, LinkCreatorAttributionProps {}
+
+const LinkCreatorAttributionStoriesQuery = graphql`
+  query LinkCreatorAttributionStoriesQuery($id: ID!) {
+    node(id: $id) {
+      ... on Actor {
+        ...LinkCreatorAttribution_creator
+      }
+    }
+  }
+`;
+
+function renderLinkCreatorAttribution(args: LinkCreatorAttributionStoryArgs) {
+  const { environment, node } = createRelayStoryData<
+    LinkCreatorAttributionStoriesQuery["response"]
+  >(
+    LinkCreatorAttributionStoriesQuery,
+    { id: "story-actor" },
+    actorMockResolvers(args),
+    "actor",
+  );
+  return (
+    <RelayEnvironmentProvider environment={environment}>
+      <StorySurface width={args.width}>
+        <div class="p-4">
+          <LinkCreatorAttribution $creator={node} />
+        </div>
+      </StorySurface>
+    </RelayEnvironmentProvider>
+  );
+}
+
+const meta = {
+  title: "Components/LinkCreatorAttribution",
+  component: LinkCreatorAttribution,
+  args: {
+    handle: defaultActorHandle,
+    name: defaultActorName,
+    width: 280,
+  },
+  argTypes: {
+    width: { control: { min: 240, max: 720, step: 8, type: "range" } },
+  },
+  parameters: { layout: "padded" },
+  render: renderLinkCreatorAttribution,
+} satisfies Meta<LinkCreatorAttributionStoryArgs>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const LongHandle: Story = {
+  args: { handle: longActorHandle },
+};

--- a/web-next/src/components/LinkCreatorAttribution.stories.tsx
+++ b/web-next/src/components/LinkCreatorAttribution.stories.tsx
@@ -2,10 +2,7 @@ import { graphql } from "relay-runtime";
 import { RelayEnvironmentProvider } from "solid-relay";
 import type { Meta, StoryObj } from "storybook-solidjs-vite";
 import type { LinkCreatorAttributionStoriesQuery } from "./__generated__/LinkCreatorAttributionStoriesQuery.graphql.ts";
-import {
-  LinkCreatorAttribution,
-  type LinkCreatorAttributionProps,
-} from "./LinkCreatorAttribution.tsx";
+import { LinkCreatorAttribution } from "./LinkCreatorAttribution.tsx";
 import {
   type ActorStoryArgs,
   actorMockResolvers,
@@ -16,8 +13,7 @@ import {
   StorySurface,
 } from "./storybook/actorStoryFixtures.tsx";
 
-interface LinkCreatorAttributionStoryArgs
-  extends ActorStoryArgs, LinkCreatorAttributionProps {}
+interface LinkCreatorAttributionStoryArgs extends ActorStoryArgs {}
 
 const LinkCreatorAttributionStoriesQuery = graphql`
   query LinkCreatorAttributionStoriesQuery($id: ID!) {
@@ -51,7 +47,6 @@ function renderLinkCreatorAttribution(args: LinkCreatorAttributionStoryArgs) {
 
 const meta = {
   title: "Components/LinkCreatorAttribution",
-  component: LinkCreatorAttribution,
   args: {
     handle: defaultActorHandle,
     name: defaultActorName,

--- a/web-next/src/components/LinkCreatorAttribution.tsx
+++ b/web-next/src/components/LinkCreatorAttribution.tsx
@@ -10,6 +10,7 @@ import {
 } from "~/components/ui/avatar.tsx";
 import { useLingui } from "~/lib/i18n/macro.ts";
 import { cn } from "~/lib/utils.ts";
+import { ActorHandle } from "./ActorHandle.tsx";
 import type { LinkCreatorAttribution_creator$key } from "./__generated__/LinkCreatorAttribution_creator.graphql.ts";
 
 export interface LinkCreatorAttributionProps {
@@ -65,7 +66,10 @@ export function LinkCreatorAttribution(props: LinkCreatorAttributionProps) {
                 class="font-semibold hover:underline"
               />{" "}
             </Show>
-            <span class="select-all text-muted-foreground">{c.handle}</span>
+            <ActorHandle
+              handle={c.handle}
+              class="wrap-anywhere text-muted-foreground"
+            />
           </div>
         </div>
       )}

--- a/web-next/src/components/PostAuthor.stories.tsx
+++ b/web-next/src/components/PostAuthor.stories.tsx
@@ -1,0 +1,70 @@
+import { graphql } from "relay-runtime";
+import { RelayEnvironmentProvider } from "solid-relay";
+import type { Meta, StoryObj } from "storybook-solidjs-vite";
+import type { PostAuthorStoriesQuery } from "./__generated__/PostAuthorStoriesQuery.graphql.ts";
+import { PostAuthorLine, type PostAuthorLineProps } from "./PostAuthor.tsx";
+import {
+  type ActorStoryArgs,
+  actorMockResolvers,
+  createRelayStoryData,
+  defaultActorHandle,
+  defaultActorName,
+  longActorHandle,
+  StorySurface,
+} from "./storybook/actorStoryFixtures.tsx";
+
+interface PostAuthorStoryArgs extends ActorStoryArgs, PostAuthorLineProps {}
+
+const PostAuthorStoriesQuery = graphql`
+  query PostAuthorStoriesQuery($id: ID!) {
+    node(id: $id) {
+      ... on Post {
+        ...PostAuthorLine_post
+      }
+    }
+  }
+`;
+
+function renderPostAuthorLine(args: PostAuthorStoryArgs) {
+  const { environment, node } = createRelayStoryData<
+    PostAuthorStoriesQuery["response"]
+  >(
+    PostAuthorStoriesQuery,
+    { id: "story-post" },
+    actorMockResolvers(args, "Note"),
+    "post",
+  );
+  return (
+    <RelayEnvironmentProvider environment={environment}>
+      <StorySurface width={args.width}>
+        <div class="min-w-0 p-4">
+          <PostAuthorLine $post={node} />
+        </div>
+      </StorySurface>
+    </RelayEnvironmentProvider>
+  );
+}
+
+const meta = {
+  title: "Components/PostAuthor",
+  component: PostAuthorLine,
+  args: {
+    handle: defaultActorHandle,
+    name: defaultActorName,
+    width: 280,
+  },
+  argTypes: {
+    width: { control: { min: 240, max: 720, step: 8, type: "range" } },
+  },
+  parameters: { layout: "padded" },
+  render: renderPostAuthorLine,
+} satisfies Meta<PostAuthorStoryArgs>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const LongHandle: Story = {
+  args: { handle: longActorHandle },
+};

--- a/web-next/src/components/PostAuthor.stories.tsx
+++ b/web-next/src/components/PostAuthor.stories.tsx
@@ -2,7 +2,7 @@ import { graphql } from "relay-runtime";
 import { RelayEnvironmentProvider } from "solid-relay";
 import type { Meta, StoryObj } from "storybook-solidjs-vite";
 import type { PostAuthorStoriesQuery } from "./__generated__/PostAuthorStoriesQuery.graphql.ts";
-import { PostAuthorLine, type PostAuthorLineProps } from "./PostAuthor.tsx";
+import { PostAuthorLine } from "./PostAuthor.tsx";
 import {
   type ActorStoryArgs,
   actorMockResolvers,
@@ -13,7 +13,7 @@ import {
   StorySurface,
 } from "./storybook/actorStoryFixtures.tsx";
 
-interface PostAuthorStoryArgs extends ActorStoryArgs, PostAuthorLineProps {}
+interface PostAuthorStoryArgs extends ActorStoryArgs {}
 
 const PostAuthorStoriesQuery = graphql`
   query PostAuthorStoriesQuery($id: ID!) {
@@ -47,7 +47,6 @@ function renderPostAuthorLine(args: PostAuthorStoryArgs) {
 
 const meta = {
   title: "Components/PostAuthor",
-  component: PostAuthorLine,
   args: {
     handle: defaultActorHandle,
     name: defaultActorName,

--- a/web-next/src/components/PostAuthor.tsx
+++ b/web-next/src/components/PostAuthor.tsx
@@ -1,6 +1,7 @@
 import { graphql } from "relay-runtime";
 import { Show } from "solid-js";
 import { createFragment } from "solid-relay";
+import { ActorHandle } from "~/components/ActorHandle.tsx";
 import { ActorHoverCard } from "./ActorHoverCard.tsx";
 import { HtmlContent } from "./HtmlContent.tsx";
 import { InternalLink } from "./InternalLink.tsx";
@@ -251,15 +252,10 @@ function AuthorIdentity(props: AuthorIdentityProps) {
           class={cn("min-w-0 truncate font-semibold", props.nameClass)}
         />
       </Show>
-      <span
-        class={cn(
-          "min-w-0 truncate select-all text-muted-foreground",
-          props.handleClass,
-        )}
-        title={props.actor.handle}
-      >
-        {props.actor.handle}
-      </span>
+      <ActorHandle
+        handle={props.actor.handle}
+        class={cn("min-w-0 truncate text-muted-foreground", props.handleClass)}
+      />
     </ActorHoverCard>
   );
 }

--- a/web-next/src/components/ProfileCard.stories.tsx
+++ b/web-next/src/components/ProfileCard.stories.tsx
@@ -2,7 +2,7 @@ import { graphql } from "relay-runtime";
 import { RelayEnvironmentProvider } from "solid-relay";
 import type { Meta, StoryObj } from "storybook-solidjs-vite";
 import type { ProfileCardStoriesQuery } from "./__generated__/ProfileCardStoriesQuery.graphql.ts";
-import { ProfileCard, type ProfileCardProps } from "./ProfileCard.tsx";
+import { ProfileCard } from "./ProfileCard.tsx";
 import {
   type ActorStoryArgs,
   actorMockResolvers,
@@ -13,7 +13,7 @@ import {
   StorySurface,
 } from "./storybook/actorStoryFixtures.tsx";
 
-interface ProfileCardStoryArgs extends ActorStoryArgs, ProfileCardProps {}
+interface ProfileCardStoryArgs extends ActorStoryArgs {}
 
 const ProfileCardStoriesQuery = graphql`
   query ProfileCardStoriesQuery($id: ID!, $actingAccountId: ID) {
@@ -45,7 +45,6 @@ function renderProfileCard(args: ProfileCardStoryArgs) {
 
 const meta = {
   title: "Components/ProfileCard",
-  component: ProfileCard,
   args: {
     handle: defaultActorHandle,
     name: defaultActorName,

--- a/web-next/src/components/ProfileCard.stories.tsx
+++ b/web-next/src/components/ProfileCard.stories.tsx
@@ -1,0 +1,75 @@
+import { graphql } from "relay-runtime";
+import { RelayEnvironmentProvider } from "solid-relay";
+import type { Meta, StoryObj } from "storybook-solidjs-vite";
+import type { ProfileCardStoriesQuery } from "./__generated__/ProfileCardStoriesQuery.graphql.ts";
+import { ProfileCard, type ProfileCardProps } from "./ProfileCard.tsx";
+import {
+  type ActorStoryArgs,
+  actorMockResolvers,
+  createRelayStoryData,
+  defaultActorHandle,
+  defaultActorName,
+  longActorHandle,
+  StorySurface,
+} from "./storybook/actorStoryFixtures.tsx";
+
+interface ProfileCardStoryArgs extends ActorStoryArgs, ProfileCardProps {}
+
+const ProfileCardStoriesQuery = graphql`
+  query ProfileCardStoriesQuery($id: ID!, $actingAccountId: ID) {
+    node(id: $id) {
+      ... on Actor {
+        ...ProfileCard_actor @arguments(actingAccountId: $actingAccountId)
+      }
+    }
+  }
+`;
+
+function renderProfileCard(args: ProfileCardStoryArgs) {
+  const { environment, node } = createRelayStoryData<
+    ProfileCardStoriesQuery["response"]
+  >(
+    ProfileCardStoriesQuery,
+    { id: "story-actor", actingAccountId: null },
+    actorMockResolvers(args),
+    "actor",
+  );
+  return (
+    <RelayEnvironmentProvider environment={environment}>
+      <StorySurface width={args.width}>
+        <ProfileCard $actor={node} />
+      </StorySurface>
+    </RelayEnvironmentProvider>
+  );
+}
+
+const meta = {
+  title: "Components/ProfileCard",
+  component: ProfileCard,
+  args: {
+    handle: defaultActorHandle,
+    name: defaultActorName,
+    width: 640,
+  },
+  argTypes: {
+    width: { control: { min: 240, max: 720, step: 8, type: "range" } },
+  },
+  parameters: { layout: "padded" },
+  render: renderProfileCard,
+} satisfies Meta<ProfileCardStoryArgs>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const LongHandle: Story = {
+  args: { handle: longActorHandle },
+};
+
+export const LongHandleAtMobileWidth: Story = {
+  args: {
+    handle: longActorHandle,
+    width: 320,
+  },
+};

--- a/web-next/src/components/ProfileCard.tsx
+++ b/web-next/src/components/ProfileCard.tsx
@@ -29,6 +29,7 @@ import {
   useMentionHoverCards,
 } from "~/lib/mentionHoverCards.tsx";
 import { encodeHandleSegment } from "~/lib/handleSegment.ts";
+import { ActorHandle } from "./ActorHandle.tsx";
 import type { ProfileCard_actor$key } from "./__generated__/ProfileCard_actor.graphql.ts";
 import { FollowButton } from "./FollowButton.tsx";
 import { InternalLink } from "./InternalLink.tsx";
@@ -168,8 +169,8 @@ export function ProfileCard(props: ProfileCardProps) {
                     </AvatarFallback>
                   </a>
                 </Avatar>
-                <div class="flex-1">
-                  <h1 class="text-xl font-semibold">
+                <div class="min-w-0 flex-1">
+                  <h1 class="wrap-anywhere text-xl font-semibold">
                     <HtmlContent
                       as="a"
                       html={actor.name ?? actor.username}
@@ -183,7 +184,10 @@ export function ProfileCard(props: ProfileCardProps) {
                     />
                   </h1>
                   <div class="text-muted-foreground">
-                    <span class="select-all">{actor.handle}</span>
+                    <ActorHandle
+                      handle={actor.handle}
+                      class="block wrap-anywhere"
+                    />
                   </div>
                 </div>
                 <div class="flex shrink-0 items-center gap-1">

--- a/web-next/src/components/SmallProfileCard.stories.tsx
+++ b/web-next/src/components/SmallProfileCard.stories.tsx
@@ -2,10 +2,7 @@ import { graphql } from "relay-runtime";
 import { RelayEnvironmentProvider } from "solid-relay";
 import type { Meta, StoryObj } from "storybook-solidjs-vite";
 import type { SmallProfileCardStoriesQuery } from "./__generated__/SmallProfileCardStoriesQuery.graphql.ts";
-import {
-  SmallProfileCard,
-  type SmallProfileCardProps,
-} from "./SmallProfileCard.tsx";
+import { SmallProfileCard } from "./SmallProfileCard.tsx";
 import {
   type ActorStoryArgs,
   actorMockResolvers,
@@ -16,8 +13,7 @@ import {
   StorySurface,
 } from "./storybook/actorStoryFixtures.tsx";
 
-interface SmallProfileCardStoryArgs
-  extends ActorStoryArgs, SmallProfileCardProps {}
+interface SmallProfileCardStoryArgs extends ActorStoryArgs {}
 
 const SmallProfileCardStoriesQuery = graphql`
   query SmallProfileCardStoriesQuery($id: ID!, $actingAccountId: ID) {
@@ -50,7 +46,6 @@ function renderSmallProfileCard(args: SmallProfileCardStoryArgs) {
 
 const meta = {
   title: "Components/SmallProfileCard",
-  component: SmallProfileCard,
   args: {
     handle: defaultActorHandle,
     name: defaultActorName,

--- a/web-next/src/components/SmallProfileCard.stories.tsx
+++ b/web-next/src/components/SmallProfileCard.stories.tsx
@@ -1,0 +1,73 @@
+import { graphql } from "relay-runtime";
+import { RelayEnvironmentProvider } from "solid-relay";
+import type { Meta, StoryObj } from "storybook-solidjs-vite";
+import type { SmallProfileCardStoriesQuery } from "./__generated__/SmallProfileCardStoriesQuery.graphql.ts";
+import {
+  SmallProfileCard,
+  type SmallProfileCardProps,
+} from "./SmallProfileCard.tsx";
+import {
+  type ActorStoryArgs,
+  actorMockResolvers,
+  createRelayStoryData,
+  defaultActorHandle,
+  defaultActorName,
+  longActorHandle,
+  StorySurface,
+} from "./storybook/actorStoryFixtures.tsx";
+
+interface SmallProfileCardStoryArgs
+  extends ActorStoryArgs, SmallProfileCardProps {}
+
+const SmallProfileCardStoriesQuery = graphql`
+  query SmallProfileCardStoriesQuery($id: ID!, $actingAccountId: ID) {
+    node(id: $id) {
+      ... on Actor {
+        ...SmallProfileCard_actor
+          @arguments(actingAccountId: $actingAccountId)
+      }
+    }
+  }
+`;
+
+function renderSmallProfileCard(args: SmallProfileCardStoryArgs) {
+  const { environment, node } = createRelayStoryData<
+    SmallProfileCardStoriesQuery["response"]
+  >(
+    SmallProfileCardStoriesQuery,
+    { id: "story-actor", actingAccountId: null },
+    actorMockResolvers(args),
+    "actor",
+  );
+  return (
+    <RelayEnvironmentProvider environment={environment}>
+      <StorySurface width={args.width}>
+        <SmallProfileCard $actor={node} />
+      </StorySurface>
+    </RelayEnvironmentProvider>
+  );
+}
+
+const meta = {
+  title: "Components/SmallProfileCard",
+  component: SmallProfileCard,
+  args: {
+    handle: defaultActorHandle,
+    name: defaultActorName,
+    width: 360,
+  },
+  argTypes: {
+    width: { control: { min: 240, max: 720, step: 8, type: "range" } },
+  },
+  parameters: { layout: "padded" },
+  render: renderSmallProfileCard,
+} satisfies Meta<SmallProfileCardStoryArgs>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const LongHandle: Story = {
+  args: { handle: longActorHandle },
+};

--- a/web-next/src/components/SmallProfileCard.tsx
+++ b/web-next/src/components/SmallProfileCard.tsx
@@ -7,6 +7,7 @@ import {
   useMentionHoverCards,
 } from "~/lib/mentionHoverCards.tsx";
 import type { SmallProfileCard_actor$key } from "./__generated__/SmallProfileCard_actor.graphql.ts";
+import { ActorHandle } from "./ActorHandle.tsx";
 import { ActorHoverCard } from "./ActorHoverCard.tsx";
 import { FollowButton } from "./FollowButton.tsx";
 import { HtmlContent } from "./HtmlContent.tsx";
@@ -76,12 +77,10 @@ export function SmallProfileCard(props: SmallProfileCardProps) {
                   />
                 </Show>
               </ActorHoverCard>
-              <span
-                class="truncate text-muted-foreground select-all"
-                title={actor.handle}
-              >
-                {actor.handle}
-              </span>
+              <ActorHandle
+                handle={actor.handle}
+                class="truncate text-muted-foreground"
+              />
             </div>
             <div class="flex shrink-0 items-center gap-1">
               <FollowButton $actor={actor} />

--- a/web-next/src/components/storybook/actorStoryFixtures.tsx
+++ b/web-next/src/components/storybook/actorStoryFixtures.tsx
@@ -79,6 +79,9 @@ export function actorMockResolvers(
       followers: { totalCount: 128 },
       mutualFollowers: { totalCount: 0, edges: [] },
     }),
+    ActorFolloweesConnection: () => ({ totalCount: 42, edges: [] }),
+    ActorFollowersConnection: () => ({ totalCount: 128, edges: [] }),
+    ActorMutualFollowersConnection: () => ({ totalCount: 0, edges: [] }),
     Note: () => ({
       id: "story-post",
       organizationAuthor: null,

--- a/web-next/src/components/storybook/actorStoryFixtures.tsx
+++ b/web-next/src/components/storybook/actorStoryFixtures.tsx
@@ -1,0 +1,122 @@
+import {
+  createOperationDescriptor,
+  Environment,
+  getRequest,
+  type GraphQLTaggedNode,
+  Network,
+  RecordSource,
+  Store,
+  type Variables,
+} from "relay-runtime";
+import { MockPayloadGenerator, type MockResolvers } from "relay-test-utils";
+import type { JSX } from "solid-js";
+
+export const defaultActorHandle = "@cloudflare@hackers.pub";
+export const defaultActorName = "Cloudflare Blog Feed";
+export const longActorHandle = "@blog_cloudflare_com_rs_5i8zpek@beta.rss2.pub";
+
+export const actorAvatarDataUri =
+  "data:image/svg+xml," +
+  encodeURIComponent(
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 80">' +
+      '<rect width="80" height="80" rx="16" fill="#f38020"/>' +
+      '<text x="40" y="50" text-anchor="middle" font-family="sans-serif" ' +
+      'font-size="28" font-weight="700" fill="white">CF</text></svg>',
+  );
+
+export interface ActorStoryArgs {
+  handle: string;
+  name: string;
+  width: number;
+}
+
+interface StorySurfaceProps {
+  children: JSX.Element;
+  width: number;
+}
+
+export function StorySurface(props: StorySurfaceProps) {
+  return (
+    <div
+      class="border bg-background"
+      style={{ width: `${props.width}px`, "max-width": "100%" }}
+    >
+      {props.children}
+    </div>
+  );
+}
+
+export function actorMockResolvers(
+  args: Pick<ActorStoryArgs, "handle" | "name">,
+  nodeType: "Actor" | "Note" = "Actor",
+): MockResolvers {
+  return {
+    Node: () => ({ __typename: nodeType }),
+    Actor: () => ({
+      id: "story-actor",
+      name: args.name,
+      rawName: args.name,
+      username: "blog_cloudflare_com_rs_5i8zpek",
+      handle: args.handle,
+      avatarUrl: actorAvatarDataUri,
+      avatarInitials: "CF",
+      bio: "<p>Engineering updates from the Cloudflare blog.</p>",
+      local: false,
+      url: "https://beta.rss2.pub/@blog_cloudflare_com_rs_5i8zpek",
+      iri: "https://beta.rss2.pub/ap/actors/blog_cloudflare_com_rs_5i8zpek",
+      suspended: false,
+      successor: null,
+      account: null,
+      fields: [],
+      isViewer: false,
+      viewerFollows: false,
+      viewerFollowState: "NONE",
+      viewerBlocks: false,
+      blocksViewer: false,
+      viewerMutes: false,
+      followsViewer: false,
+      followees: { totalCount: 42 },
+      followers: { totalCount: 128 },
+      mutualFollowers: { totalCount: 0, edges: [] },
+    }),
+    Note: () => ({
+      id: "story-post",
+      organizationAuthor: null,
+    }),
+  };
+}
+
+export function createRelayStoryData<
+  TResponse extends { readonly node?: unknown | null },
+>(
+  query: GraphQLTaggedNode,
+  variables: Variables,
+  resolvers: MockResolvers,
+  subject: string,
+): {
+  environment: Environment;
+  node: NonNullable<TResponse["node"]>;
+} {
+  const environment = new Environment({
+    network: Network.create(() => {
+      throw new Error("Storybook's mock environment has no real network");
+    }),
+    store: new Store(new RecordSource()),
+  });
+  const operation = createOperationDescriptor(getRequest(query), variables);
+  const payload = MockPayloadGenerator.generate(operation, resolvers);
+  if (payload.data == null) {
+    throw new Error(`MockPayloadGenerator produced no ${subject} data`);
+  }
+  environment.commitPayload(operation, payload.data);
+  const data = environment.lookup(operation.fragment).data as unknown as
+    | TResponse
+    | undefined;
+  if (data?.node == null) {
+    throw new Error(`${subject} story query produced no node`);
+  }
+  return {
+    environment,
+    node: data.node as NonNullable<TResponse["node"]>,
+  };
+}

--- a/web-next/src/entry-server.tsx
+++ b/web-next/src/entry-server.tsx
@@ -69,6 +69,7 @@ export default createHandler(
                 name="viewport"
                 content="width=device-width, initial-scale=1"
               />
+              <meta name="format-detection" content="email=no" />
               <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
               <link
                 rel="alternate icon"


### PR DESCRIPTION
This pull request fixes profile layouts where exceptionally long fediverse handles could extend beyond the visible viewport. The root cause was the profile flex item retaining its intrinsic minimum width while the handle itself had no safe break opportunity. The profile layout now allows the identity column to shrink with `min-w-0`, and surfaces that display the complete handle use `wrap-anywhere` so the text remains within the available width.

Handle rendering is now centralized in `ActorHandle`. Full-profile surfaces allow long handles to wrap, while compact surfaces such as previews and account lists continue to truncate them intentionally with an ellipsis. The document also disables email-format detection so mobile browsers do not mistake fediverse handles for email addresses.

Component-local Storybook stories cover the default, wrapping, truncation, and mobile-width states. These stories are split by component so each component's behavior can be reviewed and maintained independently.

## Screenshots

### Before

<img width="449" height="602" alt="image" src="https://github.com/user-attachments/assets/f3d6e3cf-b653-4cce-9644-d3bea64ed112" />

### After

<img width="484" height="602" alt="image" src="https://github.com/user-attachments/assets/88266dc4-4f75-4c00-a01a-ca97f12d0b89" />


## Screenshots - Storybook

### ProfileCard: mobile wrapping

![ProfileCard mobile wrapping](https://raw.githubusercontent.com/moreal/hackerspub/0e326f33953bb50cf21764aa4818b2b933ac27e5/pr-assets/long-actor-handles/profile-mobile-wrapping.png)

### ActorHandle: explicit truncation

![ActorHandle truncation](https://raw.githubusercontent.com/moreal/hackerspub/0e326f33953bb50cf21764aa4818b2b933ac27e5/pr-assets/long-actor-handles/handle-truncation.png)

### ActorPreviewCard: compact truncation

![ActorPreviewCard truncation](https://raw.githubusercontent.com/moreal/hackerspub/0e326f33953bb50cf21764aa4818b2b933ac27e5/pr-assets/long-actor-handles/preview-card-truncation.png)

### AccountListBase: compact truncation

![AccountListBase truncation](https://raw.githubusercontent.com/moreal/hackerspub/0e326f33953bb50cf21764aa4818b2b933ac27e5/pr-assets/long-actor-handles/account-list-truncation.png)

### LinkCreatorAttribution: wrapping

![LinkCreatorAttribution wrapping](https://raw.githubusercontent.com/moreal/hackerspub/0e326f33953bb50cf21764aa4818b2b933ac27e5/pr-assets/long-actor-handles/link-creator-wrapping.png)

## AI assistance

Implementation, Storybook fixtures, validation, screenshots, and this pull request description were assisted by Codex (`gpt-5.6-sol`). Every assisted commit includes the required `Assisted-by` trailer.
